### PR TITLE
Fix avatarGlob to not pick up cached avatars with prefix collisions

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -128,7 +128,7 @@ class AtomIoClient
       callback(null, null)
 
   avatarGlob: (login) ->
-    path.join @getCachePath(), "#{login}-*"
+    path.join @getCachePath(), "#{login}-*([0-9])"
 
   fetchAndCacheAvatar: (login, callback) ->
     if @online()


### PR DESCRIPTION
This fixes #482.

The glob pattern of `#{login}-*` was erroneously picking up cache files named (for example) `atom-minimap-1234567890` when looking for a file matching `atom-{TIMESTAMP}` (or anyone whose login happened to start with `atom-`).

Changing it to only match trailing digits means the wildcard will only match the timestamp, not timestamp plus any other chars if `#{login}-` happens to be a prefix of somebody else's username.