### PR TITLE
Normalize cursor and select for headings and package cards

### DIFF
--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -16,6 +16,7 @@
     background-color: @package-card-background-color;
     overflow: hidden;
     cursor: pointer;
+    -webkit-user-select: none;
 
     &:hover {
       background-color: contrast(@package-card-background-color, darken(@package-card-background-color, 2%), lighten(@package-card-background-color, 2%));
@@ -251,7 +252,7 @@
 
   // Remove hover styles if it's in a detail view
   .package-detail .package-card {
-    cursor: auto;
+    cursor: default;
     &:hover {
       background-color: @package-card-background-color;
     }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -274,6 +274,8 @@
     font-size: 1.4em;
     font-weight: bold;
     line-height: 1;
+    -webkit-user-select: none;
+    cursor: default;
   }
 
   .control-label {


### PR DESCRIPTION
This disables select for package cards and headings, and uses the default cursor for package cards in the detail view.

/cc @simurai @thedaniel 