### PR TITLE
Collapse packages/themes on click

### DIFF
--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -208,4 +208,4 @@ class InstalledPackagesPanel extends View
 
   handleEvents: ->
     @on 'click', '.sub-section .icon-package', (e) ->
-      [].map.call(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)
+      e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -81,7 +81,6 @@ class InstalledPackagesPanel extends View
       , InstalledPackagesPanel.loadPackagesDelay
 
     @handleEvents()
-
     @loadPackages()
 
   focus: ->

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -80,6 +80,8 @@ class InstalledPackagesPanel extends View
         @loadPackages()
       , InstalledPackagesPanel.loadPackagesDelay
 
+    @handleEvents()
+
     @loadPackages()
 
   focus: ->
@@ -203,3 +205,7 @@ class InstalledPackagesPanel extends View
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()
     @filterPackageListByText(filterText)
+
+  handleEvents: ->
+    @on 'click', '.sub-section .icon-package', (e) =>
+      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = !(child.hidden))

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -208,4 +208,4 @@ class InstalledPackagesPanel extends View
 
   handleEvents: ->
     @on 'click', '.sub-section .icon-package', (e) ->
-      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)
+      [].map.call(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -207,5 +207,5 @@ class InstalledPackagesPanel extends View
     @filterPackageListByText(filterText)
 
   handleEvents: ->
-    @on 'click', '.sub-section .icon-package', (e) =>
-      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = !(child.hidden))
+    @on 'click', '.sub-section .icon-package', (e) ->
+      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -89,7 +89,6 @@ class ThemesPanel extends View
       user: new ListView(@items.user, @communityPackages, @createPackageCard)
 
     @handleEvents()
-
     @loadPackages()
 
     @disposables = new CompositeDisposable()

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -304,4 +304,4 @@ class ThemesPanel extends View
 
   handleEvents: ->
     @on 'click', '.sub-section .icon-paintcan', (e) ->
-      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)
+      [].map.call(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -303,5 +303,5 @@ class ThemesPanel extends View
     @filterPackageListByText(filterText)
 
   handleEvents: ->
-    @on 'click', '.sub-section .icon-paintcan', (e) =>
-      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = !(child.hidden))
+    @on 'click', '.sub-section .icon-paintcan', (e) ->
+      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -304,4 +304,4 @@ class ThemesPanel extends View
 
   handleEvents: ->
     @on 'click', '.sub-section .icon-paintcan', (e) ->
-      [].map.call(e.currentTarget.nextSibling.children, (child) -> child.hidden = not child.hidden)
+      e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -88,6 +88,8 @@ class ThemesPanel extends View
       core: new ListView(@items.core, @corePackages, @createPackageCard)
       user: new ListView(@items.user, @communityPackages, @createPackageCard)
 
+    @handleEvents()
+
     @loadPackages()
 
     @disposables = new CompositeDisposable()
@@ -299,3 +301,7 @@ class ThemesPanel extends View
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()
     @filterPackageListByText(filterText)
+
+  handleEvents: ->
+    @on 'click', '.sub-section .icon-paintcan', (e) =>
+      _.map(e.currentTarget.nextSibling.children, (child) -> child.hidden = !(child.hidden))

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -131,10 +131,26 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.deprecatedCount.text().trim()).toBe '0'
       expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 0
 
-  it 'collapses sub-sections when their headers are clicked', ->
-    @panel.find('.sub-section-heading').click()
+  it 'collapses and expands a sub-section if its header is clicked', ->
+    @panel.find('.sub-section.installed-packages .sub-section-heading').click()
+    expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
 
+    expect(@panel.find('.sub-section.deprecated-packages')).not.toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+    @panel.find('.sub-section.installed-packages .sub-section-heading').click()
+    expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+
+  it 'can collapse and expand any of the sub-sections', ->
+    @panel.find('.sub-section-heading').click()
     expect(@panel.find('.sub-section.deprecated-packages')).toHaveClass 'collapsed'
     expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
     expect(@panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
     expect(@panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'
+
+    @panel.find('.sub-section-heading').click()
+    expect(@panel.find('.sub-section.deprecated-packages')).not.toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -130,3 +130,11 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.deprecatedSection).not.toBeVisible()
       expect(@panel.deprecatedCount.text().trim()).toBe '0'
       expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 0
+
+  it 'collapses sub-sections when their headers are clicked', ->
+    @panel.find('.sub-section-heading').click()
+
+    expect(@panel.find('.sub-section.deprecated-packages')).toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
+    expect(@panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -126,3 +126,10 @@ describe "ThemesPanel", ->
       runs ->
         expect(panel.communityCount.text().trim()).toBe '2'
         expect(panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
+
+    it 'collapses sub-sections when their headers are clicked', ->
+      panel.find('.sub-section-heading').click()
+
+      expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -127,9 +127,23 @@ describe "ThemesPanel", ->
         expect(panel.communityCount.text().trim()).toBe '2'
         expect(panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
-    it 'collapses sub-sections when their headers are clicked', ->
-      panel.find('.sub-section-heading').click()
+    it 'collapses/expands a sub-section if its header is clicked', ->
+      panel.find('.sub-section.installed-packages .sub-section-heading').click()
+      expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
 
+      expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+      panel.find('.sub-section.installed-packages .sub-section-heading').click()
+      expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+
+    it 'can collapse and expand any of the sub-sections', ->
+      panel.find('.sub-section-heading').click()
       expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
       expect(panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'
+
+      panel.find('.sub-section-heading').click()
+      expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -290,7 +290,7 @@
     margin: @section-padding 0;
   }
 
-  .sub-section.collapsed .package-container .row {
+  .sub-section.collapsed .package-container .package-card {
     display: none;
   }
 

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -290,6 +290,10 @@
     margin: @section-padding 0;
   }
 
+  .sub-section.collapsed .package-container .row {
+    display: none;
+  }
+
   .sub-section-heading {
     color: @text-color-highlight;
     font-size: 1.4em;

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -1,4 +1,5 @@
 @import "octicon-mixins";
+@import "octicon-utf-codes";
 @import "ui-variables";
 
 @section-padding: 4 * @component-padding;
@@ -288,19 +289,37 @@
 
   .sub-section {
     margin: @section-padding 0;
-  }
 
-  .sub-section.collapsed .package-container .package-card {
-    display: none;
-  }
+    .sub-section-heading {
+      color: @text-color-highlight;
+      font-size: 1.4em;
+      font-weight: bold;
+      line-height: 1;
+      -webkit-user-select: none;
+      cursor: pointer;
 
-  .sub-section-heading {
-    color: @text-color-highlight;
-    font-size: 1.4em;
-    font-weight: bold;
-    line-height: 1;
-    -webkit-user-select: none;
-    cursor: default;
+      &:after {
+        .icon(16px);
+        content: @fold;
+        position: absolute;
+        right: 0;
+        color: @text-color-subtle;
+      }
+
+      &:hover:after {
+        color: @text-color-highlight;
+      }
+    }
+
+    &.collapsed {
+      .sub-section-heading:after {
+        content: @unfold;
+      }
+
+      .package-container .package-card {
+        display: none;
+      }
+    }
   }
 
   .control-label {


### PR DESCRIPTION
Minimal implementation of the enhancement requested in #475.

- [x] Make packages and themes to collapse/expand on click
- [x] Make dynamically added entries to be shown or hidden depending on the visibility of the list (e.g. when installing a new package or theme)
- [x] Add specs

Closes #475