### PR TITLE
Remove text related to deprecated APIs being removed in V1.0.

### DIFF
--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -15,11 +15,6 @@ class UpdatesPanel extends View
             @button outlet: 'updateAllButton', class: 'pull-right update-all-button btn btn-primary', 'Update All'
             @button outlet: 'checkButton', class: 'pull-right update-all-button btn btn', 'Check for Updates'
 
-          @div class: 'text native-key-bindings', tabindex: -1, =>
-            @span class: 'icon icon-question'
-            @span 'Deprecated APIs will be removed when Atom 1.0 is released in June. Please update your packages. '
-            @a class: 'link', outlet: 'openBlogPost', 'Learn more\u2026'
-
           @div outlet: 'updateErrors'
           @div outlet: 'checkingMessage', class: 'alert alert-info featured-message icon icon-hourglass', 'Checking for updates\u2026'
           @div outlet: 'noUpdatesMessage', class: 'alert alert-info featured-message icon icon-heart', 'All of your installed packages are up to date!'


### PR DESCRIPTION
Now that Atom is at V1.0 we no longer need to show a warning message regarding deprecated APIs being removed in the V1.0 release.

![screen shot 2015-06-25 at 10 00 40 am](https://cloud.githubusercontent.com/assets/260614/8361084/d5baf188-1b25-11e5-8d41-5b75d586282d.png)

