### PR TITLE
Enablement updates

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -95,7 +95,6 @@ class PackageCard extends View
         atom.packages.enablePackage(@pack.name)
       else
         atom.packages.disablePackage(@pack.name)
-      @updateEnablement()
       false
 
   detached: ->
@@ -141,6 +140,12 @@ class PackageCard extends View
         .removeClass('is-disabled')
 
   handlePackageEvents: ->
+    atom.packages.onDidDeactivatePackage (pack) =>
+      @updateEnablement() if pack.name is @pack.name
+
+    atom.packages.onDidActivatePackage (pack) =>
+      @updateEnablement() if pack.name is @pack.name
+      
     @subscribeToPackageEvent 'package-installed package-install-failed theme-installed theme-install-failed', (pack, error) =>
       @installButton.prop('disabled', false)
       unless error?

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -61,3 +61,20 @@ describe "InstalledPackageView", ->
       view = new InstalledPackageView(pack, new PackageManager())
       keybindingsTable = view.find('.package-keymap-table tbody')
       expect(keybindingsTable.children().length).toBe 0
+
+  fit "displays the correct enablement state", ->
+    availablePackageView = null
+
+    waitsForPromise ->
+      atom.packages.activatePackage('status-bar')
+
+    runs ->
+      expect(atom.packages.isPackageActive('status-bar')).toBe(true)
+      atom.packages.disablePackage('status-bar')
+      expect(atom.packages.isPackageDisabled('status-bar')).toBe(true)
+
+      pack = atom.packages.getLoadedPackage('status-bar')
+      view = new InstalledPackageView(pack, new PackageManager())
+      availablePackageView = view.find('.available-package-view')
+      console.log(availablePackageView)
+      expect(availablePackageView.hasClass('disabled')).toBe(true)

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -63,18 +63,21 @@ describe "PackageDetailView", ->
       expect(keybindingsTable.children().length).toBe 0
 
   fit "displays the correct enablement state", ->
-    availablePackageView = null
+    packageCard = null
 
     waitsForPromise ->
       atom.packages.activatePackage('status-bar')
 
     runs ->
       expect(atom.packages.isPackageActive('status-bar')).toBe(true)
+      pack = atom.packages.getLoadedPackage('status-bar')
+      view = new PackageDetailView(pack, new PackageManager())
+      packageCard = view.find('.package-card')
+
+    runs ->
+      # Trigger observeDisabledPackages() here
+      # because it is not default in specs
+      atom.packages.observeDisabledPackages()
       atom.packages.disablePackage('status-bar')
       expect(atom.packages.isPackageDisabled('status-bar')).toBe(true)
-
-      pack = atom.packages.getLoadedPackage('status-bar')
-      view = new InstalledPackageView(pack, new PackageManager())
-      availablePackageView = view.find('.available-package-view')
-      console.log(availablePackageView)
-      expect(availablePackageView.hasClass('disabled')).toBe(true)
+      expect(packageCard.hasClass('disabled')).toBe(true)

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -62,7 +62,7 @@ describe "PackageDetailView", ->
       keybindingsTable = view.find('.package-keymap-table tbody')
       expect(keybindingsTable.children().length).toBe 0
 
-  fit "displays the correct enablement state", ->
+  it "displays the correct enablement state", ->
     packageCard = null
 
     waitsForPromise ->


### PR DESCRIPTION
This adds a spec and fixes enablement styles (whether a package is enabled or disabled) which were going missing when navigating to `detail-package-view`.

Problem:
Disabled in this view
![screen shot 2015-03-04 at 9 25 55 pm](https://cloud.githubusercontent.com/assets/1305617/6499746/808a079e-c2b5-11e4-80db-4e1c68f8b11b.png)
Enabled in this view
![screen shot 2015-03-04 at 9 25 58 pm](https://cloud.githubusercontent.com/assets/1305617/6499748/82509606-c2b5-11e4-9ef2-294837b96bc0.png)
