### PR TITLE
Use new version of status-bar Service API

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.58.0": "consumeStatusBar"
+        "^1.0.0": "consumeStatusBar"
       }
     }
   }


### PR DESCRIPTION
The `status-bar` now has a `1.0.0` version of its service, this changes `settings-view` to use that. :sparkles: 