### PR TITLE
Prevent repo link being full width

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -450,6 +450,10 @@
       padding-right: @component-padding;
     }
 
+    .link {
+      width: -webkit-fit-content; // prevents hover area being full-width
+    }
+
     .link,
     .text {
       margin: 0 15px @component-padding 15px;


### PR DESCRIPTION
Before:

![minimap-before](https://cloud.githubusercontent.com/assets/378023/7548629/855f32d8-f64c-11e4-84eb-21e7ba3b434a.gif)


After:

![minimap-after](https://cloud.githubusercontent.com/assets/378023/7548635/901c3c98-f64c-11e4-8fc7-96c85c2657be.gif)
