### PR TITLE
Settings button works on Available Updates

### DIFF
--- a/lib/package-update-view.coffee
+++ b/lib/package-update-view.coffee
@@ -25,14 +25,20 @@ class PackageUpdateView extends View
 
     @handlePackageEvents()
 
-    @upgradeButton.on 'click', =>
+    @on 'click', =>
+      @parents('.settings-view').view()?.showPanel(@pack.name, {back: 'Updates', pack: @pack})
+
+    @upgradeButton.on 'click', (event) =>
+      event.stopPropagation()
       @upgrade()
 
-    @uninstallButton.on 'click', =>
+    @uninstallButton.on 'click', (event) =>
+      event.stopPropagation()
       @uninstall()
 
     @settingsButton.on 'click', =>
-      @parents('.settings-view').view()?.showPanel(@pack.name, {back: 'Available Updates'})
+      event.stopPropagation()
+      @parents('.settings-view').view()?.showPanel(@pack.name, {back: 'Updates', pack: @pack})
 
   detached: ->
     @statusTooltip?.dispose()

--- a/styles/package-update.less
+++ b/styles/package-update.less
@@ -22,6 +22,7 @@
       border-radius: @component-border-radius*2;
       border: 1px solid @base-border-color;
       background-color: lighten(@tool-panel-background-color, 8%);
+      cursor: pointer;
 
       .caption {
         width: 100%;


### PR DESCRIPTION
Both the Settings button and the panel itself can be clicked to access the package detail panel.

Fixes #499