### PR TITLE
Settings view allows installing package versions not supported by the current version of Atom

### DIFF
--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -76,10 +76,15 @@ class AvailablePackageView extends View
     # The package is not bundled with Atom and is not installed so we'll have
     # to find a package version that is compatible with this Atom version.
     else
-      @packageManager.requestPackage @pack.name, (err, pack) =>
-        if err?
-          console.error(err)
-        else
+      atomVersion = @packageManager.normalizeVersion(atom.getVersion())
+      # The latest version is compatible with the current Atom version, no need
+      # to make a request to get all versions.
+      if @packageManager.satisfiesVersion(atomVersion, @pack)
+        @installButton.show()
+      else
+        @packageManager.requestPackage @pack.name, (err, pack) =>
+          return console.error(err) if err?
+
           packageVersion = @packageManager.getLatestCompatibleVersion(pack)
           # A compatible version exist, we activate the install button and
           # replace @pack so that the install action installs the compatible
@@ -106,7 +111,6 @@ class AvailablePackageView extends View
             </span>
             """
             console.error("No available version compatible with the installed Atom version: #{atom.getVersion()}")
-            return
 
     @installButton.on 'click', =>
       @install()

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -88,11 +88,23 @@ class AvailablePackageView extends View
             @versionValue.text(packageVersion)
             if packageVersion isnt @pack.version
               @versionValue.addClass('text-warning')
+              @packageDescription.append """
+              <br/>
+              <span class='text-warning'>
+                Version #{packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Atom.
+              </span>
+              """
 
             @pack = pack.versions[packageVersion]
             @installButton.show()
           else
             @versionValue.addClass('text-danger')
+            @packageDescription.append """
+            <br/>
+            <span class='text-danger'>
+              There's no version of this package that is compatible with your Atom version. The version must satisfy #{@pack.engines.atom}.
+            </span>
+            """
             console.error("No available version compatible with the installed Atom version: #{atom.getVersion()}")
             return
 

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -17,7 +17,7 @@ class AvailablePackageView extends View
       @div class: 'stats pull-right', =>
         @span class: "stats-item", =>
           @span class: 'icon icon-versions'
-          @span class:'value', version
+          @span outlet: 'versionValue', class:'value', String(version)
 
         @span class: 'stats-item', =>
           @span class: 'icon icon-cloud-download'
@@ -85,9 +85,14 @@ class AvailablePackageView extends View
           # replace @pack so that the install action installs the compatible
           # version of the package.
           if packageVersion
+            @versionValue.text(packageVersion)
+            if packageVersion isnt @pack.version
+              @versionValue.addClass('text-warning')
+
             @pack = pack.versions[packageVersion]
             @installButton.show()
           else
+            @versionValue.addClass('text-danger')
             console.error("No available version compatible with the installed Atom version: #{atom.getVersion()}")
             return
 

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -57,6 +57,7 @@ class AvailablePackageView extends View
     {@name} = @pack
 
     @handlePackageEvents()
+    @handleControlsEvent()
     @updateEnablement()
     @loadCachedMetadata()
 
@@ -112,6 +113,7 @@ class AvailablePackageView extends View
             """
             console.error("No available version compatible with the installed Atom version: #{atom.getVersion()}")
 
+  handleControlsEvent: ->
     @installButton.on 'click', =>
       @install()
 

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 {View} = require 'atom-space-pen-views'
 {Subscriber} = require 'emissary'
 shell = require 'shell'
+semver = require 'semver'
 
 module.exports =
 class AvailablePackageView extends View
@@ -60,7 +61,15 @@ class AvailablePackageView extends View
     @updateEnablement()
     @loadCachedMetadata()
 
-    if atom.packages.isBundledPackage(@pack.name)
+    # Unfortunately, semver.satisfies('x.y.z-w', '>a.b.c') returns false, where
+    # semver.satisfies('x.y.z', '>a.b.c') returns true. So we have to remove
+    # the version hash so that it can be tested properly.
+    [atomVersion] = atom.getVersion().split('-')
+
+    isBundledPackage = atom.packages.isBundledPackage(@pack.name)
+    satisfiesAtomVersion = semver.satisfies(atomVersion, @pack.engines?.atom ? '*')
+
+    if isBundledPackage or !satisfiesAtomVersion
       @installButton.hide()
       @uninstallButton.hide()
 

