### PR TITLE
Replace emissary with event-kit

### DIFF
--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 {$, $$, TextEditorView, View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
+{CompositeDisposable} = require 'atom'
 
 PackageCard = require './package-card'
 Client = require './atom-io-client'
@@ -14,7 +14,6 @@ PackageNameRegex = /config\/install\/(package|theme):([a-z0-9-_]+)/i
 
 module.exports =
 class InstallPanel extends View
-  Subscriber.includeInto(this)
 
   @content: ->
     @div =>
@@ -47,6 +46,7 @@ class InstallPanel extends View
           @div outlet: 'featuredContainer', class: 'container package-container'
 
   initialize: (@packageManager) ->
+    @disposables = new CompositeDisposable()
     client = $('.settings-view').view()?.client
     @client = @packageManager.getClient()
     @atomIoURL = 'https://atom.io/packages'
@@ -63,17 +63,16 @@ class InstallPanel extends View
     @loadFeaturedPackages()
 
   detached: ->
-    @packageManagerSubscription.dispose()
-    @unsubscribe()
+    @disposables.dispose()
 
   focus: ->
     @searchEditorView.focus()
 
   handleSearchEvents: ->
-    @packageManagerSubscription = @packageManager.on 'package-install-failed', (pack, error) =>
+    @disposables.add @packageManager.on 'package-install-failed', (pack, error) =>
       @searchErrors.append(new ErrorView(@packageManager, error))
 
-    @subscribe atom.commands.add @searchEditorView.element, 'core:confirm', =>
+    @disposables.add atom.commands.add @searchEditorView.element, 'core:confirm', =>
       @performSearch()
 
     @searchPackagesButton.on 'click', =>

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -63,13 +63,14 @@ class InstallPanel extends View
     @loadFeaturedPackages()
 
   detached: ->
+    @packageManagerSubscription.dispose()
     @unsubscribe()
 
   focus: ->
     @searchEditorView.focus()
 
   handleSearchEvents: ->
-    @subscribe @packageManager, 'package-install-failed', (pack, error) =>
+    @packageManagerSubscription = @packageManager.on 'package-install-failed', (pack, error) =>
       @searchErrors.append(new ErrorView(@packageManager, error))
 
     @subscribe atom.commands.add @searchEditorView.element, 'core:confirm', =>

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -1,13 +1,11 @@
 _ = require 'underscore-plus'
 {View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 shell = require 'shell'
 marked = null
 {ownerFromRepository} = require './utils'
 
 module.exports =
 class PackageCard extends View
-  Subscriber.includeInto(this)
 
   @content: ({name, description, version, repository}) ->
     # stars, downloads
@@ -168,7 +166,7 @@ class PackageCard extends View
       false
 
   detached: ->
-    @unsubscribe()
+    @packageManagerSubscription.dispose()
 
   loadCachedMetadata: ->
     @client.avatar ownerFromRepository(@pack.repository), (err, avatarPath) =>
@@ -384,7 +382,7 @@ class PackageCard extends View
     false
 
   subscribeToPackageEvent: (event, callback) ->
-    @subscribe @packageManager, event, (pack, error) =>
+    @packageManagerSubscription = @packageManager.on event, (pack, error) =>
       packageName = pack.name
       packageName = pack.pack.name if pack.pack?
       callback(pack, error) if packageName is @pack.name

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {View} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
 shell = require 'shell'
 marked = null
 {ownerFromRepository} = require './utils'
@@ -52,6 +53,8 @@ class PackageCard extends View
               @button type: 'button', class: 'btn status-indicator', tabindex: -1, outlet: 'statusIndicator'
 
   initialize: (@pack, @packageManager, options) ->
+    @disposables = new CompositeDisposable()
+
     # It might be useful to either wrap @pack in a class that has a ::validate
     # method, or add a method here. At the moment I think all cases of malformed
     # package metadata are handled here and in ::content but belt and suspenders,
@@ -166,7 +169,7 @@ class PackageCard extends View
       false
 
   detached: ->
-    @packageManagerSubscription.dispose()
+    @disposables.dispose()
 
   loadCachedMetadata: ->
     @client.avatar ownerFromRepository(@pack.repository), (err, avatarPath) =>
@@ -318,13 +321,13 @@ class PackageCard extends View
         'This package has deprecations and is not installable.'
 
   handlePackageEvents: ->
-    atom.packages.onDidDeactivatePackage (pack) =>
+    @disposables.add atom.packages.onDidDeactivatePackage (pack) =>
       @updateDisabledState() if pack.name is @pack.name
 
-    atom.packages.onDidActivatePackage (pack) =>
+    @disposables.add atom.packages.onDidActivatePackage (pack) =>
       @updateDisabledState() if pack.name is @pack.name
 
-    atom.config.onDidChange 'core.disabledPackages', =>
+    @disposables.add atom.config.onDidChange 'core.disabledPackages', =>
       @updateDisabledState()
 
     @subscribeToPackageEvent 'package-installing', (pack) =>
@@ -382,7 +385,7 @@ class PackageCard extends View
     false
 
   subscribeToPackageEvent: (event, callback) ->
-    @packageManagerSubscription = @packageManager.on event, (pack, error) =>
+    @disposables.add @packageManager.on event, (pack, error) =>
       packageName = pack.name
       packageName = pack.pack.name if pack.pack?
       callback(pack, error) if packageName is @pack.name

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -5,7 +5,6 @@ _ = require 'underscore-plus'
 fs = require 'fs-plus'
 shell = require 'shell'
 {View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 
 ErrorView = require './error-view'
 PackageCard = require './package-card'
@@ -17,7 +16,6 @@ SettingsPanel = require './settings-panel'
 
 module.exports =
 class PackageDetailView extends View
-  Subscriber.includeInto(this)
 
   @content: (pack, packageManager) ->
     @div class: 'package-detail', =>
@@ -71,7 +69,7 @@ class PackageDetailView extends View
       @pack.activateConfig()
 
   detached: ->
-    @unsubscribe()
+    # @unsubscribe()
 
   beforeShow: (opts) ->
     if opts?.back
@@ -120,16 +118,16 @@ class PackageDetailView extends View
     @sections.append(new PackageReadmeView(readme))
 
   subscribeToPackageManager: ->
-    @subscribe @packageManager, 'theme-installed package-installed', (pack) =>
+    @packageManager.on 'theme-installed package-installed', (pack) =>
       return unless @pack.name is pack.name
 
       @loadPackage()
       @updateInstalledState()
 
-    @subscribe @packageManager, 'theme-uninstalled package-uninstalled', (pack) =>
+    @packageManager.on 'theme-uninstalled package-uninstalled', (pack) =>
       @updateInstalledState() if @pack.name is pack.name
 
-    @subscribe @packageManager, 'theme-updated package-updated', (pack) =>
+    @packageManager.on 'theme-updated package-updated', (pack) =>
       return unless @pack.name is pack.name
 
       @loadPackage()

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -5,6 +5,7 @@ _ = require 'underscore-plus'
 fs = require 'fs-plus'
 shell = require 'shell'
 {View} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
 
 ErrorView = require './error-view'
 PackageCard = require './package-card'
@@ -51,6 +52,7 @@ class PackageDetailView extends View
       @div outlet: 'sections'
 
   initialize: (@pack, @packageManager) ->
+    @disposables = new CompositeDisposable()
     @loadPackage()
     @activate()
     @populate()
@@ -69,7 +71,7 @@ class PackageDetailView extends View
       @pack.activateConfig()
 
   detached: ->
-    # @unsubscribe()
+    @disposables.dispose()
 
   beforeShow: (opts) ->
     if opts?.back
@@ -118,16 +120,16 @@ class PackageDetailView extends View
     @sections.append(new PackageReadmeView(readme))
 
   subscribeToPackageManager: ->
-    @packageManager.on 'theme-installed package-installed', (pack) =>
+    @disposables.add @packageManager.on 'theme-installed package-installed', (pack) =>
       return unless @pack.name is pack.name
 
       @loadPackage()
       @updateInstalledState()
 
-    @packageManager.on 'theme-uninstalled package-uninstalled', (pack) =>
+    @disposables.add @packageManager.on 'theme-uninstalled package-uninstalled', (pack) =>
       @updateInstalledState() if @pack.name is pack.name
 
-    @packageManager.on 'theme-updated package-updated', (pack) =>
+    @disposables.add @packageManager.on 'theme-updated package-updated', (pack) =>
       return unless @pack.name is pack.name
 
       @loadPackage()

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -1,6 +1,5 @@
 _ = require 'underscore-plus'
-{BufferedProcess, CompositeDisposable} = require 'atom'
-{Emitter} = require 'event-kit'
+{BufferedProcess, CompositeDisposable, Emitter} = require 'atom'
 Q = require 'q'
 semver = require 'semver'
 

--- a/lib/package-snippets-view.coffee
+++ b/lib/package-snippets-view.coffee
@@ -1,12 +1,10 @@
 path = require 'path'
 _ = require 'underscore-plus'
 {$$$, View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 
 # View to display the snippets that a package has registered.
 module.exports =
 class PackageSnippetsView extends View
-  Subscriber.includeInto(this)
 
   @content: ->
     @section class: 'section', =>
@@ -23,9 +21,6 @@ class PackageSnippetsView extends View
     @packagePath = path.join(packagePath, path.sep)
     @hide()
     @addSnippets()
-
-  detached: ->
-    @unsubscribe()
 
   getSnippetProperties: ->
     packageProperties = {}

--- a/lib/package-update-view.coffee
+++ b/lib/package-update-view.coffee
@@ -1,10 +1,8 @@
 _ = require 'underscore-plus'
 {View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 
 module.exports =
 class PackageUpdateView extends View
-  Subscriber.includeInto(this)
 
   @content: ({name, description}) ->
     @div class: 'col-md-6 package-update-view', =>
@@ -36,7 +34,7 @@ class PackageUpdateView extends View
 
   detached: ->
     @statusTooltip?.dispose()
-    @unsubscribe()
+    @packageManagerSubscription.dispose()
 
   handlePackageEvents: ->
     @subscribeToPackageEvent 'package-updated theme-updated package-update-failed theme-update-failed', (pack, error) =>
@@ -71,7 +69,7 @@ class PackageUpdateView extends View
     @uninstallButton.prop('disabled', not enabled)
 
   subscribeToPackageEvent: (event, callback) ->
-    @subscribe @packageManager, event, (pack, error) =>
+    @packageManagerSubscription = @packageManager.on event, (pack, error) =>
       callback(pack, error) if pack.name is @pack.name
 
   uninstall: ->

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -2,7 +2,6 @@ path = require 'path'
 _ = require 'underscore-plus'
 {$, $$, ScrollView, TextEditorView} = require 'atom-space-pen-views'
 {Disposable} = require 'atom'
-{Subscriber} = require 'emissary'
 async = require 'async'
 CSON = require 'season'
 fuzzaldrin = require 'fuzzaldrin'
@@ -19,7 +18,6 @@ UpdatesPanel = require './updates-panel'
 
 module.exports =
 class SettingsView extends ScrollView
-  Subscriber.includeInto(this)
 
   @content: ->
     @div class: 'settings-view pane-item', tabindex: -1, =>
@@ -36,9 +34,6 @@ class SettingsView extends ScrollView
 
     @deferredPanel = {name: activePanelName}
     process.nextTick => @initializePanels()
-
-  detached: ->
-    @unsubscribe()
 
   #TODO Remove both of these post 1.0
   onDidChangeTitle: -> new Disposable()

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -5,7 +5,6 @@ fuzzaldrin = require 'fuzzaldrin'
 _ = require 'underscore-plus'
 {CompositeDisposable} = require 'atom'
 {$$, TextEditorView, View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 
 PackageCard = require './package-card'
 ErrorView = require './error-view'
@@ -13,7 +12,6 @@ PackageManager = require './package-manager'
 
 module.exports =
 class ThemesPanel extends View
-  Subscriber.includeInto(this)
 
   @content: ->
     @div =>
@@ -81,14 +79,14 @@ class ThemesPanel extends View
     @packageViews = []
     @loadPackages()
 
-    @subscribe @packageManager, 'theme-install-failed theme-uninstall-failed', (pack, error) =>
+    @disposables.add @packageManager.on 'theme-install-failed theme-uninstall-failed', (pack, error) =>
       @themeErrors.append(new ErrorView(@packageManager, error))
 
     @openUserStysheet.on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open-your-stylesheet')
       false
 
-    @subscribe @packageManager, 'theme-installed theme-uninstalled', =>
+    @disposables.add @packageManager.on 'theme-installed theme-uninstalled', =>
       @populateThemeMenus()
 
     @disposables.add atom.themes.onDidChangeActiveThemes => @updateActiveThemes()
@@ -110,7 +108,6 @@ class ThemesPanel extends View
     @filterEditor.focus()
 
   detached: ->
-    @unsubscribe()
     @disposables.dispose()
 
   filterThemes: (packages) ->

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -1,11 +1,9 @@
 {$, $$, View} = require 'atom-space-pen-views'
-{Subscriber} = require 'emissary'
 ErrorView = require './error-view'
 PackageUpdateView = require './package-update-view'
 
 module.exports =
 class UpdatesPanel extends View
-  Subscriber.includeInto(this)
 
   @content: ->
     @div =>
@@ -30,11 +28,11 @@ class UpdatesPanel extends View
 
     @checkForUpdates()
 
-    @subscribe @packageManager, 'package-update-failed theme-update-failed', (pack, error) =>
+    @packageManagerSubscription = @packageManager.on 'package-update-failed theme-update-failed', (pack, error) =>
       @updateErrors.append(new ErrorView(@packageManager, error))
 
   detached: ->
-    @unsubscribe()
+    @packageManagerSubscription.dispose()
 
   beforeShow: (opts) ->
     if opts?.back

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom-space-pen-views": "^2.0.2",
     "cheerio": "0.15.0",
     "emissary": "1.x",
+    "event-kit": "1.2.0",
     "fs-plus": "^2.4",
     "fuzzaldrin": "^2.1",
     "glob": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "async": "~0.2.9",
     "atom-space-pen-views": "^2.0.2",
     "cheerio": "0.15.0",
-    "emissary": "1.x",
     "event-kit": "1.2.0",
     "fs-plus": "^2.4",
     "fuzzaldrin": "^2.1",


### PR DESCRIPTION
Replaces the deprecated `emissary` lib with `event-kit`.

The first one is still a dependency as it's needed in `install-panel.coffee` for [subscribing to a third-party](https://github.com/mgarciaisaia/settings-view/blob/537-event-kit/lib/install-panel.coffee#L76-L77) - or isn't it?

Fixes #537