### PR TITLE
Use .remove() rather than .hide() for sake of button group

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -64,9 +64,10 @@ class PackageCard extends View
       @installButton.remove()
       @uninstallButton.remove()
 
-    # core themes only have a settings option, no status
-    if atom.packages.isBundledPackage(@pack.name) and @type is 'theme'
+    # themes have no status and cannot be dis/enabled
+    if @type is 'theme'
       @statusIndicator.remove()
+      @enablementButton.remove()
 
     unless @hasSettings(@pack)
       @settingsButton.remove()

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -61,12 +61,12 @@ class PackageCard extends View
     @loadCachedMetadata()
 
     if atom.packages.isBundledPackage(@pack.name)
-      @installButton.hide()
-      @uninstallButton.hide()
+      @installButton.remove()
+      @uninstallButton.remove()
 
     # core themes only have a settings option, no status
     if atom.packages.isBundledPackage(@pack.name) and @type is 'theme'
-      @statusIndicator.hide()
+      @statusIndicator.remove()
 
     unless @hasSettings(@pack)
       @settingsButton.remove()

--- a/spec/available-package-view-spec.coffee
+++ b/spec/available-package-view-spec.coffee
@@ -14,7 +14,17 @@ describe "PackageCard", ->
   it "doesn't show the disable control for a theme", ->
     setPackageStatusSpies {installed: true, disabled: false}
     view = new PackageCard {theme: 'syntax', name: 'test-theme'}, @packageManager
-    expect(view.enablementButton.css('display')).toBe('none')
+    expect(view.find.enablementButton).not.toExist()
+
+  it "doesn't show the status indicator for a theme", ->
+    setPackageStatusSpies {installed: true, disabled: false}
+    view = new PackageCard {theme: 'syntax', name: 'test-theme'}, @packageManager
+    expect(view.find.statusIndicatorButton).not.toExist()
+
+  it "doesn't show the settings button for a theme", ->
+    setPackageStatusSpies {installed: true, disabled: false}
+    view = new PackageCard {theme: 'syntax', name: 'test-theme'}, @packageManager
+    expect(view.find.settingsButton).not.toExist()
 
   it "can be disabled if installed", ->
     setPackageStatusSpies {installed: true, disabled: false}
@@ -42,7 +52,7 @@ describe "PackageCard", ->
     view.installButton.click()
     expect(@packageManager.install).toHaveBeenCalled()
 
-  it "hides the settings button if a package has no settings", ->
+  it "removes the settings button if a package has no settings", ->
     setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
     view = new PackageCard {name: 'test-package'}, @packageManager
     expect(view.find('.btn.settings')).not.toExist()


### PR DESCRIPTION
Instead of _hiding_ certain buttons, we should _remove_ them so that they do not interfere with how the border radius is applied to the button group.

Before & After

![screen shot 2015-04-01 at 12 44 38 pm](https://cloud.githubusercontent.com/assets/1305617/6973377/40df7caa-d93f-11e4-91ec-7230140dadd5.png)

![screen shot 2015-04-02 at 1 50 24 pm](https://cloud.githubusercontent.com/assets/1305617/6973378/456b57f8-d93f-11e4-9007-1783f6ebf48d.png)


This:
- `.remove()` `install` and `uninstall` buttons from bundled packages.
- `.remove()` `statusIndicator` and `enablement` from themes since you cannot toggle them enabled/disabled.
- adds and updates specs to verify themes do not get `settings` `enablement` or `statusIndicator` buttons