### PR TITLE
Allow disabled packages to be installed, take 2

### DIFF
--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -68,7 +68,6 @@ class AvailablePackageView extends View
       @setStatusIcon('check')
     else
       @settingsButton.hide()
-      @installButton.prop('disabled', true) if @isDisabled()
 
   isInstalled: -> atom.packages.isPackageLoaded(@pack.name)
 
@@ -83,6 +82,10 @@ class AvailablePackageView extends View
     @packageManager.install @pack, (error) =>
       if error?
         console.error("Installing #{@type} #{@pack.name} failed", error.stack ? error, error.stderr)
+      else
+        # if a package was disabled before installing it, re-enable it
+        if @isDisabled()
+          atom.packages.enablePackage(@pack.name)
 
   uninstall: ->
     @packageManager.emit('package-uninstalling', @pack)


### PR DESCRIPTION
This is a second attempt at https://github.com/atom/settings-view/pull/74, which fixes #71.

Currently, disabled packages can't be installed via Settings. This PR introduces two changes:
- disabled packages can now be installed after searching for them (same as #74)
- disabled packages are automatically re-enabled after being installed

:movie_camera: :clapper: 

![testy](https://cloud.githubusercontent.com/assets/38924/3142233/94248c98-e9b2-11e3-88d0-16111d926c56.gif)

cc @probablycorey 
