### PR TITLE
Add coffeelint.json

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,17 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  }
+}


### PR DESCRIPTION
This adds [coffeelint.json](https://github.com/atom/atom/blob/master/coffeelint.json) from the main Atom repo. 

This is probably not ideal – ideally it would be great if each core package not only had a coffeelint.json file, but was synced with the one in the main Atom repo for maximum DRYness. I'm not really sure how to do this though. This would be easy enough to do in Travis builds (e.g. atom/atom#5982), but there is real value in having coffeelint properly configured during local development too. And git submodules would be a real pain.

If this does seem like the best way to go about it right now I'd be happy to go and add this to all core packages.

/cc @kevinsawicki 