### PR TITLE
Add active theme settings buttons

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -233,7 +233,9 @@ class PackageCard extends View
   isDisabled: -> atom.packages.isPackageDisabled(@pack.name)
 
   hasSettings: (pack) ->
-    atom.config.get(pack.name)?
+    for key, value of atom.config.get(pack.name)
+      return true
+    false
 
   subscribeToPackageEvent: (event, callback) ->
     @subscribe @packageManager, event, (pack, error) =>

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -176,15 +176,20 @@ class ThemesPanel extends View
         })
 
   toggleCurrentThemeButtons: ->
-    if atom.config.get(@activeUiTheme)?
+    if @hasSettings(@activeUiTheme)
       @currentUiThemeSettings.show()
     else
       @currentUiThemeSettings.hide()
 
-    if atom.config.get(@activeSyntaxTheme)?
+    if @hasSettings(@activeSyntaxTheme)
       @currentSyntaxThemeSettings.show()
     else
       @currentSyntaxThemeSettings.hide()
+
+  hasSettings: (keyPath) ->
+    for key, value of atom.config.get(keyPath)
+      return true
+    false
 
   # Populate the theme menus from the theme manager's active themes
   populateThemeMenus: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -151,6 +151,17 @@ class ThemesPanel extends View
     @activeUiTheme = @getActiveUiTheme()
     @activeSyntaxTheme = @getActiveSyntaxTheme()
     @populateThemeMenus()
+
+    if not atom.config.get(@activeUiTheme)?
+      @currentUiThemeSettings.hide()
+    else
+      @currentUiThemeSettings.show()
+
+    if not atom.config.get(@activeSyntaxTheme)?
+      @currentSyntaxThemeSettings.hide()
+    else
+      @currentSyntaxThemeSettings.show()
+
     @handleCurrentThemeButtons()
 
   handleCurrentThemeButtons: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -166,15 +166,15 @@ class ThemesPanel extends View
       @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {back: 'Themes', pack: @activeSyntaxTheme})
 
   toggleCurrentThemeButtons: ->
-    if not atom.config.get(@activeUiTheme)?
-      @currentUiThemeSettings.hide()
-    else
+    if atom.config.get(@activeUiTheme)?
       @currentUiThemeSettings.show()
-
-    if not atom.config.get(@activeSyntaxTheme)?
-      @currentSyntaxThemeSettings.hide()
     else
+      @currentUiThemeSettings.hide()
+
+    if atom.config.get(@activeSyntaxTheme)?
       @currentSyntaxThemeSettings.show()
+    else
+      @currentSyntaxThemeSettings.hide()
 
 
   # Populate the theme menus from the theme manager's active themes

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -92,6 +92,8 @@ class ThemesPanel extends View
       @populateThemeMenus()
 
     @disposables.add atom.themes.onDidChangeActiveThemes => @updateActiveThemes()
+    @disposables.add atom.tooltips.add(@currentUiThemeSettings, {title: 'Settings'})
+    @disposables.add atom.tooltips.add(@currentSyntaxThemeSettings, {title: 'Settings'})
     @updateActiveThemes()
 
     @filterEditor.getModel().onDidStopChanging => @matchPackages()
@@ -173,6 +175,7 @@ class ThemesPanel extends View
       @currentSyntaxThemeSettings.hide()
     else
       @currentSyntaxThemeSettings.show()
+
 
   # Populate the theme menus from the theme manager's active themes
   populateThemeMenus: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -154,9 +154,9 @@ class ThemesPanel extends View
     @activeSyntaxTheme = @getActiveSyntaxTheme()
     @populateThemeMenus()
     @toggleActiveThemeButtons()
-    @handleActiveThemeButtons()
+    @handleActiveThemeButtonEvents()
 
-  handleActiveThemeButtons: ->
+  handleActiveThemeButtonEvents: ->
     @activeUiThemeSettings.on 'click', (event) =>
       event.stopPropagation()
       activeUiTheme = atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0]?.metadata

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -31,16 +31,18 @@ class ThemesPanel extends View
                 @label class: 'control-label', =>
                   @div class: 'setting-title themes-label text', 'UI Theme'
                   @div class: 'setting-description text theme-description', 'This styles the tabs, status bar, tree view, and dropdowns'
