### PR TITLE
Add theme color, contrast, and saturation settings

### DIFF
--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -44,17 +44,17 @@ class ThemesPanel extends View
           @div class: 'form-group', =>
             @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Saturation'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
-              @div class: 'theme-saturation theme-saturation-1', 'data-saturation': '20%'
-              @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '10%'
+              @div class: 'theme-saturation theme-saturation-1', 'data-saturation': '40%'
+              @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '20%'
               @div class: 'theme-saturation theme-saturation-3 theme-saturation-selected', 'data-saturation': '0%'
               @div class: 'theme-saturation theme-saturation-4', 'data-saturation': '-10%'
-              @div class: 'theme-saturation theme-saturation-5', 'data-saturation': '-20%'
+              @div class: 'theme-saturation theme-saturation-5', 'data-saturation': '-100%'
 
           @div class: 'form-group', =>
             @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Contrast'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
-              @div class: 'theme-contrast theme-contrast-1', 'data-contrast': '20%', 'A'
-              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '10%', 'A'
+              @div class: 'theme-contrast theme-contrast-1', 'data-contrast': '40%', 'A'
+              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '20%', 'A'
               @div class: 'theme-contrast theme-contrast-3 theme-contrast-selected', 'data-contrast': '0%', 'A'
               @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '-10%', 'A'
               @div class: 'theme-contrast theme-contrast-5', 'data-contrast': '-20%', 'A'

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -33,7 +33,7 @@ class ThemesPanel extends View
               @div class: 'text theme-description', 'This styles the text inside the editor'
 
           @div class: 'form-group', =>
-            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Base Color'
+            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Hue'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
               @div class: 'theme-base-color theme-base-color-1 theme-base-color-selected'
               @div class: 'theme-base-color theme-base-color-2'

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -41,20 +41,20 @@ class ThemesPanel extends View
               @div class: 'theme-base-color theme-base-color-4'
 
           @div class: 'form-group', =>
-            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Contrast'
-            @div class: 'col-sm-10 col-lg-4 col-md-4', =>
-              @div class: 'theme-contrast theme-contrast-1 theme-contrast-selected', 'data-contrast': '20%', 'A'
-              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '15%', 'A'
-              @div class: 'theme-contrast theme-contrast-3', 'data-contrast': '10%', 'A'
-              @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '5%', 'A'
-
-          @div class: 'form-group', =>
             @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Saturation'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
               @div class: 'theme-saturation theme-saturation-1 theme-saturation-selected', 'data-saturation': '20%'
               @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '15%'
               @div class: 'theme-saturation theme-saturation-3', 'data-saturation': '10%'
               @div class: 'theme-saturation theme-saturation-4', 'data-saturation': '5%'
+
+          @div class: 'form-group', =>
+            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Contrast'
+            @div class: 'col-sm-10 col-lg-4 col-md-4', =>
+              @div class: 'theme-contrast theme-contrast-1 theme-contrast-selected', 'data-contrast': '20%', 'A'
+              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '15%', 'A'
+              @div class: 'theme-contrast theme-contrast-3', 'data-contrast': '10%', 'A'
+              @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '5%', 'A'
 
       @div class: 'section packages', =>
         @div class: 'section-heading icon icon-cloud-download', 'Install Themes'

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -32,6 +32,30 @@ class ThemesPanel extends View
               @select outlet: 'syntaxMenu', class: 'form-control'
               @div class: 'text theme-description', 'This styles the text inside the editor'
 
