### PR TITLE
Re-point atom.io URL for theme view to themes page

### DIFF
--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -59,7 +59,7 @@ class ThemesPanel extends View
 
   initialize: (@packageManager) ->
     @openAtomIo.on 'click', =>
-      require('shell').openExternal('https://atom.io/packages')
+      require('shell').openExternal('https://atom.io/themes')
       false
 
     @searchMessage.hide()


### PR DESCRIPTION
It was originally pointing to the packages page (http://atom.io/packages).
This changes the URL for the themes view to http://atom.io/themes, whilst
leaving the packages URL intact.
