### PR TITLE
Add link to atom.io when a package is not installed

### DIFF
--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -137,6 +137,7 @@ class AvailablePackageView extends View
       unless error?
         @updateEnablement()
 
+        @packageName.removeClass('is-disabled')
         @learnMoreButton.hide()
         @installButton.hide()
         @uninstallButton.show()
@@ -155,6 +156,7 @@ class AvailablePackageView extends View
     @subscribeToPackageEvent 'package-uninstalled package-uninstall-failed theme-uninstalled theme-uninstall-failed', (pack, error) =>
       @installButton.prop('disabled', false)
       unless error?
+        @packageName.addClass('is-disabled')
         @learnMoreButton.show()
         @installButton.show()
         @uninstallButton.hide()
@@ -162,10 +164,12 @@ class AvailablePackageView extends View
         @enablementButton.hide()
 
     if @isInstalled() or @isDisabled()
+      @packageName.removeClass('is-disabled')
       @learnMoreButton.hide()
       @installButton.hide()
       @uninstallButton.show()
     else
+      @packageName.addClass('is-disabled')
       @settingsButton.hide()
       @uninstallButton.hide()
       @enablementButton.hide()

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -35,6 +35,7 @@ class AvailablePackageView extends View
           @a outlet: 'loginLink', class: 'author', href: "https://atom.io/users/#{owner}", owner
         @div class: 'meta-controls', =>
           @div class: 'btn-group', =>
+            @button type: 'button', class: 'btn btn-default icon icon-link', outlet: 'learnMoreButton', 'View on Atom.io'
             @button type: 'button', class: 'btn btn-info icon icon-cloud-download install-button', outlet: 'installButton', 'Install'
           @div outlet: 'buttons', class: 'btn-group', =>
             @button type: 'button', class: 'btn icon icon-gear',           outlet: 'settingsButton', 'Settings'
@@ -63,6 +64,10 @@ class AvailablePackageView extends View
     if atom.packages.isBundledPackage(@pack.name)
       @installButton.hide()
       @uninstallButton.hide()
+
+    @learnMoreButton.on 'click', =>
+      shell.openExternal "https://atom.io/packages/#{@pack.name}"
+      false
 
     @installButton.on 'click', =>
       @install()
@@ -132,6 +137,7 @@ class AvailablePackageView extends View
       unless error?
         @updateEnablement()
 
+        @learnMoreButton.hide()
         @installButton.hide()
         @uninstallButton.show()
         @settingsButton.show()
@@ -149,12 +155,14 @@ class AvailablePackageView extends View
     @subscribeToPackageEvent 'package-uninstalled package-uninstall-failed theme-uninstalled theme-uninstall-failed', (pack, error) =>
       @installButton.prop('disabled', false)
       unless error?
+        @learnMoreButton.show()
         @installButton.show()
         @uninstallButton.hide()
         @settingsButton.hide()
         @enablementButton.hide()
 
     if @isInstalled() or @isDisabled()
+      @learnMoreButton.hide()
       @installButton.hide()
       @uninstallButton.show()
     else

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -107,6 +107,11 @@
       .css-truncate-target {
         color: $greenDark;
       }
+
+      a.is-disabled {
+        text-decoration: none;
+        cursor: text;
+      }
     }
 
     .stats {


### PR DESCRIPTION
This PR is option 1B from the discussion in #351. It maybe just be a stop gap solution. It...

1. Adds an "View on Atom.io" button next to the "Install" button
2. Disables the package name link (no underline when hovering)

![io](https://cloud.githubusercontent.com/assets/378023/5954604/182fe792-a7dd-11e4-9d5b-65e84a46d24f.gif)

#### Todo:

- [ ] Add specs?

I guess it would also need some specs? I could try to add it, but not sure if it's a good idea. :grin: 