-                @select outlet: 'uiMenu', class: 'form-control'
-                @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear'
+                @div class: 'select-wrapper', =>
+                  @select outlet: 'uiMenu', class: 'form-control'
+                  @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear'
 
             @div class: 'themes-picker-item control-group', =>
               @div class: 'controls', =>
                 @label class: 'control-label', =>
                   @div class: 'setting-title themes-label text', 'Syntax Theme'
                   @div class: 'setting-description text theme-description', 'This styles the text inside the editor'
-                @select outlet: 'syntaxMenu', class: 'form-control'
-                @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear'
+                @div class: 'select-wrapper', =>
+                  @select outlet: 'syntaxMenu', class: 'form-control'
+                  @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear'
 
       @section class: 'section', =>
         @div class: 'section-container', =>

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -159,17 +159,21 @@ class ThemesPanel extends View
   handleCurrentThemeButtons: ->
     @currentUiThemeSettings.on 'click', (event) =>
       event.stopPropagation()
-      @parents('.settings-view').view()?.showPanel(@activeUiTheme, {
-        back: 'Themes',
-        pack: atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0].metadata
-      })
+      activeUiTheme = atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0]?.metadata
+      if activeUiTheme?
+        @parents('.settings-view').view()?.showPanel(@activeUiTheme, {
+          back: 'Themes',
+          pack: activeUiTheme
+        })
 
     @currentSyntaxThemeSettings.on 'click', (event) =>
       event.stopPropagation()
-      @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {
-        back: 'Themes',
-        pack: atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0].metadata
-      })
+      activeSyntaxTheme = atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'syntax')[0]?.metadata
+      if activeSyntaxTheme?
+        @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {
+          back: 'Themes',
+          pack: activeSyntaxTheme
+        })
 
   toggleCurrentThemeButtons: ->
     if atom.config.get(@activeUiTheme)?
@@ -181,7 +185,6 @@ class ThemesPanel extends View
       @currentSyntaxThemeSettings.show()
     else
       @currentSyntaxThemeSettings.hide()
-
 
   # Populate the theme menus from the theme manager's active themes
   populateThemeMenus: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -31,7 +31,7 @@ class ThemesPanel extends View
                 @label class: 'control-label', =>
                   @div class: 'setting-title themes-label text', 'UI Theme'
                   @div class: 'setting-description text theme-description', 'This styles the tabs, status bar, tree view, and dropdowns'
-                @div class: 'select-wrapper', =>
+                @div class: 'select-container', =>
                   @select outlet: 'uiMenu', class: 'form-control'
                   @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear current-theme-settings'
 
@@ -40,7 +40,7 @@ class ThemesPanel extends View
                 @label class: 'control-label', =>
                   @div class: 'setting-title themes-label text', 'Syntax Theme'
                   @div class: 'setting-description text theme-description', 'This styles the text inside the editor'
-                @div class: 'select-wrapper', =>
+                @div class: 'select-container', =>
                   @select outlet: 'syntaxMenu', class: 'form-control'
                   @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear current-theme-settings'
 

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -159,11 +159,17 @@ class ThemesPanel extends View
   handleCurrentThemeButtons: ->
     @currentUiThemeSettings.on 'click', (event) =>
       event.stopPropagation()
-      @parents('.settings-view').view()?.showPanel(@activeUiTheme, {back: 'Themes', pack: @activeUiTheme})
+      @parents('.settings-view').view()?.showPanel(@activeUiTheme, {
+        back: 'Themes',
+        pack: atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0].metadata
+      })
 
     @currentSyntaxThemeSettings.on 'click', (event) =>
       event.stopPropagation()
