### PR TITLE
Use correct semver in fixture package.json

### DIFF
--- a/spec/fixtures/a-theme/package.json
+++ b/spec/fixtures/a-theme/package.json
@@ -1,5 +1,5 @@
 {
   "theme": "syntax",
   "name": "a-theme",
-  "version": "1.0"
+  "version": "1.0.0"
 }

--- a/spec/fixtures/language-test/package.json
+++ b/spec/fixtures/language-test/package.json
@@ -1,5 +1,5 @@
 {
   "name": "language-test",
-  "version": "1.0",
+  "version": "1.0.0",
   "repository": "https://github.com/example/language-test"
 }

--- a/spec/fixtures/package-with-config/package.json
+++ b/spec/fixtures/package-with-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-with-config",
-  "version": "1.0",
+  "version": "1.0.0",
   "repository": "https://github.com/example/package-with-config",
   "main": "main"
 }


### PR DESCRIPTION
In the near-ish future we'll be checking for correct semver in `package.json` files so we'll need these updated. 

Actually, https://github.com/atom/atom/pull/6645 will need this to pass, also :sparkles: 