--- a/lib/available-package-view.coffee
+++ b/lib/available-package-view.coffee
@@ -27,6 +27,7 @@ class AvailablePackageView extends View
         @h4 class: 'card-name', =>
           @a outlet: 'packageName', name
         @span outlet: 'packageDescription', class: 'package-description', description
+        @div outlet: 'packageMessage', class: 'package-message'
 
       @div class: 'meta', =>
         @div class: 'meta-user', =>
@@ -94,22 +95,18 @@ class AvailablePackageView extends View
             @versionValue.text(packageVersion)
             if packageVersion isnt @pack.version
               @versionValue.addClass('text-warning')
-              @packageDescription.append """
-              <br/>
-              <span class='text-warning'>
-                Version #{packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Atom.
-              </span>
+              @packageMessage.addClass('text-warning')
+              @packageMessage.text """
+              Version #{packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Atom.
               """
 
             @pack = pack.versions[packageVersion]
             @installButton.show()
           else
             @versionValue.addClass('text-danger')
-            @packageDescription.append """
-            <br/>
-            <span class='text-danger'>
-              There's no version of this package that is compatible with your Atom version. The version must satisfy #{@pack.engines.atom}.
-            </span>
+            @packageMessage.addClass('text-danger')
+            @packageMessage.append """
+            There's no version of this package that is compatible with your Atom version. The version must satisfy #{@pack.engines.atom}.
             """
             console.error("No available version compatible with the installed Atom version: #{atom.getVersion()}")
 

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -87,10 +87,11 @@ class PackageCard extends View
       if @packageManager.satisfiesVersion(atomVersion, @pack)
         @installButton.show()
       else
-        @packageManager.requestPackage @pack.name, (err, pack) =>
+        @packageManager.loadCompatiblePackageVersion @pack.name, (err, pack) =>
           return console.error(err) if err?
 
-          packageVersion = @packageManager.getLatestCompatibleVersion(pack)
+          packageVersion = pack.version
+
           # A compatible version exist, we activate the install button and
           # replace @pack so that the install action installs the compatible
           # version of the package.
