### PR TITLE
Always call superclass when focusing Settings View so that the panel is correctly focused

### DIFF
--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -153,12 +153,12 @@ class SettingsView extends ScrollView
     @sidebar.find("[name='#{name}']").addClass('active')
 
   focus: ->
+    super
+
     # Pass focus to panel that is currently visible
     for panel in @panels.children() when $(panel).isVisible()
       $(panel).view().focus()
       return
-
-    super
 
   showPanel: (name) ->
     if panel = @getOrCreatePanel(name)


### PR DESCRIPTION
Fixes atom/atom#2416

Previously, in some cases, calling focus wasn't causing the selected panel to correctly focus if the Settings View was focused by cycling through tabs with a keyboard shortcut, as described in atom/atom#2416.

I'm not really sure why this happens, but it seems to happen only for panels which don't implement their own focus handler, e.g. the Settings panel and panels for specific packages. Panels which do have a focus handler implemented weren't affected (e.g. the Keybindings panel).

This change moves the `focus()` call to the superclass so that it's always executed (allowing the panel to focus correctly even if it doesn't have a focus handler), but also allows the panel's focus handler to be executed afterwards if it does exist.

I have a feeling that there's a better and more correct way to fix this problem, but I don't see it. Happy to be schooled, though. :smile_cat: :school: 

**Before** (notice how the keystrokes to go to the next/previous tab don't work when the Settings View tab is cycled to):

![](https://cloud.githubusercontent.com/assets/38924/3140130/4db95842-e908-11e3-87f0-6ad631070e72.gif)

**After**:

![](https://cloud.githubusercontent.com/assets/38924/3140134/6c9811ae-e908-11e3-899c-b104471d0933.gif)

cc @kevinsawicki (related commit: https://github.com/atom/settings-view/commit/ed57389218cac86b8ea7f5ebc9309ad4f04bfe34)
