### PR TITLE
Use ::onDidLoadSnippets on snippets module instead of deprecated atom.packages.on

### DIFF
--- a/lib/package-snippets-view.coffee
+++ b/lib/package-snippets-view.coffee
@@ -42,12 +42,11 @@ class PackageSnippetsView extends View
 
   getSnippets: (callback) ->
     snippetsPackage = atom.packages.getLoadedPackage('snippets')
-    if snippetsPackage?.mainModule?
-      if snippetsPackage.mainModule.loaded
+    if snippetsModule = snippetsPackage?.mainModule
+      if snippetsModule.loaded
         callback(@getSnippetProperties())
       else
-        @subscribe atom.packages.once 'snippets:loaded', =>
-          callback(@getSnippetProperties())
+        snippetsModule.onDidLoadSnippets => callback(@getSnippetProperties())
     else
       callback([])
 


### PR DESCRIPTION
:warning: This should not be merged until atom/atom@184aecb4a4348bd4e58c0d3c35948583665cbfea is released :warning:

This method was added to the snippets module in snippets v0.65.0 so we can avoid using the deprecated event subscription on atom.packages. This is the final deprecation warning in this package.