### PR TITLE
Fix unreadable grey buttons in package list

### DIFF
--- a/stylesheets/available-package.less
+++ b/stylesheets/available-package.less
@@ -201,7 +201,6 @@
       }
 
       .author {
-        color: @text-color-subtle;
         margin-left: @component-padding;
         &:focus {
           outline: none;
@@ -227,6 +226,10 @@
         &.is-disabled {
           background: @background-color-warning;
         }
+      }
+
+      .btn-group button.icon {
+        color: #fff;
       }
     }
 


### PR DESCRIPTION
In the new package view, I noticed that the buttons were almost unreadable. Some CSS from atom/atom (specifically [this line](https://github.com/atom/atom/blob/master/static/icons.less#L10)) was interfering.

Before:
![screen shot 2015-01-07 at 10 31 11 pm](https://cloud.githubusercontent.com/assets/5074763/5657434/3330a6fc-96bd-11e4-968c-ff04e1a43c30.png)

After:
![screen shot 2015-01-07 at 10 33 10 pm](https://cloud.githubusercontent.com/assets/5074763/5657437/386fc760-96bd-11e4-972f-f9625fc3aff3.png)