### PR TITLE
Allow uninstalling of disabled packages

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -18,7 +18,7 @@ class PackageManager
     @client ?= new Client(this)
 
   isPackageInstalled: (packageName) ->
-    if atom.packages.isPackageLoaded(packageName) or atom.packages.isPackageDisabled(packageName)
+    if atom.packages.isPackageLoaded(packageName)
       true
     else if packageNames = @getAvailablePackageNames()
       packageNames.indexOf(packageName) > -1

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -268,6 +268,7 @@ class PackageManager
         else
           atom.packages.loadPackage(name)
 
+        @addPackageToAvailablePackageNames(name)
         callback?()
         @emitPackageEvent 'installed', pack
       else
@@ -295,6 +296,7 @@ class PackageManager
     apmProcess = @runCommand ['uninstall', '--hard', name], (code, stdout, stderr) =>
       if code is 0
         @unload(name)
+        @removePackageFromAvailablePackageNames(name)
         callback?()
         @emitPackageEvent 'uninstalled', pack
       else
@@ -363,8 +365,20 @@ class PackageManager
   cacheAvailablePackageNames: (packages) ->
     @availablePackageCache = []
     for packageType in ['core', 'user', 'dev']
+      continue unless packages[packageType]?
       packageNames = (pack.name for pack in packages[packageType])
       @availablePackageCache.push(packageNames...)
+    @availablePackageCache
+
+  addPackageToAvailablePackageNames: (packageName) ->
+    @availablePackageCache ?= []
+    @availablePackageCache.push(packageName) if @availablePackageCache.indexOf(packageName) < 0
+    @availablePackageCache
+
+  removePackageFromAvailablePackageNames: (packageName) ->
+    @availablePackageCache ?= []
+    index = @availablePackageCache.indexOf(packageName)
+    @availablePackageCache.splice(index, 1) if index > -1
     @availablePackageCache
 
   getAvailablePackageNames: ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -59,7 +59,7 @@ describe "package manager", ->
 
     it "returns true when a package is disabled", ->
       spyOn(atom.packages, 'isPackageDisabled').andReturn true
-      expect(packageManager.isPackageInstalled('some-package')).toBe true
+      expect(packageManager.isPackageInstalled('some-package')).toBe false
 
     it "returns true when a package is in the availablePackageCache", ->
       spyOn(packageManager, 'getAvailablePackageNames').andReturn ['some-package']

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -84,6 +84,32 @@ describe "package manager", ->
       expect(packageManager.runCommand).toHaveBeenCalled()
       expect(runArgs).toEqual ['install', 'something@0.2.3']
 
+    it "installs the package and adds the package to the available package names", ->
+      packageManager.cacheAvailablePackageNames(user: [{name: 'a-package'}])
+      packageManager.install {name: 'something', version: '0.2.3'}, ->
+
+      expect(packageManager.getAvailablePackageNames()).not.toContain('something')
+      runCallback(0, '', '')
+      expect(packageManager.getAvailablePackageNames()).toContain('something')
+
+  describe "::uninstall()", ->
+    [runArgs, runCallback] = []
+
+    beforeEach ->
+      spyOn(packageManager, 'unload')
+      spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
+        runArgs = args
+        runCallback = callback
+        onWillThrowError: ->
+
+    it "uninstalls the package and removes the package from the available package names", ->
+      packageManager.cacheAvailablePackageNames(user: [{name: 'something'}])
+      packageManager.uninstall {name: 'something'}, ->
+
+      expect(packageManager.getAvailablePackageNames()).toContain('something')
+      runCallback(0, '', '')
+      expect(packageManager.getAvailablePackageNames()).not.toContain('something')
+
   describe "::installAlternative", ->
     beforeEach ->
       spyOn(atom.packages, 'activatePackage')


### PR DESCRIPTION
Previous to this PR, _all_ disabled packages are assumed installed. https://github.com/atom/settings-view/issues/504 makes this worse by not removing disabled packages from the `disabledPackages` list. So basically, no package that has been disabled and uninstalled can be installed from the UI. :/

![not-installed](https://cloud.githubusercontent.com/assets/69169/8535908/22279382-23ff-11e5-8bd9-1f2cf1ce3f73.jpg)

In package manager, I'm maintaining a `availablePackageCache` list. This is updated whenever a package is installed, uninstalled, or the package listing is requested from apm.