### PR TITLE
Fix the getRepositoryUrl not found bug

### DIFF
--- a/lib/installed-package-view.coffee
+++ b/lib/installed-package-view.coffee
@@ -91,12 +91,12 @@ class InstalledPackageView extends View
       false
 
     @packageRepo.on 'click', =>
-      if repoUrl = @getRepositoryUrl()
+      if repoUrl = @packageManager.getRepositoryUrl()
         shell.openExternal(repoUrl)
       false
 
     @issueButton.on 'click', =>
-      if repoUrl = @getRepositoryUrl()
+      if repoUrl = @packageManager.getRepositoryUrl()
         shell.openExternal("#{repoUrl}/issues/new")
       false
 


### PR DESCRIPTION
I think it's because this refactor https://github.com/atom/settings-view/commit/75c2faf60d486ef5ac2736497f2611a2ef0dc30d  didn't change all `@getRepositoryUrl()` to `@packageManager.getRepositoryUrl()` 
