### PR TITLE
Ensure package-detail contains its children

### DIFF
--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -4,6 +4,10 @@
 
 .settings-view {
 
+  .package-detail {
+    overflow-y: auto;
+  }
+
   // TODO: Somehow unify the "card".
 
   .package-card {

--- a/styles/available-package.less
+++ b/styles/available-package.less
@@ -4,10 +4,6 @@
 
 .settings-view {
 
-  .package-detail {
-    overflow-y: auto;
-  }
-
   // TODO: Somehow unify the "card".
 
   .package-card {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -403,11 +403,11 @@
     flex-flow: column;
     display: flex;
     position: relative;
-    overflow: auto;
 
     > div {
       flex: 1;
       min-width: 372px; // magic number: fit the Settings, Uninstall and Disable button
+      overflow: auto;
     }
   }
 


### PR DESCRIPTION
Came across the need to add this (the div was ending before all of its children) while investigating the _click `package-card` and go to detail view only to have your scroll bar somewhere in the middle_ issue. 

Adding this seems to take care of the scrolling issue and you now start at the top of the detail view. 

<img src="https://cloud.githubusercontent.com/assets/1305617/7423215/04f658d4-ef48-11e4-8d75-5710542b6fb3.png" width="500px">
_package-detail, before fix, ending too early_

**To Reproduce**
- Open Settings 
- Click Packages, scroll to very last package in list and click the package card
- See that you're in the middle of that package's detail/settings view.

Repeat on this branch, find that you start at the top of the detail/settings view as expected.


cc @simurai for CSS guidance—do you know why this helps and if I've used it correctly?

Closes #472