### PR TITLE
Support URIs for each of the panels

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,7 +20,13 @@ atom.deserializers.add(deserializer)
 module.exports =
   activate: ->
     atom.workspace.addOpener (uri) ->
-      createSettingsView({uri}) if uri is configUri
+      if uri.startsWith(configUri)
+        settingsView = createSettingsView({uri})
+        if match = /config\/([a-z]+)/gi.exec(uri)
+          panelName = match[1]
+          panelName = panelName[0].toUpperCase() + panelName.slice(1)
+          openPanel(panelName)
+        settingsView
 
     atom.commands.add 'atom-workspace',
       'settings-view:open': -> openPanel('Settings')

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -73,11 +73,7 @@ describe "SettingsView", ->
     beforeEach ->
       jasmine.attachToDOM(atom.views.getView(atom.workspace))
       waitsForPromise ->
-        atom.packages.activatePackage('settings-view').then (pack) ->
-          mainModule = pack.mainModule
-
-    it "can be activated", ->
-      expect(mainModule).toBeDefined()
+        atom.packages.activatePackage('settings-view')
 
     describe "when atom.workspace.open() is used with a config URI", ->
       beforeEach ->

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -68,6 +68,36 @@ describe "SettingsView", ->
       expect(settingsView.panels.find('#panel-1')).toBeHidden()
       expect(settingsView.panels.find('#panel-2')).toBeVisible()
 
-  it "can be activated", ->
-    waitsForPromise ->
-      atom.packages.activatePackage('settings-view')
+  describe "when the package is activated", ->
+    mainModule = null
+    beforeEach ->
+      jasmine.attachToDOM(atom.views.getView(atom.workspace))
+      waitsForPromise ->
+        atom.packages.activatePackage('settings-view').then (pack) ->
+          mainModule = pack.mainModule
+
+    it "can be activated", ->
+      expect(mainModule).toBeDefined()
+
+    describe "when atom.workspace.open() is used with a config URI", ->
+      beforeEach ->
+        settingsView = null
+
+      it "opens the settings to the correct panel with atom://config/<panel-name>", ->
+        waitsForPromise ->
+          atom.workspace.open('atom://config').then (s) -> settingsView = s
+
+        runs ->
+          expect(settingsView.activePanelName).toBe 'Settings'
+
+        waitsForPromise ->
+          atom.workspace.open('atom://config/themes').then (s) -> settingsView = s
+
+        runs ->
+          expect(settingsView.activePanelName).toBe 'Themes'
+
+        waitsForPromise ->
+          atom.workspace.open('atom://config/install').then (s) -> settingsView = s
+
+        runs ->
+          expect(settingsView.activePanelName).toBe 'Install'

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -83,17 +83,20 @@ describe "SettingsView", ->
         waitsForPromise ->
           atom.workspace.open('atom://config').then (s) -> settingsView = s
 
+        waits 1
         runs ->
           expect(settingsView.activePanelName).toBe 'Settings'
 
         waitsForPromise ->
           atom.workspace.open('atom://config/themes').then (s) -> settingsView = s
 
+        waits 1
         runs ->
           expect(settingsView.activePanelName).toBe 'Themes'
 
         waitsForPromise ->
           atom.workspace.open('atom://config/install').then (s) -> settingsView = s
 
+        waits 1
         runs ->
           expect(settingsView.activePanelName).toBe 'Install'


### PR DESCRIPTION
Support things like this

```coffee
atom.workspace.open('atom://config')
atom.workspace.open('atom://config/themes')
atom.workspace.open('atom://config/install')
```