### PR TITLE
Normalize order of displayed packages

### DIFF
--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -22,6 +22,13 @@ class InstalledPackagesPanel extends View
 
           @div outlet: 'updateErrors'
 
+          @section class: 'sub-section dev-packages', =>
+            @h3 class: 'sub-section-heading icon icon-package', =>
+              @text 'Development Packages'
+              @span outlet: 'devCount', class:'section-heading-count badge badge-flexible', '…'
+            @div outlet: 'devPackages', class: 'container package-container', =>
+              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+
           @section class: 'sub-section installed-packages', =>
             @h3 class: 'sub-section-heading icon icon-package', =>
               @text 'Community Packages'
@@ -34,13 +41,6 @@ class InstalledPackagesPanel extends View
               @text 'Core Packages'
               @span outlet: 'coreCount', class:'section-heading-count badge badge-flexible', '…'
             @div outlet: 'corePackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
-
-          @section class: 'sub-section dev-packages', =>
-            @h3 class: 'sub-section-heading icon icon-package', =>
-              @text 'Development Packages'
-              @span outlet: 'devCount', class:'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'devPackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
   initialize: (@packageManager) ->


### PR DESCRIPTION
This is not a major issue, just a minor annoyance that I've noticed over the past few weeks. The order in which installed packages are displayed seems unnatural to me for the following reasons:
* `dev-packages` generally make up the smallest sub-section of installed packages, they should therefore be displayed first
* `dev-packages` are also adjusted more often than `community` or `core` packages, by people trying to tweak them before a release
* `dev-packages` take precedence over `community-packages`, so they should be listed before, not after the `community-packages`
* `core-packages` are almost never going to change, and will therefore be needed least often and should be displayed last

Like I said, not a big deal, it's just another one of those minor details that, if adjusted, will make the user experience just that much better!