### PR TITLE
Fix call for package upgradeable check and bring back the squirrel

### DIFF
--- a/lib/package-menu-view.coffee
+++ b/lib/package-menu-view.coffee
@@ -23,7 +23,7 @@ class PackageMenuView extends View
     return if atom.packages.isBundledPackage(@pack.name)
 
     @getAvailablePackage (availablePackage) =>
-      if @packageManager.canUpgrade(@pack, availablePackage)
+      if @packageManager.canUpgrade(@pack, availablePackage.latestVersion)
         @link.addClass('icon-squirrel')
 
   getAvailablePackage: (callback) ->


### PR DESCRIPTION
Currently, the squirrel octicon is not shown in the packages list for packages which can be upgraded. This change brings back the squirrel by fixing a check for the `canUpgrade` call which sets the required class. (See: https://github.com/atom/settings-view/commit/2f866b464c2b8ee1487afcce78c785b5b12a0cf0 for related changes)

Before:

![screen shot 2014-08-16 at 10 43 08 pm](https://cloud.githubusercontent.com/assets/38924/3943055/00dc14e6-2586-11e4-8166-82701c795448.png)

After:

![screen shot 2014-08-16 at 10 20 46 pm](https://cloud.githubusercontent.com/assets/38924/3942987/d9c8890a-2582-11e4-9f9c-499eaa0280c3.png)

cc @kevinsawicki 