+          @div class: 'form-group', =>
+            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Base Color'
+            @div class: 'col-sm-10 col-lg-4 col-md-4', =>
+              @div class: 'theme-base-color theme-base-color-1 theme-base-color-selected'
+              @div class: 'theme-base-color theme-base-color-2'
+              @div class: 'theme-base-color theme-base-color-3'
+              @div class: 'theme-base-color theme-base-color-4'
+
+          @div class: 'form-group', =>
+            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Contrast'
+            @div class: 'col-sm-10 col-lg-4 col-md-4', =>
+              @div class: 'theme-contrast theme-contrast-1 theme-contrast-selected', 'data-contrast': '20%', 'A'
+              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '15%', 'A'
+              @div class: 'theme-contrast theme-contrast-3', 'data-contrast': '10%', 'A'
+              @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '5%', 'A'
+
+          @div class: 'form-group', =>
+            @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Saturation'
+            @div class: 'col-sm-10 col-lg-4 col-md-4', =>
+              @div class: 'theme-saturation theme-saturation-1 theme-saturation-selected', 'data-saturation': '20%'
+              @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '15%'
+              @div class: 'theme-saturation theme-saturation-3', 'data-saturation': '10%'
+              @div class: 'theme-saturation theme-saturation-4', 'data-saturation': '5%'
+
       @div class: 'section packages', =>
         @div class: 'section-heading icon icon-cloud-download', 'Install Themes'
 
@@ -91,6 +115,30 @@ class ThemesPanel extends View
       @scheduleUpdateThemeConfig()
 
     @loadFeaturedThemes()
+
+    @on 'click', '.theme-base-color', ({target}) =>
+      @find('.theme-base-color-selected').removeClass('theme-base-color-selected')
+
+      target.classList.add('theme-base-color-selected')
+
+      baseColor = window.getComputedStyle(target)['background-color']
+      atom.config.set('core.themeColor', baseColor)
+
+    @on 'click', '.theme-contrast', ({target}) =>
+      @find('.theme-contrast-selected').removeClass('theme-contrast-selected')
+
+      target.classList.add('theme-contrast-selected')
+
+      {contrast} = target.dataset
+      atom.config.set('core.themeContrast', contrast)
+
+    @on 'click', '.theme-saturation', ({target}) =>
+      @find('.theme-saturation-selected').removeClass('theme-saturation-selected')
+
+      target.classList.add('theme-saturation-selected')
+
+      {saturation} = target.dataset
+      atom.config.set('core.themeSaturation', saturation)
 
   focus: ->
     @searchEditorView.focus()

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -39,22 +39,25 @@ class ThemesPanel extends View
               @div class: 'theme-base-color theme-base-color-2'
               @div class: 'theme-base-color theme-base-color-3'
               @div class: 'theme-base-color theme-base-color-4'
+              @div class: 'theme-base-color theme-base-color-5'
 
           @div class: 'form-group', =>
             @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Saturation'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
-              @div class: 'theme-saturation theme-saturation-1 theme-saturation-selected', 'data-saturation': '20%'
-              @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '15%'
-              @div class: 'theme-saturation theme-saturation-3', 'data-saturation': '10%'
-              @div class: 'theme-saturation theme-saturation-4', 'data-saturation': '5%'
+              @div class: 'theme-saturation theme-saturation-1', 'data-saturation': '20%'
+              @div class: 'theme-saturation theme-saturation-2', 'data-saturation': '10%'
+              @div class: 'theme-saturation theme-saturation-3 theme-saturation-selected', 'data-saturation': '0%'
+              @div class: 'theme-saturation theme-saturation-4', 'data-saturation': '-10%'
+              @div class: 'theme-saturation theme-saturation-5', 'data-saturation': '-20%'
 
           @div class: 'form-group', =>
             @label class: 'col-sm-2 col-lg-2 control-label themes-label text', 'Contrast'
             @div class: 'col-sm-10 col-lg-4 col-md-4', =>
-              @div class: 'theme-contrast theme-contrast-1 theme-contrast-selected', 'data-contrast': '20%', 'A'
-              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '15%', 'A'
-              @div class: 'theme-contrast theme-contrast-3', 'data-contrast': '10%', 'A'
-              @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '5%', 'A'
+              @div class: 'theme-contrast theme-contrast-1', 'data-contrast': '20%', 'A'
+              @div class: 'theme-contrast theme-contrast-2', 'data-contrast': '10%', 'A'
+              @div class: 'theme-contrast theme-contrast-3 theme-contrast-selected', 'data-contrast': '0%', 'A'
+              @div class: 'theme-contrast theme-contrast-4', 'data-contrast': '-10%', 'A'
+              @div class: 'theme-contrast theme-contrast-5', 'data-contrast': '-20%', 'A'
 
       @div class: 'section packages', =>
         @div class: 'section-heading icon icon-cloud-download', 'Install Themes'