-      @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {back: 'Themes', pack: @activeSyntaxTheme})
+      @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {
+        back: 'Themes',
+        pack: atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0].metadata
+      })
 
   toggleCurrentThemeButtons: ->
     if atom.config.get(@activeUiTheme)?

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -33,7 +33,7 @@ class ThemesPanel extends View
                   @div class: 'setting-description text theme-description', 'This styles the tabs, status bar, tree view, and dropdowns'
                 @div class: 'select-container', =>
                   @select outlet: 'uiMenu', class: 'form-control'
-                  @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear current-theme-settings'
+                  @button outlet: 'activeUiThemeSettings', class: 'btn icon icon-gear active-theme-settings'
 
             @div class: 'themes-picker-item control-group', =>
               @div class: 'controls', =>
@@ -42,7 +42,7 @@ class ThemesPanel extends View
                   @div class: 'setting-description text theme-description', 'This styles the text inside the editor'
                 @div class: 'select-container', =>
                   @select outlet: 'syntaxMenu', class: 'form-control'
-                  @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear current-theme-settings'
+                  @button outlet: 'activeSyntaxThemeSettings', class: 'btn icon icon-gear active-theme-settings'
 
       @section class: 'section', =>
         @div class: 'section-container', =>
@@ -92,8 +92,8 @@ class ThemesPanel extends View
       @populateThemeMenus()
 
     @disposables.add atom.themes.onDidChangeActiveThemes => @updateActiveThemes()
-    @disposables.add atom.tooltips.add(@currentUiThemeSettings, {title: 'Settings'})
-    @disposables.add atom.tooltips.add(@currentSyntaxThemeSettings, {title: 'Settings'})
+    @disposables.add atom.tooltips.add(@activeUiThemeSettings, {title: 'Settings'})
+    @disposables.add atom.tooltips.add(@activeSyntaxThemeSettings, {title: 'Settings'})
     @updateActiveThemes()
 
     @filterEditor.getModel().onDidStopChanging => @matchPackages()
@@ -153,11 +153,11 @@ class ThemesPanel extends View
     @activeUiTheme = @getActiveUiTheme()
     @activeSyntaxTheme = @getActiveSyntaxTheme()
     @populateThemeMenus()
-    @toggleCurrentThemeButtons()
-    @handleCurrentThemeButtons()
+    @toggleActiveThemeButtons()
+    @handleActiveThemeButtons()
 
-  handleCurrentThemeButtons: ->
-    @currentUiThemeSettings.on 'click', (event) =>
+  handleActiveThemeButtons: ->
+    @activeUiThemeSettings.on 'click', (event) =>
       event.stopPropagation()
       activeUiTheme = atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'ui')[0]?.metadata
       if activeUiTheme?
@@ -166,7 +166,7 @@ class ThemesPanel extends View
           pack: activeUiTheme
         })
 
-    @currentSyntaxThemeSettings.on 'click', (event) =>
+    @activeSyntaxThemeSettings.on 'click', (event) =>
       event.stopPropagation()
       activeSyntaxTheme = atom.themes.getActiveThemes().filter((theme) -> theme.metadata.theme is 'syntax')[0]?.metadata
       if activeSyntaxTheme?
@@ -175,16 +175,16 @@ class ThemesPanel extends View
           pack: activeSyntaxTheme
         })
 
-  toggleCurrentThemeButtons: ->
+  toggleActiveThemeButtons: ->
     if @hasSettings(@activeUiTheme)
-      @currentUiThemeSettings.show()
+      @activeUiThemeSettings.show()
     else
-      @currentUiThemeSettings.hide()
+      @activeUiThemeSettings.hide()
 
     if @hasSettings(@activeSyntaxTheme)
-      @currentSyntaxThemeSettings.show()
+      @activeSyntaxThemeSettings.show()
     else
-      @currentSyntaxThemeSettings.hide()
+      @activeSyntaxThemeSettings.hide()
 
   hasSettings: (keyPath) ->
     for key, value of atom.config.get(keyPath)

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -33,7 +33,7 @@ class ThemesPanel extends View
                   @div class: 'setting-description text theme-description', 'This styles the tabs, status bar, tree view, and dropdowns'
                 @div class: 'select-wrapper', =>
                   @select outlet: 'uiMenu', class: 'form-control'
