### PR TITLE
Add package card hover state

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -20,7 +20,7 @@ class PackageDetailView extends View
   Subscriber.includeInto(this)
 
   @content: (pack, packageManager) ->
-    @div =>
+    @div class: 'package-detail', =>
       @ol outlet: 'breadcrumbContainer', class: 'native-key-bindings breadcrumb', tabindex: -1, =>
         @li =>
           @a outlet: 'breadcrumb'

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -1,5 +1,6 @@
 @import "octicon-mixins";
 @import "ui-variables";
+@import "variables";
 
 .settings-view {
 
@@ -12,19 +13,19 @@
     font-size: 1.2em;
     border-radius: @component-border-radius*2;
     border: 1px solid @base-border-color;
-    background-color: lighten(@tool-panel-background-color, 8%);
+    background-color: @package-card-background-color;
     overflow: hidden;
     cursor: pointer;
 
     &:hover {
-      background-color: lighten(@tool-panel-background-color, 10%);
+      background-color: contrast(@package-card-background-color, darken(@package-card-background-color, 2%), lighten(@package-card-background-color, 2%));
     }
     &:active {
-      background-color: lighten(@tool-panel-background-color, 8%);
+      background-color: @package-card-background-color;
     }
 
     &.disabled {
-      background-color: lighten(@tool-panel-background-color, 5%);
+      background-color: darken(@package-card-background-color, 3%);
       .body,
       .avatar,
       .author,
@@ -47,7 +48,7 @@
       color: @text-color;
       border-radius: @component-border-radius*2;
       border: 1px solid @base-border-color;
-      background-color: lighten(@tool-panel-background-color, 8%);
+      background-color: @package-card-background-color;
 
       .caption {
         width: 100%;
@@ -252,10 +253,10 @@
   .package-detail .package-card {
     cursor: auto;
     &:hover {
-      background-color: lighten(@tool-panel-background-color, 8%);
+      background-color: @package-card-background-color;
     }
     &.disabled {
-      background-color: lighten(@tool-panel-background-color, 5%);
+      background-color: darken(@package-card-background-color, 3%);
     }
   }
 

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -23,6 +23,10 @@
       .stats {
         opacity: .5;
       }
+
+      &:hover {
+        background-color: lighten(@tool-panel-background-color, 4%);
+      }
     }
 
     &:hover {

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -14,6 +14,14 @@
     border: 1px solid @base-border-color;
     background-color: lighten(@tool-panel-background-color, 8%);
     overflow: hidden;
+    cursor: pointer;
+
+    &:hover {
+      background-color: lighten(@tool-panel-background-color, 10%);
+    }
+    &:active {
+      background-color: lighten(@tool-panel-background-color, 8%);
+    }
 
     &.disabled {
       background-color: lighten(@tool-panel-background-color, 5%);
@@ -23,14 +31,6 @@
       .stats {
         opacity: .5;
       }
-
-      &:hover {
-        background-color: lighten(@tool-panel-background-color, 4%);
-      }
-    }
-
-    &:hover {
-      background-color: lighten(@tool-panel-background-color, 5%);
     }
 
     &.col-lg-4 {

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -247,6 +247,18 @@
     // End copy-paste from atom.io
 
   }
+
+  // Remove hover styles if it's in a detail view
+  .package-detail .package-card {
+    cursor: auto;
+    &:hover {
+      background-color: lighten(@tool-panel-background-color, 8%);
+    }
+    &.disabled {
+      background-color: lighten(@tool-panel-background-color, 5%);
+    }
+  }
+
 }
 
 @-webkit-keyframes available-package-is-installing {

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -25,7 +25,7 @@
     }
 
     &.disabled {
-      background-color: darken(@package-card-background-color, 3%);
+      background-color: @package-card-disabled-background-color;
       .body,
       .avatar,
       .author,
@@ -256,7 +256,7 @@
       background-color: @package-card-background-color;
     }
     &.disabled {
-      background-color: darken(@package-card-background-color, 3%);
+      background-color: @package-card-disabled-background-color;
     }
   }
 

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -25,6 +25,10 @@
       }
     }
 
+    &:hover {
+      background-color: lighten(@tool-panel-background-color, 5%);
+    }
+
     &.col-lg-4 {
       min-width: 190px;
       padding: @component-padding 0;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1,2 +1,3 @@
 // Import only after ui-variables.less
 @package-card-background-color: lighten(@tool-panel-background-color, 8%);
+@package-card-disabled-background-color: darken(@package-card-background-color, 3%);

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1,0 +1,2 @@
+// Import only after ui-variables.less
+@package-card-background-color: lighten(@tool-panel-background-color, 8%);


### PR DESCRIPTION
Now that #373 has landed, I recently noticed that clicking on the package card body now takes you to the detail view for that package, which is quite nice, but threw me at first. It wasn't clear that anything would happen from clicking the package card body.

This adds a hover state to visually indicate that the user can interact with the package card body. I considered changing the cursor to a pointer too, but I wasn't sure if that'd be too weird - let me know if you think that's worth adding too!

![screencap](https://cloud.githubusercontent.com/assets/823545/6639054/8635b630-c962-11e4-9eed-74d949d39ea3.gif)
