### PR TITLE
Split themes into separate tabs

### DIFF
--- a/spec/package-panel-spec.coffee
+++ b/spec/package-panel-spec.coffee
@@ -128,7 +128,7 @@ describe "PackagePanel", ->
 
   describe 'Available tab', ->
     it 'lists all available packages', ->
-      panel.find("li a:contains(Available)").click()
+      panel.find("li a:contains(Available Packages)").parent().click()
       panel.attachToDom()
 
       expect(panel.availablePackages.children('.panel').length).toBe 3


### PR DESCRIPTION
So currently themes are lumped in with the rest of the packages, I think we should split them out so people can search for just themes or just packages.

Here's my proposal:

![screen shot 2013-09-23 at 12 31 42 pm](https://f.cloud.github.com/assets/1424/1194580/6aaa3e20-2488-11e3-8894-f17fbf7e20b0.png)
