### PR TITLE
Unload old packages from module cache.

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -151,7 +151,10 @@ class PackageManager
       activateOnSuccess = not atom.packages.isPackageDisabled(name)
     activateOnFailure = atom.packages.isPackageActive(name)
     atom.packages.deactivatePackage(name) if atom.packages.isPackageActive(name)
-    atom.packages.unloadPackage(name) if atom.packages.isPackageLoaded(name)
+    if atom.packages.isPackageLoaded(name)
+      # remove old version from node.js module cache
+      delete require.cache[atom.packages.getLoadedPackage(name).getMainModulePath()]
+      atom.packages.unloadPackage(name)
 
     args = ['install', "#{name}@#{newVersion}"]
     exit = (code, stdout, stderr) =>


### PR DESCRIPTION
fixes atom/atom#5940
Before this, old package versions would be loaded from the node.js module cache through require(), after doing a package update. This would sometimes produce errors since only the main module of the package was outdated.