### PR TITLE
Remove redundant updates container on the package detail view

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -30,10 +30,6 @@ class PackageDetailView extends View
 
       @section class: 'section', =>
         @form class: 'section-container package-detail-view', =>
-          @div outlet: 'updateArea', class: 'alert alert-success package-update', =>
-            @span outlet: 'updateLabel', class: 'icon icon-squirrel update-message'
-            @span outlet: 'updateLink', class: 'alert-link update-link icon icon-cloud-download', 'Install'
-
           @div class: 'container package-container', =>
             @div class: 'row', =>
               @subview 'packageCard', new PackageCard(pack.metadata, packageManager, onSettingsView: true)
@@ -143,7 +139,6 @@ class PackageDetailView extends View
 
       @loadPackage()
       @updateFileButtons()
-      @updateArea.hide()
       @populate()
 
   handleButtonEvents: ->
@@ -201,30 +196,21 @@ class PackageDetailView extends View
     loadTime + activateTime
 
   installUpdate: ->
-    return if @updateLink.prop('disabled')
     return unless @availableVersion
 
-    @updateLink.prop('disabled', true)
-    @updateLink.text('Installing\u2026')
 
     @packageManager.update @pack, @availableVersion, (error) =>
       if error?
-        @updateLink.prop('disabled', false)
-        @updateLink.text('Install')
         @errors.append(new ErrorView(@packageManager, error))
 
   checkForUpdate: ->
-    @updateArea.hide()
     return if atom.packages.isBundledPackage(@pack.name)
 
-    @updateLink.on 'click', => @installUpdate()
 
     @packageManager.getOutdated().then (packages) =>
       for pack in packages when pack.name is @pack.name
         if @packageManager.canUpgrade(@pack, pack.latestVersion)
           @availableVersion = pack.latestVersion
-          @updateLabel.text("Version #{@availableVersion} is now available!")
-          @updateArea.show()
 
   # Even though the title of this view is hilariously "PackageDetailView",
   # the package might not be installed.

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -195,17 +195,8 @@ class PackageDetailView extends View
     activateTime = @pack.activateTime ? 0
     loadTime + activateTime
 
-  installUpdate: ->
-    return unless @availableVersion
-
-
-    @packageManager.update @pack, @availableVersion, (error) =>
-      if error?
-        @errors.append(new ErrorView(@packageManager, error))
-
   checkForUpdate: ->
     return if atom.packages.isBundledPackage(@pack.name)
-
 
     @packageManager.getOutdated().then (packages) =>
       for pack in packages when pack.name is @pack.name

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -56,7 +56,6 @@ class PackageDetailView extends View
     @populate()
     @handleButtonEvents()
     @updateFileButtons()
-    @checkForUpdate()
     @subscribeToPackageManager()
 
   loadPackage: ->
@@ -194,14 +193,6 @@ class PackageDetailView extends View
     loadTime = @pack.loadTime ? 0
     activateTime = @pack.activateTime ? 0
     loadTime + activateTime
-
-  checkForUpdate: ->
-    return if atom.packages.isBundledPackage(@pack.name)
-
-    @packageManager.getOutdated().then (packages) =>
-      for pack in packages when pack.name is @pack.name
-        if @packageManager.canUpgrade(@pack, pack.latestVersion)
-          @availableVersion = pack.latestVersion
 
   # Even though the title of this view is hilariously "PackageDetailView",
   # the package might not be installed.


### PR DESCRIPTION
Now that updates are displayed inline in package cards, the available updates container above the package card in the package detail view is a bit redundant - this removes it.

### Before

<img width="784" alt="settings_-__users_machistequintana_github_atom-dark-ui_-_atom" src="https://cloud.githubusercontent.com/assets/823545/8629817/e88b3a6c-272c-11e5-9d4b-f3c7a456cffb.png">

### After

<img width="782" alt="settings_-__users_machistequintana_github_settings-view_-_atom" src="https://cloud.githubusercontent.com/assets/823545/8629823/03b35af4-272d-11e5-9851-5250184f4715.png">

/cc @benogle @thedaniel @simurai 