### PR TITLE
Always show the search message when searching

### DIFF
--- a/lib/packages-panel.coffee
+++ b/lib/packages-panel.coffee
@@ -80,8 +80,7 @@ class PackagesPanel extends View
     @searchEditorView.focus()
 
   search: (query) ->
-    if @resultsContainer.children().length is 0
-      @searchMessage.text("Searching for \u201C#{query}\u201D\u2026").show()
+    @searchMessage.text("Searching for \u201C#{query}\u201D\u2026").show()
 
     @packageManager.search(query, {packages: true})
       .then (packages=[]) =>


### PR DESCRIPTION
Fixes atom/atom#2469

Currently, the "Searching for `<query>`..." search message is shown only when there are no previous search results listed. If a search was already performed and that search found some results, then searching again does not show the search message. To some users, this lack of feedback that a search is being performed seems like search is hanging.

This change makes the search message show up on every search.

**Before**:

![before](https://cloud.githubusercontent.com/assets/38924/3139107/3fec3dd0-e8ca-11e3-896a-1bd338b1d99b.gif)

**After**:

![after](https://cloud.githubusercontent.com/assets/38924/3139108/45470d96-e8ca-11e3-8eb0-38f2d953c262.gif)

cc @kevinsawicki (blame points to you, so just double-checking that I'm not missing anything)
