### PR TITLE
Access status-bar through new service API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -31,10 +31,7 @@ module.exports =
       'settings-view:uninstall-packages': -> openPanel('Packages')
       'settings-view:check-for-package-updates': -> openPanel('Updates')
 
-    atom.packages.onDidActivateInitialPackages(checkForUpdates)
-
-checkForUpdates = ->
-  if statusBar = atom.views.getView(atom.workspace)?.querySelector('status-bar')
+  consumeStatusBar: (statusBar) ->
     PackageManager = require './package-manager'
     packageManager = new PackageManager()
     packageManager.getOutdated().then (packages) ->

--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
   "repository": "https://github.com/atom/settings-view",
   "engines": {
     "atom": "*"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.58.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -20,5 +20,4 @@ describe "package updates status view", ->
 
   describe "when packages are outdated", ->
     it "adds a tile to the status bar", ->
-      consumeStatusBar: (statusBar) ->
-        expect($('status-bar .package-updates-status-view').text()).toBe '1'
+      expect($('status-bar .package-updates-status-view').text()).toBe '1'

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -20,8 +20,5 @@ describe "package updates status view", ->
 
   describe "when packages are outdated", ->
     it "adds a tile to the status bar", ->
-      waitsFor ->
-        $('status-bar .package-updates-status-view').length > 0
-
-      runs ->
+      consumeStatusBar: (statusBar) ->
         expect($('status-bar .package-updates-status-view').text()).toBe '1'


### PR DESCRIPTION
:warning: Depends on https://github.com/atom/status-bar/pull/51 being merged and released in Atom v0.178 :warning: