### PR TITLE
Settings indicator

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -68,7 +68,10 @@ class PackageCard extends View
     if atom.packages.isBundledPackage(@pack.name) and @type is 'theme'
       @statusIndicator.hide()
 
-    if opts?.onSettingsView or not @hasSettings(@pack)
+    unless @hasSettings(@pack)
+      @settingsButton.hide()
+
+    if opts?.onSettingsView
       @settingsButton.remove()
     else
       @on 'click', =>

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -37,8 +37,8 @@ class PackageCard extends View
           @div class: 'btn-group', =>
             @button type: 'button', class: 'btn btn-info icon icon-cloud-download install-button', outlet: 'installButton', 'Install'
           @div outlet: 'buttons', class: 'btn-group', =>
-            @button type: 'button', class: 'btn icon icon-gear settings',           outlet: 'settingsButton', 'Settings'
-            @button type: 'button', class: 'btn icon icon-trashcan uninstall',       outlet: 'uninstallButton', 'Uninstall'
+            @button type: 'button', class: 'btn icon icon-gear settings',             outlet: 'settingsButton', 'Settings'
+            @button type: 'button', class: 'btn icon icon-trashcan uninstall',        outlet: 'uninstallButton', 'Uninstall'
             @button type: 'button', class: 'btn icon icon-playback-pause enablement', outlet: 'enablementButton', =>
               @span class: 'disable-text', 'Disable'
             @button type: 'button', class: 'btn status-indicator', tabindex: -1, outlet: 'statusIndicator'

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -191,7 +191,7 @@ class PackageCard extends View
   isDisabled: -> atom.packages.isPackageDisabled(@pack.name)
 
   hasSettings: (pack) ->
-    if atom.config.get(pack.name)? then true else false
+    atom.config.get(pack.name)?
 
   subscribeToPackageEvent: (event, callback) ->
     @subscribe @packageManager, event, (pack, error) =>

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -37,9 +37,9 @@ class PackageCard extends View
           @div class: 'btn-group', =>
             @button type: 'button', class: 'btn btn-info icon icon-cloud-download install-button', outlet: 'installButton', 'Install'
           @div outlet: 'buttons', class: 'btn-group', =>
-            @button type: 'button', class: 'btn icon icon-gear',           outlet: 'settingsButton', 'Settings'
-            @button type: 'button', class: 'btn icon icon-trashcan',       outlet: 'uninstallButton', 'Uninstall'
-            @button type: 'button', class: 'btn icon icon-playback-pause', outlet: 'enablementButton', =>
+            @button type: 'button', class: 'btn icon icon-gear settings',           outlet: 'settingsButton', 'Settings'
+            @button type: 'button', class: 'btn icon icon-trashcan uninstall',       outlet: 'uninstallButton', 'Uninstall'
+            @button type: 'button', class: 'btn icon icon-playback-pause enablement', outlet: 'enablementButton', =>
               @span class: 'disable-text', 'Disable'
             @button type: 'button', class: 'btn status-indicator', tabindex: -1, outlet: 'statusIndicator'
 
@@ -69,7 +69,7 @@ class PackageCard extends View
       @statusIndicator.hide()
 
     unless @hasSettings(@pack)
-      @settingsButton.hide()
+      @settingsButton.remove()
 
     if opts?.onSettingsView
       @settingsButton.remove()

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -68,7 +68,7 @@ class PackageCard extends View
     if atom.packages.isBundledPackage(@pack.name) and @type is 'theme'
       @statusIndicator.hide()
 
-    if opts?.onSettingsView
+    if opts?.onSettingsView or not @hasSettings(@pack)
       @settingsButton.remove()
     else
       @on 'click', =>
@@ -145,7 +145,7 @@ class PackageCard extends View
 
     atom.packages.onDidActivatePackage (pack) =>
       @updateEnablement() if pack.name is @pack.name
-      
+
     @subscribeToPackageEvent 'package-installed package-install-failed theme-installed theme-install-failed', (pack, error) =>
       @installButton.prop('disabled', false)
       unless error?
@@ -186,6 +186,9 @@ class PackageCard extends View
   isInstalled: -> atom.packages.isPackageLoaded(@pack.name) and not atom.packages.isPackageDisabled(@pack.name)
 
   isDisabled: -> atom.packages.isPackageDisabled(@pack.name)
+
+  hasSettings: (pack) ->
+    if atom.config.get(pack.name)? then true else false
 
   subscribeToPackageEvent: (event, callback) ->
     @subscribe @packageManager, event, (pack, error) =>

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -43,6 +43,6 @@ describe "PackageCard", ->
     expect(@packageManager.install).toHaveBeenCalled()
 
   it "hides the settings button if a package has no settings", ->
-    setPackageStatusSpies {installed: true, disabled: false, hasSettings: true}
+    setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
     view = new PackageCard {name: 'test-package'}, @packageManager
     expect(view.settingsButton.css('display')).toBe('none')

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -40,3 +40,8 @@ describe "PackageCard", ->
     expect(view.uninstallButton.css('display')).toBe('none')
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
+
+  xit "hides the settings button if a package has no settings", ->
+    setPackageStatusSpies {installed: true, disabled: false}
+    view = new PackageCard {name: 'test-package'}, @packageManager
+    expect(view.settingsButton).not.toExist()

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -4,6 +4,7 @@ describe "PackageCard", ->
   setPackageStatusSpies = (opts) ->
     spyOn(PackageCard.prototype, 'isInstalled').andReturn(opts.installed)
     spyOn(PackageCard.prototype, 'isDisabled').andReturn(opts.disabled)
+    spyOn(PackageCard.prototype, 'hasSettings').andReturn(opts.hasSettings)
 
 
   beforeEach ->
@@ -42,6 +43,6 @@ describe "PackageCard", ->
     expect(@packageManager.install).toHaveBeenCalled()
 
   xit "hides the settings button if a package has no settings", ->
-    setPackageStatusSpies {installed: true, disabled: false}
+    setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
     view = new PackageCard {name: 'test-package'}, @packageManager
     expect(view.settingsButton).not.toExist()

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -45,4 +45,4 @@ describe "PackageCard", ->
   it "hides the settings button if a package has no settings", ->
     setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
     view = new PackageCard {name: 'test-package'}, @packageManager
-    expect(view.settingsButton.css('display')).toBe('none')
+    expect(view.find('.btn.settings')).not.toExist()

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -42,7 +42,7 @@ describe "PackageCard", ->
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
 
-  xit "hides the settings button if a package has no settings", ->
-    setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
+  it "hides the settings button if a package has no settings", ->
+    setPackageStatusSpies {installed: true, disabled: false, hasSettings: true}
     view = new PackageCard {name: 'test-package'}, @packageManager
-    expect(view.settingsButton).not.toExist()
+    expect(view.settingsButton.css('display')).toBe('none')


### PR DESCRIPTION
Resolves #355 

![image](https://cloud.githubusercontent.com/assets/823545/6830494/68e48a42-d2f0-11e4-99db-b55ea37d7f19.png)

I kept the style of the settings button as-is, but we could remove the text if that would be better. Personally, I think we should keep it for clarity. (Maybe remove it on smaller viewport widths?)

I could also add the "scroll to settings" behavior to this PR as well - let me know if you think that would be best.

/cc @thedaniel @simurai @zephraph