### PR TITLE
Use proper typographic quotation marks

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -81,7 +81,7 @@ class PackageManager
         catch error
           deferred.reject(error)
       else
-        error = new Error("Searching for '#{query}' failed.")
+        error = new Error("Searching for \u201C#{query}\u201D failed.")
         error.stdout = stdout
         error.stderr = stderr
         deferred.reject(error)
@@ -111,7 +111,7 @@ class PackageManager
           @emit 'package-updated', pack
       else
         atom.packages.activatePackage(name) if activateOnFailure
-        error = new Error("Updating to '#{name}@#{newVersion}' failed.")
+        error = new Error("Updating to \u201C#{name}@#{newVersion}\u201D failed.")
         error.stdout = stdout
         error.stderr = stderr
         if theme
@@ -144,7 +144,7 @@ class PackageManager
           @emit 'package-installed', pack
       else
         atom.packages.activatePackage(name) if activateOnFailure
-        error = new Error("Installing '#{name}@#{version}' failed.")
+        error = new Error("Installing \u201C#{name}@#{version}\u201D failed.")
         error.stdout = stdout
         error.stderr = stderr
         if theme
@@ -168,7 +168,7 @@ class PackageManager
         else
           @emit 'package-uninstalled', pack
       else
-        error = new Error("Uninstalling '#{name}' failed.")
+        error = new Error("Uninstalling \u201C#{name}\u201D failed.")
         error.stdout = stdout
         error.stderr = stderr
         if theme

--- a/lib/packages-panel.coffee
+++ b/lib/packages-panel.coffee
@@ -58,13 +58,13 @@ class PackagesPanel extends View
 
   search: (query) ->
     if @resultsContainer.children().length is 0
-      @searchMessage.text("Searching for '#{query}'\u2026").show()
+      @searchMessage.text("Searching for \u201C#{query}\u201D\u2026").show()
 
     @packageManager.search(query)
       .then (packages=[]) =>
         packages = @filterInstalledPackages(packages)
         if packages.length is 0
-          @searchMessage.text("No package results for '#{query}'").show()
+          @searchMessage.text("No package results for \u201C#{query}\u201D").show()
         else
           @searchMessage.hide()
         @addPackageViews(@resultsContainer, packages)

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -171,7 +171,7 @@ class SettingsView extends ScrollView
       try
         pack.activateConfig()
       catch error
-        console.error "Error activating package config for '#{pack.name}'", error
+        console.error "Error activating package config for \u201C#{pack.name}\u201D", error
       finally
         callback()
 

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -186,13 +186,13 @@ class ThemesPanel extends View
 
   search: (query) ->
     if @resultsContainer.children().length is 0
-      @searchMessage.text("Searching for '#{query}'\u2026").show()
+      @searchMessage.text("Searching for \u201C#{query}\u201D\u2026").show()
 
     @packageManager.search(query)
       .then (themes) =>
         themes = @filterInstalledThemes(themes)
         if themes.length is 0
-          @searchMessage.text("No theme results for '#{query}'").show()
+          @searchMessage.text("No theme results for \u201C#{query}\u201D").show()
         else
           @searchMessage.hide()
         @addThemeViews(@resultsContainer, themes)


### PR DESCRIPTION
Consistently use [U+201C LEFT DOUBLE QUOTATION MARK](http://codepoints.net/U+201C) and [U+201D RIGHT DOUBLE QUOTATION MARK](http://codepoints.net/U+201D) instead of [U+0027 APOSTROPHE](http://codepoints.net/U+0027).
