### PR TITLE
Prevent text selection in the config menu

### DIFF
--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -81,6 +81,7 @@
     -webkit-flex-direction: column;
     box-shadow: -1px 0px 1px -1px #aeaeae inset;
     background-color: #e7e7e7;
+    -webkit-user-select: none;
 
     .atom-banner {
       margin-left: 20px;


### PR DESCRIPTION
Simply disables user text selection in the config menu. Double-clicking or dragging inside the config menu will no longer result in having selected text and makes the package feel a little more desktop-like.
