### PR TITLE
The GeneralPanel panel's name is Settings, not General

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,7 +24,7 @@ module.exports =
       createSettingsView({uri}) if uri is configUri
 
     atom.workspaceView.command 'settings-view:open', ->
-      openPanel('General')
+      openPanel('Settings')
 
     atom.workspaceView.command 'settings-view:show-keybindings', ->
       openPanel('Keybindings')


### PR DESCRIPTION
The `GeneralPanel` is [added to the list of panels under the name `"Settings"`](https://github.com/atom/settings-view/blob/329ba4c44f12048bddee14fe1f99cad39e4be444/lib/settings-view.coffee#L80), but the [`settings-view:open` command currently tries to find it under the name `"General"`](https://github.com/atom/settings-view/blob/329ba4c44f12048bddee14fe1f99cad39e4be444/lib/main.coffee#L27).

The result of this is that the `settings-view:open` command works in the following way:
- if the Settings View was not opened, then the `settings-view:open` command opened the Settings View and the "Settings" panel was focused (by default, because a panel named "General" didn't exist)
- if the Settings View was opened, then the `settings-view:open` command just focused the Settings View (if it wasn't focused) and the previously focused panel was left focused (e.g. if the "Packages" panel was selected, then it was still selected).

As a result, there is no way to focus the "Settings" panel with just a keyboard if the Settings View is already open and the "Settings" panel isn't already focused (which some users might want -- see https://github.com/atom/atom/issues/2466).

This change makes the `settings-view:open` command open the Settings panel every time, by using the true name of the panel. 

Some users might be surprised by this change, because they were using the command as a way to just focus the Settings View (expecting to see the last panel that was selected). If this is a concern, then we could add a new command, e.g. `settings-view:show-settings` which would be used to focus the Settings panel, while the existing `settings-view:open` command would be left as is (but perhaps modified so that it's clear that there is no "General" panel).

cc @kevinsawicki for some :eyes: and sanity :smile_cat: 