--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -341,76 +341,17 @@
       -webkit-user-select: none;
       text-align: center;
       cursor: pointer;
+      background-color: hsla(0, 0%, 0%, .1)
     }
 
     .theme-base-color-selected,
     .theme-contrast-selected,
     .theme-saturation-selected {
-      border: 2px solid hsla(0, 0%, 100%, .75);
+      border: 2px solid hsla(0, 0%, 0%, .75);
     }
 
     .theme-base-color {
       border-radius: 50%;
-    }
-
-    .theme-base-color-1 {
-      background-color: hsl(220, 80%, 55%);
-    }
-
-    .theme-base-color-2 {
-      background-color: hsl(260, 90%, 65%);
-    }
-
-    .theme-base-color-3 {
-      background-color: hsl(320, 60%, 45%);
-    }
-
-    .theme-base-color-4 {
-      background-color: hsl(20, 75%, 50%);
-    }
-
-    .theme-base-color-5 {
-      background-color: hsl(150, 60%, 40%);
-    }
-
-    .theme-saturation-1 {
-      background-color: hsl(220, 100%, 50%); // 40%
-    }
-
-    .theme-saturation-2 {
-      background-color: hsl(220, 75%, 50%); // 20%
-    }
-
-    .theme-saturation-3 {
-      background-color: hsl(220, 50%, 50%); // 0%
-    }
-
-    .theme-saturation-4 {
-      background-color: hsl(220, 25%, 50%); // -10%
-    }
-
-    .theme-saturation-5 {
-      background-color: hsl(220, 0%, 50%); // -100%
-    }
-
-    .theme-contrast-1 {
-      color: hsla(0, 0%, 100%, .9); // 40%
-    }
-
-    .theme-contrast-2 {
-      color: hsla(0, 0%, 100%, .7); // 20%
-    }
-
-    .theme-contrast-3 {
-      color: hsla(0, 0%, 100%, .5); // 0%
-    }
-
-    .theme-contrast-4 {
-      color: hsla(0, 0%, 100%, .3); // -10%
-    }
-
-    .theme-contrast-5 {
-      color: hsla(0, 0%, 100%, .1); // -20%
     }
 
     .package-container {

--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -335,7 +335,7 @@
       height: 34px;
       font-family: monospace;
       font-size: 24px;
-      border-radius: 2px;
+      border-radius: @component-border-radius;
       display: inline-block;
       margin: 0 @component-padding 0 @component-padding;
       -webkit-user-select: none;
@@ -347,6 +347,10 @@
     .theme-contrast-selected,
     .theme-saturation-selected {
       border: 2px solid hsla(0, 0%, 100%, .75);
+    }
+
+    .theme-base-color {
+      border-radius: 50%;
     }
 
     .theme-base-color-1 {

--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -346,55 +346,67 @@
     .theme-base-color-selected,
     .theme-contrast-selected,
     .theme-saturation-selected {
-      border: 2px solid rgba(200, 200, 200, 50%);
+      border: 2px solid hsla(0, 0%, 100%, .75);
     }
 
     .theme-base-color-1 {
-      background-color: darkblue;
+      background-color: hsl(220, 80%, 55%);
     }
 
     .theme-base-color-2 {
-      background-color: darkred;
+      background-color: hsl(260, 90%, 65%);
     }
 
     .theme-base-color-3 {
-      background-color: darkgreen;
+      background-color: hsl(320, 60%, 45%);
     }
 
     .theme-base-color-4 {
-      background-color: darkmagenta;
+      background-color: hsl(20, 75%, 50%);
     }
 
-    .theme-contrast-1 {
-      color: rgba(255, 255, 255, 100%);
-    }
-
-    .theme-contrast-2 {
-      color: rgba(255, 255, 255, 75%);
-    }
-
-    .theme-contrast-3 {
-      color: rgba(255, 255, 255, 50%);
-    }
-
-    .theme-contrast-4 {
-      color: rgba(255, 255, 255, 25%);
+    .theme-base-color-5 {
+      background-color: hsl(150, 60%, 40%);
     }
 
     .theme-saturation-1 {
-      background-color: hsl(0, 100%, 50%);
+      background-color: hsl(220, 100%, 50%); // 40%
     }
 
     .theme-saturation-2 {
-      background-color: hsl(0, 75%, 50%);
+      background-color: hsl(220, 75%, 50%); // 20%
     }
 
     .theme-saturation-3 {
-      background-color: hsl(0, 50%, 50%);
+      background-color: hsl(220, 50%, 50%); // 0%
     }
 
     .theme-saturation-4 {
-      background-color: hsl(0, 25%, 50%);
+      background-color: hsl(220, 25%, 50%); // -10%
+    }
+
+    .theme-saturation-5 {
+      background-color: hsl(220, 0%, 50%); // -100%
+    }
+
+    .theme-contrast-1 {
+      color: hsla(0, 0%, 100%, .9); // 40%
+    }
+
+    .theme-contrast-2 {
+      color: hsla(0, 0%, 100%, .7); // 20%
+    }
+
+    .theme-contrast-3 {
+      color: hsla(0, 0%, 100%, .5); // 0%
+    }
+
+    .theme-contrast-4 {
+      color: hsla(0, 0%, 100%, .3); // -10%
+    }
+
+    .theme-contrast-5 {
+      color: hsla(0, 0%, 100%, .1); // -20%
     }
 
     .package-container {

--- a/stylesheets/settings-view.less
+++ b/stylesheets/settings-view.less
@@ -328,6 +328,75 @@
       cursor: default;
     }
 
+    .theme-base-color,
+    .theme-contrast,
+    .theme-saturation {
+      width: 34px;
+      height: 34px;
+      font-family: monospace;
+      font-size: 24px;
+      border-radius: 2px;
+      display: inline-block;
+      margin: 0 @component-padding 0 @component-padding;
+      -webkit-user-select: none;
+      text-align: center;
+      cursor: pointer;
+    }
+
+    .theme-base-color-selected,
+    .theme-contrast-selected,
+    .theme-saturation-selected {
+      border: 2px solid rgba(200, 200, 200, 50%);
+    }
+
+    .theme-base-color-1 {
+      background-color: darkblue;
+    }
+
+    .theme-base-color-2 {
+      background-color: darkred;
+    }
+
+    .theme-base-color-3 {
+      background-color: darkgreen;
+    }
+
+    .theme-base-color-4 {
+      background-color: darkmagenta;
+    }
+
+    .theme-contrast-1 {
+      color: rgba(255, 255, 255, 100%);
+    }
+
+    .theme-contrast-2 {
+      color: rgba(255, 255, 255, 75%);
+    }
+
+    .theme-contrast-3 {
+      color: rgba(255, 255, 255, 50%);
+    }
+
+    .theme-contrast-4 {
+      color: rgba(255, 255, 255, 25%);
+    }
+
+    .theme-saturation-1 {
+      background-color: hsl(0, 100%, 50%);
+    }
+
+    .theme-saturation-2 {
+      background-color: hsl(0, 75%, 50%);
+    }
+
+    .theme-saturation-3 {
+      background-color: hsl(0, 50%, 50%);
+    }
+
+    .theme-saturation-4 {
+      background-color: hsl(0, 25%, 50%);
+    }
+
     .package-container {
       padding-top: @component-padding;
       max-width: 100%;


### PR DESCRIPTION
Initial work towards making themes adjustable by making certain Less variables defined by config settings and used in themes.

![theme-settings](https://cloud.githubusercontent.com/assets/671378/5002209/f528ea86-69b2-11e4-9ac9-8fa01d6530ce.gif)

@simurai couple questions for you:

* What do you think the preset colors should be?
* What do you think the preset contrast percentages should be?
* What do you think the preset saturation percentages should be?

Depends on https://github.com/atom/atom/pull/4153