### PR TITLE
Add bottom padding to selects

### DIFF
--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -65,7 +65,7 @@
     }
   }
 
-  select.form-control {
+  .controls select.form-control {
     margin-bottom: @component-padding;
   }
 


### PR DESCRIPTION
There's no gap between selects and the following label which looks a bit weird.

![screen shot 2014-11-11 at 17 27 10](https://cloud.githubusercontent.com/assets/1759837/4997564/fe634b7c-69c7-11e4-8bdd-4497b41013a7.png)

After:

![screen shot 2014-11-11 at 17 26 58](https://cloud.githubusercontent.com/assets/1759837/4997566/0157806e-69c8-11e4-8206-2a5babf2434c.png)
