### PR TITLE
Only add disabled packages if they weren't loaded

### DIFF
--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -103,7 +103,8 @@ class SettingsView extends ScrollView
         try
           metadata = CSON.readFileSync(metadataPath)
           name = metadata?.name ? packageName
-          @packages.push({name, metadata, path: packagePath})
+          unless _.findWhere(@packages, {name})
+            @packages.push({name, metadata, path: packagePath})
 
     @packages.sort (pack1, pack2) =>
       title1 = @packageManager.getPackageTitle(pack1)


### PR DESCRIPTION
Fixes https://github.com/atom/settings-view/issues/55

This change ensures that disabled packages are only added to the list of installed packages if they haven't been loaded.

Specifically, this prevents the following situation from happening:
1. Atom is started with package `Foo` as enabled, so the package exists in `atom.packages.getLoadedPackages()`
2. The Settings view is opened
3. An update exists for `Foo` (but `Foo` isn't updated to the new version)
4. `Foo` is disabled, so it is added to `core.disabledPackages`
5. The Settings view is closed
6. The Settings view is re-opened
7. The list of packages is constructed, and because `Foo` was both loaded and disabled later, it's added to the list two times.

![](https://f.cloud.github.com/assets/38924/2411731/dd01531e-aaca-11e3-944b-02902037c7c0.gif)

cc @kevinsawicki
