### PR TITLE
Handle apm process errors

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -61,7 +61,7 @@ class AtomIoClient
         localStorage.setItem(@cacheKeyForPath(key), JSON.stringify(cached))
         # end copypasta
         callback(null, packages)
-      .catch (error) =>
+      .catch (error) ->
         callback(error, null)
 
   request: (path, callback) ->
@@ -154,7 +154,7 @@ class AtomIoClient
         if error and error.code isnt 'ENOENT' # Ignore cache paths that don't exist
           console.warn("Error deleting avatar (#{error.code}): #{avatarPath}")
 
-    fs.readdir @getCachePath(), (error, _files) =>
+    fs.readdir @getCachePath(), (error, _files) ->
       _files ?= []
       files = {}
       for filename in _files

--- a/lib/keybindings-panel.coffee
+++ b/lib/keybindings-panel.coffee
@@ -38,7 +38,7 @@ class KeybindingsPanel extends View
     @otherPlatformPattern = new RegExp("\\.platform-(?!#{_.escapeRegExp(process.platform)}\\b)")
     @platformPattern = new RegExp("\\.platform-#{_.escapeRegExp(process.platform)}\\b")
 
-    @openUserKeymap.on 'click', =>
+    @openUserKeymap.on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open-your-keymap')
       false
 

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -188,8 +188,8 @@ class PackageManager
         deferred.reject(error)
 
     apmProcess.onWillThrowError ({error, handle}) ->
-        handle()
-        deferred.reject(createProcessError(errorMessage, error))
+      handle()
+      deferred.reject(createProcessError(errorMessage, error))
 
     deferred.promise
 
@@ -319,8 +319,8 @@ class PackageManager
         deferred.reject(new Error())
 
     apmProcess.onWillThrowError ({error, handle}) ->
-        handle()
-        deferred.reject(error)
+      handle()
+      deferred.reject(error)
 
     deferred.promise
 

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -187,9 +187,8 @@ class PackageManager
         error.stderr = stderr
         deferred.reject(error)
 
-    apmProcess.onWillThrowError ({error, handle}) ->
-      handle()
-      deferred.reject(createProcessError(errorMessage, error))
+    handleProcessErrors apmProcess, errorMessage, (error) ->
+      deferred.reject(error)
 
     deferred.promise
 

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -312,7 +312,7 @@ class PackageManager
   checkNativeBuildTools: ->
     deferred = Q.defer()
 
-    apmProcess = @runCommand ['install', '--check'], (code, stdout, stderr) =>
+    apmProcess = @runCommand ['install', '--check'], (code, stdout, stderr) ->
       if code is 0
         deferred.resolve()
       else

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -347,5 +347,5 @@ createProcessError = (message, processError) ->
 
 handleProcessErrors = (apmProcess, message, callback) ->
   apmProcess.onWillThrowError ({error, handle}) ->
-      handle()
-      callback(createProcessError(message, error))
+    handle()
+    callback(createProcessError(message, error))

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -239,6 +239,7 @@ class PackageManager
     @unload(name)
     args = ['install', "#{name}@#{version}"]
 
+    errorMessage = "Installing \u201C#{name}@#{version}\u201D failed."
     onError = (error) =>
       error.packageInstallError = not theme
       @emitPackageEvent 'install-failed', pack, error
@@ -255,13 +256,13 @@ class PackageManager
         @emitPackageEvent 'installed', pack
       else
         atom.packages.activatePackage(name) if activateOnFailure
-        error = new Error("Installing \u201C#{name}@#{version}\u201D failed.")
+        error = new Error(errorMessage)
         error.stdout = stdout
         error.stderr = stderr
         onError(error)
 
     apmProcess = @runCommand(args, exit)
-    handleProcessErrors(apmProcess, "Installing \u201C#{name}@#{version}\u201D failed.", onError)
+    handleProcessErrors(apmProcess, errorMessage, onError)
 
   uninstall: (pack, callback) ->
     {name} = pack

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -171,7 +171,6 @@ class PackageManager
       args.push '--themes'
     else if options.packages
       args.push '--packages'
-
     errorMessage = "Searching for \u201C#{query}\u201D failed."
 
     apmProcess = @runCommand args, (code, stdout, stderr) ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -80,7 +80,7 @@ class ThemesPanel extends View
     @subscribe @packageManager, 'theme-install-failed theme-uninstall-failed', (pack, error) =>
       @themeErrors.append(new ErrorView(@packageManager, error))
 
-    @openUserStysheet.on 'click', =>
+    @openUserStysheet.on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open-your-stylesheet')
       false
 

--- a/spec/keybindings-panel-spec.coffee
+++ b/spec/keybindings-panel-spec.coffee
@@ -5,7 +5,7 @@ describe "KeybindingsPanel", ->
   [keyBindings, panel] = []
 
   beforeEach ->
-    expect(atom.keymap).toBeDefined()
+    expect(atom.keymaps).toBeDefined()
     keyBindings = [
       {
         source: "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
@@ -26,7 +26,7 @@ describe "KeybindingsPanel", ->
         selector: ".platform-a, .platform-b"
       }
     ]
-    spyOn(atom.keymap, 'getKeyBindings').andReturn(keyBindings)
+    spyOn(atom.keymaps, 'getKeyBindings').andReturn(keyBindings)
     panel = new KeybindingsPanel
 
   it "loads and displays core key bindings", ->