@@ -103,7 +104,7 @@ class PackageCard extends View
               Version #{packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Atom.
               """
 
-            @installablePack = pack.versions[packageVersion]
+            @installablePack = pack
             @installButton.show()
           else
             @versionValue.addClass('text-danger')
@@ -191,7 +192,7 @@ class PackageCard extends View
 
     atom.packages.onDidActivatePackage (pack) =>
       @updateEnablement() if pack.name is @pack.name
-      
+
     @subscribeToPackageEvent 'package-installed package-install-failed theme-installed theme-install-failed', (pack, error) =>
       @installButton.prop('disabled', false)
       unless error?

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -147,17 +147,19 @@ class PackageManager
 
     latestVersion = null
     for version, metadata of pack.versions ? {}
-      continue unless semver.valid(version)
       continue unless metadata
-
-      engine = metadata.engines?.atom ? '*'
-      continue unless semver.validRange(engine)
-      continue unless semver.satisfies(atomVersion, engine)
+      continue unless semver.valid(version)
+      continue unless @satisfiesVersion(atomVersion, metadata)
 
       latestVersion ?= version
       latestVersion = version if semver.gt(version, latestVersion)
 
     latestVersion
+
+  satisfiesVersion: (version, metadata) ->
+    engine = metadata.engines?.atom ? '*'
+    return false unless semver.validRange(engine)
+    return semver.satisfies(version, engine)
 
   normalizeVersion: (version) ->
     [version] = version.split('-') if typeof version is 'string'

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -3,9 +3,6 @@ _ = require 'underscore-plus'
 {Emitter} = require 'emissary'
 Q = require 'q'
 semver = require 'semver'
-url = require 'url'
-apm = require 'apm'
-request = require 'apm/lib/request'
 
 Client = require './atom-io-client'
 

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -40,3 +40,29 @@ describe "AvailablePackageView", ->
     expect(view.uninstallButton.css('display')).toBe('none')
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
+
+  it "can be installed if currently not installed and package engine match atom version", ->
+    setPackageStatusSpies {installed: false, disabled: false}
+
+    view = new AvailablePackageView {
+      name: 'test-package'
+      engines:
+        atom: '>0.50.0'
+    }, @packageManager
+    
+    expect(view.installButton.css('display')).not.toBe('none')
+    expect(view.uninstallButton.css('display')).toBe('none')
+    view.installButton.click()
+    expect(@packageManager.install).toHaveBeenCalled()
+
+  it "can't be installed if the atom version doesn't match the package engine version", ->
+    setPackageStatusSpies {installed: false, disabled: false}
+
+    view = new AvailablePackageView {
+      name: 'test-package'
+      engines:
+        atom: '>=99.0.0'
+    }, @packageManager
+
+    expect(view.installButton.css('display')).toBe('none')
+    expect(view.uninstallButton.css('display')).toBe('none')

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -8,9 +8,13 @@ describe "AvailablePackageView", ->
 
 
   beforeEach ->
-    @packageManager = jasmine.createSpyObj('packageManager', ['on', 'getClient', 'emit', 'install', 'uninstall', 'requestPackage', 'getLatestCompatibleVersion'])
+    @packageManager = jasmine.createSpyObj('packageManager', ['on', 'getClient', 'emit', 'install', 'uninstall', 'requestPackage', 'getLatestCompatibleVersion', 'satisfiesVersion', 'normalizeVersion'])
     @packageManager.getLatestCompatibleVersion.andCallFake ->
       PackageManager.prototype.getLatestCompatibleVersion(arguments...)
+    @packageManager.satisfiesVersion.andCallFake ->
+      PackageManager.prototype.satisfiesVersion(arguments...)
+    @packageManager.normalizeVersion.andCallFake ->
+      PackageManager.prototype.normalizeVersion(arguments...)
     @packageManager.getClient.andCallFake -> jasmine.createSpyObj('client', ['avatar', 'package'])
     @packageManager.requestPackage.andCallFake (packageName, callback) ->
       pack =
@@ -83,6 +87,9 @@ describe "AvailablePackageView", ->
       engines:
         atom: '>0.50.0'
     }, @packageManager
+
+    # In that case there's no need to make a request to get all the versions
+    expect(@packageManager.requestPackage).not.toHaveBeenCalled()
 
     expect(view.installButton.css('display')).not.toBe('none')
     expect(view.uninstallButton.css('display')).toBe('none')

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -1,4 +1,5 @@
 AvailablePackageView = require '../lib/available-package-view'
+PackageManager = require '../lib/package-manager'
 
 describe "AvailablePackageView", ->
   setPackageStatusSpies = (opts) ->
@@ -7,8 +8,21 @@ describe "AvailablePackageView", ->
 
 
   beforeEach ->
-    @packageManager = jasmine.createSpyObj('packageManager', ['on', 'getClient', 'emit', 'install', 'uninstall'])
+    @packageManager = jasmine.createSpyObj('packageManager', ['on', 'getClient', 'emit', 'install', 'uninstall', 'requestPackage', 'getLatestCompatibleVersion'])
+    @packageManager.getLatestCompatibleVersion.andCallFake ->
+      PackageManager.prototype.getLatestCompatibleVersion(arguments...)
     @packageManager.getClient.andCallFake -> jasmine.createSpyObj('client', ['avatar', 'package'])
+    @packageManager.requestPackage.andCallFake (packageName, callback) ->
+      pack =
+        name: packageName
+        releases:
+          latest: '0.1.0'
+        versions:
+          '0.1.0':
+            engines:
+              atom: '>0.50.0'
+
+      callback(null, pack)
 
   it "doesn't show the disable control for a theme", ->
     setPackageStatusSpies {installed: true, disabled: false}
@@ -41,21 +55,99 @@ describe "AvailablePackageView", ->
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
 
-  it "can be installed if currently not installed and package engine match atom version", ->
+  it "can be installed if currently not installed and package latest release engine match atom version", ->
+    @packageManager.requestPackage.andCallFake (packageName, callback) ->
+      pack =
+        name: packageName
+        releases:
+          latest: '0.1.0'
+        versions:
+          '0.0.1':
+            name: packageName
+            version: '0.0.1'
+            engines:
+              atom: '>0.0.0'
+          '0.1.0':
+            name: packageName
+            version: '0.1.0'
+            engines:
+              atom: '>0.50.0'
+
+      callback(null, pack)
+
     setPackageStatusSpies {installed: false, disabled: false}
 
     view = new AvailablePackageView {
       name: 'test-package'
+      version: '0.1.0'
       engines:
         atom: '>0.50.0'
     }, @packageManager
-    
+
     expect(view.installButton.css('display')).not.toBe('none')
     expect(view.uninstallButton.css('display')).toBe('none')
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
+    expect(@packageManager.install.mostRecentCall.args[0]).toEqual({
+      name: 'test-package'
+      version: '0.1.0'
+      engines:
+        atom: '>0.50.0'
+    })
 
-  it "can't be installed if the atom version doesn't match the package engine version", ->
+  it "can be installed with a previous version whose engine match the current atom version", ->
+    @packageManager.requestPackage.andCallFake (packageName, callback) ->
+      pack =
+        name: packageName
+        releases:
+          latest: '0.1.0'
+        versions:
+          '0.0.1':
+            name: packageName
+            version: '0.0.1'
+            engines:
+              atom: '>0.50.0'
+          '0.1.0':
+            name: packageName
+            version: '0.0.1'
+            engines:
+              atom: '>99.0.0'
+
+      callback(null, pack)
+
+    setPackageStatusSpies {installed: false, disabled: false}
+
+    view = new AvailablePackageView {
+      name: 'test-package'
+      version: '0.1.0'
+      engines:
+        atom: '>99.0.0'
+    }, @packageManager
+
+    expect(view.installButton.css('display')).not.toBe('none')
+    expect(view.uninstallButton.css('display')).toBe('none')
+    view.installButton.click()
+    expect(@packageManager.install).toHaveBeenCalled()
+    expect(@packageManager.install.mostRecentCall.args[0]).toEqual({
+      name: 'test-package'
+      version: '0.0.1'
+      engines:
+        atom: '>0.50.0'
+    })
+
+  it "can't be installed if there is no version compatible with the current atom version", ->
+    @packageManager.requestPackage.andCallFake (packageName, callback) ->
+      pack =
+        name: packageName
+        releases:
+          latest: '0.1.0'
+        versions:
+          '0.1.0':
+            engines:
+              atom: '>99.0.0'
+
+      callback(null, pack)
+
     setPackageStatusSpies {installed: false, disabled: false}
 
     view = new AvailablePackageView {
@@ -66,3 +158,5 @@ describe "AvailablePackageView", ->
 
     expect(view.installButton.css('display')).toBe('none')
     expect(view.uninstallButton.css('display')).toBe('none')
+    expect(view.settingsButton.css('display')).toBe('none')
+    expect(view.enablementButton.css('display')).toBe('none')

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -135,7 +135,7 @@ describe "AvailablePackageView", ->
     expect(view.uninstallButton.css('display')).toBe('none')
     expect(view.versionValue.text()).toBe('0.0.1')
     expect(view.versionValue).toHaveClass('text-warning')
-    expect(view.packageDescription.find('.text-warning')).toExist()
+    expect(view.packageMessage).toHaveClass('text-warning')
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
     expect(@packageManager.install.mostRecentCall.args[0]).toEqual({
@@ -171,4 +171,4 @@ describe "AvailablePackageView", ->
     expect(view.settingsButton.css('display')).toBe('none')
     expect(view.enablementButton.css('display')).toBe('none')
     expect(view.versionValue).toHaveClass('text-danger')
-    expect(view.packageDescription.find('.text-danger')).toExist()
+    expect(view.packageMessage).toHaveClass('text-danger')

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -128,6 +128,7 @@ describe "AvailablePackageView", ->
     expect(view.uninstallButton.css('display')).toBe('none')
     expect(view.versionValue.text()).toBe('0.0.1')
     expect(view.versionValue).toHaveClass('text-warning')
+    expect(view.packageDescription.find('.text-warning')).toExist()
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
     expect(@packageManager.install.mostRecentCall.args[0]).toEqual({
@@ -163,3 +164,4 @@ describe "AvailablePackageView", ->
     expect(view.settingsButton.css('display')).toBe('none')
     expect(view.enablementButton.css('display')).toBe('none')
     expect(view.versionValue).toHaveClass('text-danger')
+    expect(view.packageDescription.find('.text-danger')).toExist()

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -126,6 +126,8 @@ describe "AvailablePackageView", ->
 
     expect(view.installButton.css('display')).not.toBe('none')
     expect(view.uninstallButton.css('display')).toBe('none')
+    expect(view.versionValue.text()).toBe('0.0.1')
+    expect(view.versionValue).toHaveClass('text-warning')
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
     expect(@packageManager.install.mostRecentCall.args[0]).toEqual({
@@ -160,3 +162,4 @@ describe "AvailablePackageView", ->
     expect(view.uninstallButton.css('display')).toBe('none')
     expect(view.settingsButton.css('display')).toBe('none')
     expect(view.enablementButton.css('display')).toBe('none')
+    expect(view.versionValue).toHaveClass('text-danger')

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -2,7 +2,6 @@ path = require 'path'
 PackageDetailView = require '../lib/package-detail-view'
 PackageManager = require '../lib/package-manager'
 
-
 describe "PackageDetailView", ->
   beforeEach ->
     spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -5,7 +5,7 @@ PackageManager = require '../lib/package-manager'
 
 describe "PackageDetailView", ->
   beforeEach ->
-    spyOn(PackageManager.prototype, 'requestPackage').andCallFake ->
+    spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
 
   it "displays the grammars registered by the package", ->
     settingsPanels = null

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -3,6 +3,9 @@ InstalledPackageView = require '../lib/installed-package-view'
 PackageManager = require '../lib/package-manager'
 
 describe "InstalledPackageView", ->
+  beforeEach ->
+    spyOn(PackageManager.prototype, 'requestPackage').andCallFake ->
+
   it "displays the grammars registered by the package", ->
     settingsPanels = null
 

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -9,6 +9,7 @@ describe 'InstalledPackagesPanel', ->
   beforeEach ->
     @packageManager = new PackageManager
     @installed = JSON.parse fs.readFileSync(path.join(__dirname, 'fixtures', 'installed.json'))
+    spyOn(@packageManager, 'requestPackage').andCallFake ->
     spyOn(@packageManager, 'getInstalled').andReturn Q(@installed)
     @panel = new InstalledPackagesPanel(@packageManager)
 

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -9,7 +9,7 @@ describe 'InstalledPackagesPanel', ->
   beforeEach ->
     @packageManager = new PackageManager
     @installed = JSON.parse fs.readFileSync(path.join(__dirname, 'fixtures', 'installed.json'))
-    spyOn(@packageManager, 'requestPackage').andCallFake ->
+    spyOn(@packageManager, 'loadCompatiblePackageVersion').andCallFake ->
     spyOn(@packageManager, 'getInstalled').andReturn Q(@installed)
     @panel = new InstalledPackagesPanel(@packageManager)
 

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -6,6 +6,7 @@ describe "package updates status view", ->
   beforeEach ->
     outdatedPackage =
       name: 'out-dated'
+    spyOn(PackageManager.prototype, 'requestPackage').andCallFake ->
     spyOn(PackageManager.prototype, 'getOutdated').andCallFake -> Q([outdatedPackage])
     jasmine.attachToDOM(atom.views.getView(atom.workspace))
 

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -6,7 +6,7 @@ describe "package updates status view", ->
   beforeEach ->
     outdatedPackage =
       name: 'out-dated'
-    spyOn(PackageManager.prototype, 'requestPackage').andCallFake ->
+    spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
     spyOn(PackageManager.prototype, 'getOutdated').andCallFake -> Q([outdatedPackage])
     jasmine.attachToDOM(atom.views.getView(atom.workspace))
 


### PR DESCRIPTION
When installing a new package, Settings View will allow package versions to be installed whose `package.json` files require a version of Atom newer than the one currently installed.

See atom/atom#5467 for details.