### PR TITLE
Completely remove settings panel when uninstalling a package

### DIFF
--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -155,6 +155,7 @@ class SettingsView extends ScrollView
   removePanel: (name) ->
     if panel = @panelsByName?[name]
       panel.remove()
+      delete @panelsByName[name]
       @panelMenu.find("li[name=\"#{name}\"]").remove()
 
   getTitle: ->


### PR DESCRIPTION
Fixes https://github.com/atom/settings-view/issues/72.

After poking around for a bit, this seems to resolve the settings panel problem for reinstalled packages. From what I could tell, the old settings panel for the package was not completely removed when the package was uninstalled. As a result, when the package was re-installed -- the old panel was still being used (instead of the new one), and that caused Atom to crash and other problems described in https://github.com/atom/settings-view/issues/72.
