### PR TITLE
Variable font size

### DIFF
--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -9,7 +9,7 @@
     padding: @component-padding*1.5;
     margin-bottom: @component-padding;
     list-style-type: none;
-    font-size: 13px;
+    font-size: 1.2em;
     border-radius: @component-border-radius*2;
     border: 1px solid @base-border-color;
     background-color: lighten(@tool-panel-background-color, 8%);
@@ -57,8 +57,6 @@
     }
 
     .description {
-      font-size: 12px;
-      line-height: 18px;
       color: @text-color;
       overflow: hidden;
       min-height: 38px;
@@ -70,8 +68,6 @@
     }
 
     .downloads {
-      font-size: 12px;
-      line-height: 12px;
       color: @text-color-highlight;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -127,10 +123,6 @@
         display: inline-block;
         vertical-align: top;
 
-        a.social-count {
-          font-size: 13px;
-        }
-
         .star-button {
           padding: 0 6px;
 
@@ -183,7 +175,6 @@
 
       .value {
         color: #999;
-        font-size: 13px;
       }
     }
 

--- a/styles/package-update.less
+++ b/styles/package-update.less
@@ -33,18 +33,16 @@
       white-space: nowrap;
       width: 100%;
       overflow: hidden;
-      line-height: 20px;
       margin: 5px 0;
       color: @text-color-highlight;
     }
 
     .description {
-      font-size: 12px;
-      line-height: 18px;
       color: @text-color;
       overflow: hidden;
-      min-height: 38px;
-      max-height: 38px;
+      line-height: 1.5;
+      min-height: 3em;
+      max-height: 3em;
       text-overflow: ellipsis;
       display: -webkit-box;
       -webkit-line-clamp: 2; /* number of lines to show */
@@ -52,8 +50,6 @@
     }
 
     .downloads {
-      font-size: 12px;
-      line-height: 12px;
       color: @text-color-highlight;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -10,7 +10,7 @@
   .breadcrumb {
     margin-bottom: 0;
     padding: @breadcrumb-padding;
-    font-size: 13px;
+    font-size: 1.2em;
     color: @text-color-subtle;
     list-style: none;
 
@@ -87,8 +87,7 @@
   }
 
   .checkbox {
-    font-size: 13px;
-    padding-left: @component-padding*2.4;
+    padding-left: 2em;
     .setting-title {
       display: inline-block;
     }
@@ -98,9 +97,9 @@
     display: inline-block;
     position: relative;
     font-size: inherit;
-    margin: 0 0 0 -@component-padding*2.4;
-    width: 1.2em;
-    height: 1.2em;
+    margin: 0 0 0 -2em;
+    width: 1.5em;
+    height: 1.5em;
     cursor: pointer;
     outline: 0;
     border-radius: @component-border-radius;
@@ -119,8 +118,8 @@
     &:after {
       content: "";
       position: absolute;
-      top: .9em;
-      left: .45em;
+      top: 1.1em;
+      left: .5em;
       height: .15em;
       min-height: 2px;
       border-radius: 1px;
@@ -130,11 +129,11 @@
       transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
     }
     &:before {
-      width: .4em;
+      width: .5em;
       transform: rotate(225deg) scale(0);
     }
     &:after {
-      width: .8em;
+      width: 1em;
       margin: -1px;
       transform: rotate(-45deg) scale(0);
       transition-delay: .05s;
@@ -161,7 +160,6 @@
   }
 
   .color {
-    font-size: 13px;
     padding-left: 5em;
     .setting-title {
       margin-top: .15em;
@@ -251,7 +249,7 @@
   .section .section-heading {
     margin-bottom: @component-padding*2;
     color: @text-color-highlight;
-    font-size: 20px;
+    font-size: 1.75em;
     font-weight: bold;
     line-height: 1;
     -webkit-user-select: none;
@@ -273,7 +271,7 @@
 
   .sub-section-heading {
     color: @text-color-highlight;
-    font-size: 16px;
+    font-size: 1.4em;
     font-weight: bold;
     line-height: 1;
   }
@@ -284,12 +282,12 @@
   }
 
   .setting-title {
+    font-size: 1.2em;
     -webkit-user-select: none;
   }
 
   .setting-description {
     color: @text-color-subtle;
-    font-size: 10px;
     -webkit-user-select: none;
     cursor: default;
 
@@ -332,7 +330,6 @@
       li > a {
         border-radius: 1px !important;
         padding: 12px 14px;
-        font-size: @font-size + 1px;
         font-weight: bold;
         line-height: 16px;
         opacity: .85;
@@ -359,7 +356,6 @@
       }
 
       .package-version {
-        font-size: 11px;
         line-height: 16px;
         margin-left: 5px;
         font-weight: normal;
@@ -367,7 +363,6 @@
       }
 
       .package-author {
-        font-size: 11px;
         font-weight: normal;
         display: block;
         color: #999;
@@ -416,11 +411,10 @@
   .settings-panel {
     label {
       color: @text-color;
-      font-size: 13px;
     }
 
     .control-group + .control-group {
-      margin-top:  @component-padding*1.5;
+      margin-top:  1.5em;
     }
 
     .control-group .editor-container {
@@ -490,7 +484,6 @@
 
     .themes-label {
       font-weight: bold;
-      font-size: 14px;
     }
 
     .theme-chooser {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -87,7 +87,7 @@
   }
 
   .checkbox {
-    padding-left: 2em;
+    padding-left: 2.25em;
     .setting-title {
       display: inline-block;
     }
@@ -97,7 +97,7 @@
     display: inline-block;
     position: relative;
     font-size: inherit;
-    margin: 0 0 0 -2em;
+    margin: 0 0 0 -2.25em;
     width: 1.5em;
     height: 1.5em;
     cursor: pointer;
@@ -119,8 +119,8 @@
       content: "";
       position: absolute;
       top: 1.1em;
-      left: .5em;
-      height: .15em;
+      left: .6em;
+      height: .16em;
       min-height: 2px;
       border-radius: 1px;
       background-color: @base-background-color;
@@ -129,11 +129,11 @@
       transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
     }
     &:before {
-      width: .5em;
+      width: .45em;
       transform: rotate(225deg) scale(0);
     }
     &:after {
-      width: 1em;
+      width: .9em;
       margin: -1px;
       transform: rotate(-45deg) scale(0);
       transition-delay: .05s;
@@ -483,6 +483,7 @@
     flex-flow: column;
 
     .themes-label {
+      font-size: 1.25em;
       font-weight: bold;
     }
 


### PR DESCRIPTION
:warning: Don't merge yet. These changes are done on top of #373. Wait until that PR gets merged first.

This PR changes the `font-size` to `em`s. It makes it easier to change most font sizes by only selecting `.settings-view` instead of having to override lots of individual elements.

Fixes: https://github.com/atom/atom/issues/4342

Before:

![screen shot 2015-03-03 at 3 16 03 pm](https://cloud.githubusercontent.com/assets/378023/6457366/4dcdfe4e-c1b8-11e4-8226-b7b09f7cdb72.png)

After:

![screen shot 2015-03-03 at 3 01 16 pm](https://cloud.githubusercontent.com/assets/378023/6457371/57d28a7c-c1b8-11e4-9804-679752271061.png)

Customized with:

```css
.settings-view { font-size: 13px; }
```

![screen shot 2015-03-03 at 3 01 32 pm](https://cloud.githubusercontent.com/assets/378023/6457379/7009afc6-c1b8-11e4-8543-6676dab4070d.png)


__Note:__ Not everything can be changes with just the `.settings-view` selector. Controls or buttons still have a fixed px size.
