### PR TITLE
Allow disabled packages to be installed

### DIFF
--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -37,8 +37,6 @@ class AvailablePackageView extends View
       @installButton.prop('disabled', true)
       @installButton.text('Installed')
       @setStatusIcon('check')
-    else if atom.packages.isPackageDisabled(@pack.name)
-      @installButton.prop('disabled', true)
 
   setStatusIcon: (iconName) ->
     @status.removeClass('icon-check icon-alert icon-cloud-download')


### PR DESCRIPTION
Fixes https://github.com/atom/settings-view/issues/71

This change allows disabled (but uninstalled) packages to be installed. After such packages are installed, they are still in a disabled state, so they need to be enabled in settings. 

This is the minimal change that allows users to re-install packages which were disabled and then uninstalled. As mentioned in the [related issue](https://github.com/atom/settings-view/issues/71), it might be worth considering making additional changes to optimize for the most common case, instead for flexibility:

> - should uninstalling a package automatically remove it from the list of disabled packages? (i.e. re-enable it before uninstalling)
> - should installing a package automatically remove it from the list of disabled packages? (i.e. re-enable it after installing) 

Personally, I'd be :cool: with going just with this minimal change, because there might be cases when users want to just install a disabled package, and then enable it at some later point.
