### PR TITLE
:lipstick: Remove code duplication around emitting events

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -224,7 +224,6 @@ class PackageManager
   # pack - The package for which the event is being emitted.
   # error - Any error information to be included in the case of an error.
   emitPackageEvent: (eventName, pack, error) ->
-    {theme} = pack
-    theme ?= pack.metadata?.theme
+    theme = pack.theme ? pack.metadata?.theme
     eventName = if theme then "theme-#{eventName}" else "package-#{eventName}"
     @emit eventName, pack, error


### PR DESCRIPTION
There was code in a number of places that formatted the event names differently depending on whether the event was for a theme or a package. This change creates an `emitPackageEvent` method that standardizes the logic for determining if the event is for a package or a theme and emits the properly formatted event.

Caveat: It makes searching for the source of a given event more difficult.

I was looking at the code for something else I wanted to work on, saw this pattern and figured I could clean it up a little first. Totally cool if this isn't the direction you want to go, it's just something I whipped up :smile:
