### PR TITLE
Add toggle for keymap activation in package settings

### DIFF
--- a/lib/keybindings-panel.coffee
+++ b/lib/keybindings-panel.coffee
@@ -137,7 +137,7 @@ class KeybindingsPanel extends View
   # * `User` indicates that it was defined by a user.
   # * `<package-name>` the package which defined it.
   # * `Unknown` if an invalid path was passed in.
-  determineSource: (filePath) ->
+  @determineSource: (filePath) ->
     return 'Unknown' unless filePath
 
     if filePath.indexOf(path.join(atom.getLoadSettings().resourcePath, 'keymaps')) is 0

--- a/lib/keybindings-panel.coffee
+++ b/lib/keybindings-panel.coffee
@@ -100,7 +100,7 @@ class KeybindingsPanel extends View
 
   elementForKeyBinding: (keyBinding) ->
     {selector, keystrokes, command, source} = keyBinding
-    source = @determineSource(source)
+    source = KeybindingsPanel.determineSource(source)
     $$$ ->
       rowClasses = if source is 'User' then 'is-user' else ''
       @tr class: rowClasses, =>

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -97,7 +97,7 @@ class PackageDetailView extends View
 
     if @isInstalled()
       @sections.append(new SettingsPanel(@pack.name, {includeTitle: false}))
-      @sections.append(new PackageKeymapView(@pack.name))
+      @sections.append(new PackageKeymapView(@pack))
 
       if @pack.path
         @sections.append(new PackageGrammarsView(@pack.path))

--- a/lib/package-keymap-view.coffee
+++ b/lib/package-keymap-view.coffee
@@ -12,8 +12,8 @@ class PackageKeymapView extends View
       @div class: 'checkbox', =>
         @label for: 'toggleKeybindings', =>
           @input id: 'toggleKeybindings', type: 'checkbox', outlet: 'keybindingToggle'
-          @div class: 'setting-title', 'Use Keybindings?'
-        @div class: 'setting-description', 'Whether to use the keybindings from this package.'
+          @div class: 'setting-title', 'Use Keybindings'
+        @div class: 'setting-description', 'Disable this if you want to bind your own keystrokes for this package\'s commands in your keymap.'
       @table class: 'package-keymap-table table native-key-bindings text', tabindex: -1, =>
         @thead =>
           @tr =>

--- a/lib/package-keymap-view.coffee
+++ b/lib/package-keymap-view.coffee
@@ -41,7 +41,13 @@ class PackageKeymapView extends View
 
     @updateKeyBindingView()
 
-    @hide() unless @keybindingItems.children().length > 0 or @pack.hasKeymaps()
+    hasKeymaps = false
+    for [path, map] in atom.packages.getLoadedPackage(@namespace).keymaps
+      if map.length > 0
+        hasKeymaps = true
+        break
+
+    @hide() unless @keybindingItems.children().length > 0 or hasKeymaps
 
   updateKeyBindingView: ->
     @keybindingItems.empty()

--- a/lib/package-keymap-view.coffee
+++ b/lib/package-keymap-view.coffee
@@ -12,7 +12,7 @@ class PackageKeymapView extends View
       @div class: 'checkbox', =>
         @label for: 'toggleKeybindings', =>
           @input id: 'toggleKeybindings', type: 'checkbox', outlet: 'keybindingToggle'
-          @div class: 'setting-title', 'Use Keybindings'
+          @div class: 'setting-title', 'Enable'
         @div class: 'setting-description', 'Disable this if you want to bind your own keystrokes for this package\'s commands in your keymap.'
       @table class: 'package-keymap-table table native-key-bindings text', tabindex: -1, =>
         @thead =>
@@ -27,15 +27,15 @@ class PackageKeymapView extends View
     @otherPlatformPattern = new RegExp("\\.platform-(?!#{_.escapeRegExp(process.platform)}\\b)")
     @namespace = @pack.name
 
-    @keybindingToggle.prop('checked', not _.include(atom.config.get('core.disabledKeymaps') ? [], @namespace))
+    @keybindingToggle.prop('checked', not _.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], @namespace))
 
     @keybindingToggle.on 'change', (event) =>
       event.stopPropagation()
       value = !!@keybindingToggle.prop('checked')
       if value
-        atom.config.removeAtKeyPath('core.disabledKeymaps', @namespace)
+        atom.config.removeAtKeyPath('core.packagesWithKeymapsDisabled', @namespace)
       else
-        atom.config.pushAtKeyPath('core.disabledKeymaps', @namespace)
+        atom.config.pushAtKeyPath('core.packagesWithKeymapsDisabled', @namespace)
 
       @updateKeyBindingView()
 

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -1,6 +1,8 @@
 path = require 'path'
 PackageDetailView = require '../lib/package-detail-view'
 PackageManager = require '../lib/package-manager'
+PackageKeymapView = require '../lib/package-keymap-view'
+_ = require 'underscore-plus'
 
 describe "PackageDetailView", ->
   beforeEach ->
@@ -64,6 +66,25 @@ describe "PackageDetailView", ->
       view = new PackageDetailView(pack, new PackageManager())
       keybindingsTable = view.find('.package-keymap-table tbody')
       expect(keybindingsTable.children().length).toBe 0
+
+  describe "when the keybindings toggle is clicked", ->
+    it "sets the disabledKeymaps config to include the package name", ->
+
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+      runs ->
+        pack = atom.packages.getActivePackage('language-test')
+        card = new PackageKeymapView(pack)
+        jasmine.attachToDOM(card[0])
+
+        card.keybindingToggle.click()
+        expect(card.keybindingToggle.prop('checked')).toBe false
+        expect(_.include(atom.config.get('core.disabledKeymaps') ? [], 'language-test')).toBe true
+
+        card.keybindingToggle.click()
+        expect(card.keybindingToggle.prop('checked')).toBe true
+        expect(_.include(atom.config.get('core.disabledKeymaps') ? [], 'language-test')).toBe false
 
   describe "when the package is active", ->
     it "displays the correct enablement state", ->

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -68,7 +68,7 @@ describe "PackageDetailView", ->
       expect(keybindingsTable.children().length).toBe 0
 
   describe "when the keybindings toggle is clicked", ->
-    it "sets the disabledKeymaps config to include the package name", ->
+    it "sets the packagesWithKeymapsDisabled config to include the package name", ->
 
       waitsForPromise ->
         atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
@@ -80,11 +80,11 @@ describe "PackageDetailView", ->
 
         card.keybindingToggle.click()
         expect(card.keybindingToggle.prop('checked')).toBe false
-        expect(_.include(atom.config.get('core.disabledKeymaps') ? [], 'language-test')).toBe true
+        expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe true
 
         card.keybindingToggle.click()
         expect(card.keybindingToggle.prop('checked')).toBe true
-        expect(_.include(atom.config.get('core.disabledKeymaps') ? [], 'language-test')).toBe false
+        expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe false
 
   describe "when the package is active", ->
     it "displays the correct enablement state", ->


### PR DESCRIPTION
Adds UI support for toggling keymap activation on a package-level. See https://github.com/atom/atom/pull/8130 for more details.

<img width="1176" alt="screenshot 2015-07-29 08 58 40" src="https://cloud.githubusercontent.com/assets/3076428/8962553/0e18ccde-35d0-11e5-8214-8df537ea2839.png">