-                  @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear'
+                  @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear current-theme-settings'
 
             @div class: 'themes-picker-item control-group', =>
               @div class: 'controls', =>
@@ -42,7 +42,7 @@ class ThemesPanel extends View
                   @div class: 'setting-description text theme-description', 'This styles the text inside the editor'
                 @div class: 'select-wrapper', =>
                   @select outlet: 'syntaxMenu', class: 'form-control'
-                  @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear'
+                  @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear current-theme-settings'
 
       @section class: 'section', =>
         @div class: 'section-container', =>

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -32,6 +32,7 @@ class ThemesPanel extends View
                   @div class: 'setting-title themes-label text', 'UI Theme'
                   @div class: 'setting-description text theme-description', 'This styles the tabs, status bar, tree view, and dropdowns'
                 @select outlet: 'uiMenu', class: 'form-control'
+                @button outlet: 'currentUiThemeSettings', class: 'btn icon icon-gear'
 
             @div class: 'themes-picker-item control-group', =>
               @div class: 'controls', =>
@@ -39,12 +40,13 @@ class ThemesPanel extends View
                   @div class: 'setting-title themes-label text', 'Syntax Theme'
                   @div class: 'setting-description text theme-description', 'This styles the text inside the editor'
                 @select outlet: 'syntaxMenu', class: 'form-control'
+                @button outlet: 'currentSyntaxThemeSettings', class: 'btn icon icon-gear'
 
       @section class: 'section', =>
         @div class: 'section-container', =>
           @div class: 'section-heading icon icon-paintcan', =>
             @text 'Installed Themes'
-            @span outlet: 'totalPackages', class:'section-heading-count badge badge-flexible', '…'
+            @span outlet: 'totalPackages', class: 'section-heading-count badge badge-flexible', '…'
           @div class: 'editor-container', =>
             @subview 'filterEditor', new TextEditorView(mini: true, placeholderText: 'Filter themes by name')
 
@@ -80,7 +82,7 @@ class ThemesPanel extends View
     @subscribe @packageManager, 'theme-install-failed theme-uninstall-failed', (pack, error) =>
       @themeErrors.append(new ErrorView(@packageManager, error))
 
-    @openUserStysheet.on 'click', =>
+    @openUserStysheet.on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open-your-stylesheet')
       false
 
@@ -147,6 +149,16 @@ class ThemesPanel extends View
     @activeUiTheme = @getActiveUiTheme()
     @activeSyntaxTheme = @getActiveSyntaxTheme()
     @populateThemeMenus()
+    @handleCurrentThemeButtons()
+
+  handleCurrentThemeButtons: ->
+    @currentUiThemeSettings.on 'click', (event) =>
+      event.stopPropagation()
+      @parents('.settings-view').view()?.showPanel(@activeUiTheme, {back: 'Themes', pack: @activeUiTheme})
+
+    @currentSyntaxThemeSettings.on 'click', (event) =>
+      event.stopPropagation()
+      @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {back: 'Themes', pack: @activeSyntaxTheme})
 
   # Populate the theme menus from the theme manager's active themes
   populateThemeMenus: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -151,17 +151,7 @@ class ThemesPanel extends View
     @activeUiTheme = @getActiveUiTheme()
     @activeSyntaxTheme = @getActiveSyntaxTheme()
     @populateThemeMenus()
-
-    if not atom.config.get(@activeUiTheme)?
-      @currentUiThemeSettings.hide()
-    else
-      @currentUiThemeSettings.show()
-
-    if not atom.config.get(@activeSyntaxTheme)?
-      @currentSyntaxThemeSettings.hide()
-    else
-      @currentSyntaxThemeSettings.show()
-
+    @toggleCurrentThemeButtons()
     @handleCurrentThemeButtons()
 
   handleCurrentThemeButtons: ->