@@ -41,7 +41,7 @@ describe "KeybindingsPanel", ->
   describe "when a keybinding is copied", ->
     describe "when the keybinding file ends in .cson", ->
       it "writes a CSON snippet to the clipboard", ->
-        spyOn(atom.keymap, 'getUserKeymapPath').andReturn 'keymap.cson'
+        spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.cson'
         panel.find('.copy-icon').click()
         expect(atom.clipboard.read()).toBe """
           '.editor, .platform-test':
@@ -50,7 +50,7 @@ describe "KeybindingsPanel", ->
 
     describe "when the keybinding file ends in .json", ->
       it "writes a JSON snippet to the clipboard", ->
-        spyOn(atom.keymap, 'getUserKeymapPath').andReturn 'keymap.json'
+        spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.json'
         panel.find('.copy-icon').click()
         expect(atom.clipboard.read()).toBe """
           ".editor, .platform-test": {

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -9,9 +9,11 @@ describe "package manager", ->
     waitsForPromise shouldReject: true, -> packageManager.getInstalled()
     waitsForPromise shouldReject: true, -> packageManager.getOutdated()
     waitsForPromise shouldReject: true, -> packageManager.getFeatured()
+    waitsForPromise shouldReject: true, -> packageManager.getPackage('foo')
 
     installCallback = jasmine.createSpy('installCallback')
     uninstallCallback = jasmine.createSpy('uninstallCallback')
+    updateCallback = jasmine.createSpy('updateCallback')
 
     runs ->
       packageManager.install {name: 'foo', version: '1.0.0'}, installCallback
@@ -23,7 +25,6 @@ describe "package manager", ->
       expect(installCallback.argsForCall[0][0].message).toBe "Installing \u201Cfoo@1.0.0\u201D failed."
       expect(installCallback.argsForCall[0][0].packageInstallError).toBe true
 
-    runs ->
       packageManager.uninstall {name: 'foo'}, uninstallCallback
 
     waitsFor ->
@@ -31,3 +32,12 @@ describe "package manager", ->
 
     runs ->
       expect(uninstallCallback.argsForCall[0][0].message).toBe "Uninstalling \u201Cfoo\u201D failed."
+
+      packageManager.update {name: 'foo'}, '1.0.0', updateCallback
+
+    waitsFor ->
+      updateCallback.callCount is 1
+
+    runs ->
+      expect(updateCallback.argsForCall[0][0].message).toBe "Updating to \u201Cfoo@1.0.0\u201D failed."
+      expect(updateCallback.argsForCall[0][0].packageInstallError).toBe true

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1,0 +1,33 @@
+PackageManager = require '../lib/package-manager'
+
+describe "package manager", ->
+  it "handle errors spawning apm", ->
+    spyOn(atom.packages, 'getApmPath').andReturn('/an/invalid/apm/command/to/run')
+    packageManager = new PackageManager()
+
+    waitsForPromise shouldReject: true, -> packageManager.search('test')
+    waitsForPromise shouldReject: true, -> packageManager.getInstalled()
+    waitsForPromise shouldReject: true, -> packageManager.getOutdated()
+    waitsForPromise shouldReject: true, -> packageManager.getFeatured()
+
+    installCallback = jasmine.createSpy('installCallback')
+    uninstallCallback = jasmine.createSpy('uninstallCallback')
+
+    runs ->
+      packageManager.install {name: 'foo', version: '1.0.0'}, installCallback
+
+    waitsFor ->
+      installCallback.callCount is 1
+
+    runs ->
+      expect(installCallback.argsForCall[0][0].message).toBe "Installing \u201Cfoo@1.0.0\u201D failed."
+      expect(installCallback.argsForCall[0][0].packageInstallError).toBe true
+
+    runs ->
+      packageManager.uninstall {name: 'foo'}, uninstallCallback
+
+    waitsFor ->
+      uninstallCallback.callCount is 1
+
+    runs ->
+      expect(uninstallCallback.argsForCall[0][0].message).toBe "Uninstalling \u201Cfoo\u201D failed."

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -24,6 +24,7 @@ describe "package manager", ->
     runs ->
       expect(installCallback.argsForCall[0][0].message).toBe "Installing \u201Cfoo@1.0.0\u201D failed."
       expect(installCallback.argsForCall[0][0].packageInstallError).toBe true
+      expect(installCallback.argsForCall[0][0].stderr).toContain 'ENOENT'
 
       packageManager.uninstall {name: 'foo'}, uninstallCallback
 
@@ -32,6 +33,7 @@ describe "package manager", ->
 
     runs ->
       expect(uninstallCallback.argsForCall[0][0].message).toBe "Uninstalling \u201Cfoo\u201D failed."
+      expect(uninstallCallback.argsForCall[0][0].stderr).toContain 'ENOENT'
 
       packageManager.update {name: 'foo'}, '1.0.0', updateCallback
 
@@ -41,3 +43,4 @@ describe "package manager", ->
     runs ->
       expect(updateCallback.argsForCall[0][0].message).toBe "Updating to \u201Cfoo@1.0.0\u201D failed."
       expect(updateCallback.argsForCall[0][0].packageInstallError).toBe true
+      expect(updateCallback.argsForCall[0][0].stderr).toContain 'ENOENT'


### PR DESCRIPTION
This adds a `BufferedProcess::onWillThrowError` handler for each spawned `apm` command to handle any process errors instead of showing them as an uncaught notification.

Closes #491