### PR TITLE
Handle Git Repository URLs

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -149,6 +149,9 @@ class PackageCard extends View
       repo = repository
     else
       repo = repository.url
+      if repo.match 'git@github'
+        repoName = repo.split(':')[1]
+        repo = "https://github.com/#{repoName}"
     repo.match(loginRegex)?[1] ? ''
 
   loadCachedMetadata: ->

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -306,6 +306,9 @@ class PackageManager
   getRepositoryUrl: ({metadata}) ->
     {repository} = metadata
     repoUrl = repository?.url ? repository ? ''
+    if repoUrl.match 'git@github'
+      repoName = repoUrl.split(':')[1]
+      repoUrl = "https://github.com/#{repoName}"
     repoUrl.replace(/\.git$/, '').replace(/\/+$/, '')
 
   checkNativeBuildTools: ->


### PR DESCRIPTION
This handles Git urls (i.e., `git@github.com:atom/settings-view`) used in the `repository` field for packages. 

Fixes https://github.com/atom/settings-view/issues/505

Links work in `package-detail-view` so I think these two spots should cover it. Before the avatar and repo link were broken. 

![screen shot 2015-05-20 at 12 08 43 pm](https://cloud.githubusercontent.com/assets/1305617/7734998/1e4eaae6-feef-11e4-8784-277a6e260ab9.png)


It may be a bit verbose and handling the one off case like this may not be ideal to here if there are like 4 other types of urls that may also come through. Thoughts?

cc @kevinsawicki @thedaniel 

