### PR TITLE
Upgrade Bootstrap

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -101,6 +101,10 @@
 
   .checkbox {
     padding-left: 2.25em;
+    label {
+      padding-left: 0;
+      display: block;
+    }
     .setting-title {
       display: inline-block;
     }
@@ -110,7 +114,8 @@
     display: inline-block;
     position: relative;
     font-size: inherit;
-    margin: 0 0 0 -2.25em;
+    margin: 0 .75em 0 -2.25em;
+    vertical-align: top;
     width: 1.5em;
     height: 1.5em;
     cursor: pointer;


### PR DESCRIPTION
Fixes checkbox position. Depends on https://github.com/atom/atom/pull/6848

Tested on several themes. All seem good except in Isotope the `.setting-description` is mis-aligned.