### PR TITLE
Hide packages that start with a dot

### DIFF
--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -91,7 +91,7 @@ class InstalledPackagesPanel extends View
 
   filterPackages: (packages) ->
     packages.dev = packages.dev.filter ({theme}) -> not theme
-    packages.user = packages.user.filter ({theme}) -> not theme
+    packages.user = packages.user.filter ({theme, name}) -> not (theme or name.match(/^\./))
     packages.deprecated = packages.user.filter ({name, version}) -> atom.packages.isDeprecatedPackage(name, version)
     packages.core = packages.core.filter ({theme}) -> not theme
 

--- a/spec/fixtures/installed.json
+++ b/spec/fixtures/installed.json
@@ -11,6 +11,9 @@
   ],
   "user": [
     {
+      "name": ".bin"
+    },
+    {
       "name": "user-theme",
       "theme": "syntax"
     },


### PR DESCRIPTION
Refs #348 
It would probably be a better solution to not put .bin folder in the package folder to begin with, but as a temporary solution it should be hidden from the list at least.

Also, I haven't added any new specs, because it already takes the filters into account. I've added a package with name ".bin" to the fixtures and the tests are being passed properly. The spec "InstalledPackagesPanel shows packages" is hard-coded to expect only a single community package to be displayed, so it already checks that the package with name ".bin" is filtered out.