@@ -172,6 +162,17 @@ class ThemesPanel extends View
     @currentSyntaxThemeSettings.on 'click', (event) =>
       event.stopPropagation()
       @parents('.settings-view').view()?.showPanel(@activeSyntaxTheme, {back: 'Themes', pack: @activeSyntaxTheme})
+
+  toggleCurrentThemeButtons: ->
+    if not atom.config.get(@activeUiTheme)?
+      @currentUiThemeSettings.hide()
+    else
+      @currentUiThemeSettings.show()
+
+    if not atom.config.get(@activeSyntaxTheme)?
+      @currentSyntaxThemeSettings.hide()
+    else
+      @currentSyntaxThemeSettings.show()
 
   # Populate the theme menus from the theme manager's active themes
   populateThemeMenus: ->

--- a/spec/fixtures/syntax-theme-with-config/main.coffee
+++ b/spec/fixtures/syntax-theme-with-config/main.coffee
@@ -1,0 +1,5 @@
+module.exports =
+  config:
+    setting:
+      type: 'string'
+      default: 'something'

--- a/spec/fixtures/syntax-theme-with-config/package.json
+++ b/spec/fixtures/syntax-theme-with-config/package.json
@@ -1,5 +1,6 @@
 {
   "theme": "syntax",
   "name": "syntax-theme-with-config",
-  "version": "1.0"
+  "version": "1.0.0",
+  "main": "./main"
 }

--- a/spec/fixtures/syntax-theme-with-config/package.json
+++ b/spec/fixtures/syntax-theme-with-config/package.json
@@ -1,0 +1,5 @@
+{
+  "theme": "syntax",
+  "name": "syntax-theme-with-config",
+  "version": "1.0"
+}

--- a/spec/fixtures/ui-theme-with-config/main.coffee
+++ b/spec/fixtures/ui-theme-with-config/main.coffee
@@ -1,0 +1,5 @@
+module.exports =
+  config:
+    setting:
+      type: 'string'
+      default: 'something'

--- a/spec/fixtures/ui-theme-with-config/package.json
+++ b/spec/fixtures/ui-theme-with-config/package.json
@@ -1,0 +1,5 @@
+{
+  "theme": "ui",
+  "name": "ui-theme-with-config",
+  "version": "1.0"
+}

--- a/spec/fixtures/ui-theme-with-config/package.json
+++ b/spec/fixtures/ui-theme-with-config/package.json
@@ -1,5 +1,6 @@
 {
   "theme": "ui",
   "name": "ui-theme-with-config",
-  "version": "1.0"
+  "version": "1.0.0",
+  "main": "./main"
 }

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -192,6 +192,9 @@ describe "SettingsView", ->
         settingsView.showPanel('Themes')
         panel = settingsView.find('.themes-panel').view()
 
+    afterEach ->
+      atom.themes.unwatchUserStylesheet()
+
     describe "when the UI theme's settings button is clicked", ->
       it "navigates to that theme's detail view", ->
         jasmine.attachToDOM(settingsView.element)

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -192,7 +192,7 @@ describe "SettingsView", ->
         settingsView.showPanel('Themes')
         panel = settingsView.find('.themes-panel').view()
 
-    describe "when the syntax theme's settings button is clicked", ->
+    describe "when the UI theme's settings button is clicked", ->
       it "navigates to that theme's detail view", ->
         jasmine.attachToDOM(settingsView.element)
         expect(panel.currentUiThemeSettings).toBeVisible()

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -171,3 +171,41 @@ describe "SettingsView", ->
 
         packageDetail = settingsView.find('.package-detail').view()
         expect(packageDetail.title.text()).toBe 'Settings View'
