### PR TITLE
Use remove() instead of hide() for button group styling

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -68,11 +68,11 @@ class PackageCard extends View
 
     # themes have no status and cannot be dis/enabled
     if @type is 'theme'
-      @statusIndicator.hide()
-      @enablementButton.hide()
+      @statusIndicator.remove()
+      @enablementButton.remove()
 
     unless @hasSettings(@pack)
-      @settingsButton.hide()
+      @settingsButton.remove()
 
     # The package is not bundled with Atom and is not installed so we'll have
     # to find a package version that is compatible with this Atom version.


### PR DESCRIPTION
We've fixed this in places in the past (and there are likely more places that will turn up) where we switch to `remove()` so that the remaining buttons get rounded corners (even with `display: none;` it is still in the dom and messes up the CSS).

This in particular was affecting themes that had no settings and which be default cannot be disabled or have a status indicator. :traffic_light: 

This PR removes instead of hides the three non-relevant buttons. 