### PR TITLE
Activate the config for a package before displaying it

### DIFF
--- a/lib/installed-package-view.coffee
+++ b/lib/installed-package-view.coffee
@@ -53,11 +53,15 @@ class InstalledPackageView extends View
       @div outlet: 'sections'
 
   initialize: (@pack, @packageManager) ->
+    @activate()
     @populate()
     @handleButtonEvents()
     @updateFileButtons()
     @checkForUpdate()
     @subscribeToPackageManager()
+
+  activate: ->
+    @pack.activateConfig() if not atom.packages.isPackageActive(@pack.name)
 
   detached: ->
     @unsubscribe()

--- a/lib/installed-package-view.coffee
+++ b/lib/installed-package-view.coffee
@@ -61,6 +61,7 @@ class InstalledPackageView extends View
     @subscribeToPackageManager()
 
   activate: ->
+    # Package.activateConfig() is part of the Private package API and should not be used outside of core.
     @pack.activateConfig() if not atom.packages.isPackageActive(@pack.name)
 
   detached: ->

--- a/spec/fixtures/package-with-config/main.coffee
+++ b/spec/fixtures/package-with-config/main.coffee
@@ -1,0 +1,5 @@
+module.exports =
+  config:
+    setting:
+      type: 'string'
+      default: 'something'

--- a/spec/fixtures/package-with-config/package.json
+++ b/spec/fixtures/package-with-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-with-config",
+  "version": "1.0",
+  "repository": "https://github.com/example/package-with-config",
+  "main": "main"
+}

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -61,3 +61,17 @@ describe "InstalledPackageView", ->
       view = new InstalledPackageView(pack, new PackageManager())
       keybindingsTable = view.find('.package-keymap-table tbody')
       expect(keybindingsTable.children().length).toBe 0
+
+  it 'should load the config for inactive packages', ->
+    atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-config'))
+
+    waitsFor ->
+      atom.packages.isPackageLoaded('package-with-config') is true
+
+    runs ->
+      expect(atom.config.get('package-with-config.setting')).toBe undefined
+
+      pack = atom.packages.getLoadedPackage('package-with-config')
+      view = new InstalledPackageView(pack, new PackageManager())
+
+      expect(atom.config.get('package-with-config.setting')).toBe 'something'


### PR DESCRIPTION
Fixes https://github.com/atom/settings-view/issues/356 by calling `Package.activateConfig()` if the package is not yet active.