+
+  describe "when the active theme has settings", ->
+    panel = null
+
+    beforeEach ->
+      atom.packages.packageDirPaths.push(path.join(__dirname, 'fixtures'))
+      atom.packages.loadPackage('ui-theme-with-config')
+      atom.packages.loadPackage('syntax-theme-with-config')
+      atom.config.set('core.themes', ['ui-theme-with-config', 'syntax-theme-with-config'])
+
+      reloadedHandler = jasmine.createSpy('reloadedHandler')
+      atom.themes.onDidChangeActiveThemes(reloadedHandler)
+      atom.themes.activatePackages()
+
+      waitsFor "themes to be reloaded", ->
+        reloadedHandler.callCount is 1
+
+      runs ->
+        settingsView.showPanel('Themes')
+        panel = settingsView.find('.themes-panel').view()
+
+    describe "when the syntax theme's settings button is clicked", ->
+      it "navigates to that theme's detail view", ->
+        jasmine.attachToDOM(settingsView.element)
+        expect(panel.currentUiThemeSettings).toBeVisible()
+
+        panel.currentUiThemeSettings.click()
+        packageDetail = settingsView.find('.package-detail').view()
+        expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
+
+    describe "when the syntax theme's settings button is clicked", ->
+      it "navigates to that theme's detail view", ->
+        jasmine.attachToDOM(settingsView.element)
+        expect(panel.currentSyntaxThemeSettings).toBeVisible()
+
+        panel.currentSyntaxThemeSettings.click()
+        packageDetail = settingsView.find('.package-detail').view()
+        expect(packageDetail.title.text()).toBe 'Syntax Theme With Config'

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -198,17 +198,17 @@ describe "SettingsView", ->
     describe "when the UI theme's settings button is clicked", ->
       it "navigates to that theme's detail view", ->
         jasmine.attachToDOM(settingsView.element)
-        expect(panel.currentUiThemeSettings).toBeVisible()
+        expect(panel.activeUiThemeSettings).toBeVisible()
 
-        panel.currentUiThemeSettings.click()
+        panel.activeUiThemeSettings.click()
         packageDetail = settingsView.find('.package-detail').view()
         expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
 
     describe "when the syntax theme's settings button is clicked", ->
       it "navigates to that theme's detail view", ->
         jasmine.attachToDOM(settingsView.element)
-        expect(panel.currentSyntaxThemeSettings).toBeVisible()
+        expect(panel.activeSyntaxThemeSettings).toBeVisible()
 
-        panel.currentSyntaxThemeSettings.click()
+        panel.activeSyntaxThemeSettings.click()
         packageDetail = settingsView.find('.package-detail').view()
         expect(packageDetail.title.text()).toBe 'Syntax Theme With Config'

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -68,22 +68,27 @@ describe "ThemesPanel", ->
         expect(panel.uiMenu.val()).toBe 'atom-light-ui'
         expect(panel.syntaxMenu.val()).toBe 'atom-light-syntax'
 
-  fdescribe "when the active UI theme's settings button is clicked", ->
+  fdescribe "when the active UI theme has settings", ->
     beforeEach ->
       atom.packages.loadPackage('ui-theme-with-config')
       atom.packages.loadPackage('syntax-theme-with-config')
       atom.config.set('core.themes', ['ui-theme-with-config', 'syntax-theme-with-config'])
+      jasmine.attachToDOM(settingsView.element)
 
-    it "navigates to that theme's detail view", ->
-      expect(atom.config.get('core.themes')).toEqual ['ui-theme-with-config', 'syntax-theme-with-config']
-      panel.currentUiThemeSettings.click()
+    it "displays a settings button", ->
+      expect(panel.find.currentUiThemeSettings).toExist()
 
-      waitsFor ->
-        settingsView.find('.package-card:not(.hidden)').length > 0
+    describe "when the active UI theme's settings button is clicked", ->
+      it "navigates to that theme's detail view", ->
+        expect(atom.config.get('core.themes')).toEqual ['ui-theme-with-config', 'syntax-theme-with-config']
+        panel.currentUiThemeSettings.click()
 
-      runs ->
-        packageDetail = settingsView.find('.package-detail').view()
-        expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
+        waitsFor ->
+          settingsView.find('.package-card:not(.hidden)').length > 0
+
+        runs ->
+          packageDetail = settingsView.find('.package-detail').view()
+          expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
 
   xdescribe "when the themes panel is navigated to", ->
     xit "focuses the search filter", ->

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -68,28 +68,6 @@ describe "ThemesPanel", ->
         expect(panel.uiMenu.val()).toBe 'atom-light-ui'
         expect(panel.syntaxMenu.val()).toBe 'atom-light-syntax'
 
