### PR TITLE
Give config a dedicated background-color

### DIFF
--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -125,6 +125,11 @@
     .nav > li > a {
       border-radius: 0;
       color: #434343;
+
+      &:hover {
+        background-color: #f2f2f2;
+        box-shadow: -1px 0px 1px -1px #aeaeae inset;
+      }
     }
 
     .nav > li.active > a {


### PR DESCRIPTION
Most of the rest of the settings view defines it's own color scheme, but hover on the config menu items reverts to the ui theme's colors. This fixes that.

**Before**
![image](https://f.cloud.github.com/assets/136521/2323886/515219f2-a3c2-11e3-89b0-1f1d44d2b3ae.png)

**After**
![image](https://f.cloud.github.com/assets/136521/2323879/3f08dfec-a3c2-11e3-9908-351301cab966.png)

cc @kevinsawicki 
