### PR TITLE
use min-width to force minimum width to allow @component-padding in rem

### DIFF
--- a/stylesheets/available-package.less
+++ b/stylesheets/available-package.less
@@ -220,7 +220,8 @@
 
       .status-indicator {
         padding: 0;
-        width: max(4px, @component-padding/2);
+        width: @component-padding/2;
+        min-width: 4px;
         pointer-events: none;
         transition: background .4s;
         background: @background-color-success;


### PR DESCRIPTION
`min-width` accomplishes the same as the `max()` calculation: make the status indicator halve the size of `@component-padding`, but make sure it's at least 4px. Doing it like this leaves it up to the client to figure it out render-time, which allows `@component-padding` to be in something else than pixels (e.g. rem).

fixes #319

![1](https://cloud.githubusercontent.com/assets/2543659/5665749/d0bef3fe-975a-11e4-991b-888914432fb2.png)
![2](https://cloud.githubusercontent.com/assets/2543659/5665750/d0ebd374-975a-11e4-9ccd-67ede0676efe.png)