-  fdescribe "when the active UI theme has settings", ->
-    beforeEach ->
-      atom.packages.loadPackage('ui-theme-with-config')
-      atom.packages.loadPackage('syntax-theme-with-config')
-      atom.config.set('core.themes', ['ui-theme-with-config', 'syntax-theme-with-config'])
-      jasmine.attachToDOM(settingsView.element)
-
-    it "displays a settings button", ->
-      expect(panel.find.currentUiThemeSettings).toExist()
-
-    describe "when the active UI theme's settings button is clicked", ->
-      it "navigates to that theme's detail view", ->
-        expect(atom.config.get('core.themes')).toEqual ['ui-theme-with-config', 'syntax-theme-with-config']
-        panel.currentUiThemeSettings.click()
-
-        waitsFor ->
-          settingsView.find('.package-card:not(.hidden)').length > 0
-
-        runs ->
-          packageDetail = settingsView.find('.package-detail').view()
-          expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
-
   xdescribe "when the themes panel is navigated to", ->
     xit "focuses the search filter", ->
       settingsView.showPanel('Themes')

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -68,6 +68,23 @@ describe "ThemesPanel", ->
         expect(panel.uiMenu.val()).toBe 'atom-light-ui'
         expect(panel.syntaxMenu.val()).toBe 'atom-light-syntax'
 
+  fdescribe "when the active UI theme's settings button is clicked", ->
+    beforeEach ->
+      atom.packages.loadPackage('ui-theme-with-config')
+      atom.packages.loadPackage('syntax-theme-with-config')
+      atom.config.set('core.themes', ['ui-theme-with-config', 'syntax-theme-with-config'])
+
+    it "navigates to that theme's detail view", ->
+      expect(atom.config.get('core.themes')).toEqual ['ui-theme-with-config', 'syntax-theme-with-config']
+      panel.currentUiThemeSettings.click()
+
+      waitsFor ->
+        settingsView.find('.package-card:not(.hidden)').length > 0
+
+      runs ->
+        packageDetail = settingsView.find('.package-detail').view()
+        expect(packageDetail.title.text()).toBe 'Ui Theme With Config'
+
   xdescribe "when the themes panel is navigated to", ->
     xit "focuses the search filter", ->
       settingsView.showPanel('Themes')

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -91,6 +91,14 @@
     align-items: center;
   }
 
+  .btn.current-theme-settings {
+    margin-left: 2px;
+    &::before {
+      margin-right: 0;
+      text-align: left;
+    }
+  }
+
   .checkbox {
     padding-left: 2.25em;
     .setting-title {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -91,7 +91,7 @@
     align-items: stretch;
   }
 
-  .btn.current-theme-settings {
+  .btn.active-theme-settings {
     margin-left: 2px;
     &::before {
       margin-right: 0;

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -86,9 +86,9 @@
     }
   }
 
-  .select-wrapper {
+  .select-container {
     display: flex;
-    align-items: center;
+    align-items: stretch;
   }
 
   .btn.current-theme-settings {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -86,6 +86,11 @@
     }
   }
 
+  .select-wrapper {
+    display: flex;
+    align-items: center;
+  }
+
   .checkbox {
     padding-left: 2.25em;
     .setting-title {


### PR DESCRIPTION
Resolves #323

This adds a settings button for active themes if they have settings.

![screenshot 2015-04-25 14 59 07](https://cloud.githubusercontent.com/assets/823545/7334228/b7e08de8-eb5b-11e4-8167-8e032ab55331.png)

If One Dark had settings:
![screenshot 2015-04-26 13 06 10](https://cloud.githubusercontent.com/assets/823545/7338278/09c20560-ec15-11e4-9dd2-2137c7d99294.png)

TODO:
- [x] Add specs

/cc @braver @simurai @thedaniel @jlord 