### PR TITLE
Fix bugs present when running Atom on Electron

### DIFF
--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -218,11 +218,11 @@ class ThemesPanel extends View
       switch metadata.theme
         when 'ui'
           themeItem = @createThemeMenuItem(name)
-          themeItem.prop('selected', true) if name is @activeUiTheme
+          themeItem.attr('selected', true) if name is @activeUiTheme
           @uiMenu.append(themeItem)
         when 'syntax'
           themeItem = @createThemeMenuItem(name)
-          themeItem.prop('selected', true) if name is @activeSyntaxTheme
+          themeItem.attr('selected', true) if name is @activeSyntaxTheme
           @syntaxMenu.append(themeItem)
 
   # Get the name of the active ui theme.

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -49,12 +49,18 @@ describe "ThemesPanel", ->
 
   describe "when a UI theme is selected", ->
     it "updates the 'core.themes' config key with the selected UI theme", ->
-      panel.uiMenu.val('atom-light-ui').trigger('change')
+      panel.uiMenu.children()
+        .attr('selected', false)
+        .filter("[value=atom-light-ui]").attr('selected', true)
+        .trigger('change')
       expect(atom.config.get('core.themes')).toEqual ['atom-light-ui', 'atom-dark-syntax']
 
   describe "when a syntax theme is selected", ->
     it "updates the 'core.themes' config key with the selected syntax theme", ->
-      panel.syntaxMenu.val('atom-light-syntax').trigger('change')
+      panel.syntaxMenu.children()
+        .attr('selected', false)
+        .filter("[value=atom-light-syntax]").attr('selected', true)
+        .trigger('change')
       expect(atom.config.get('core.themes')).toEqual ['atom-dark-ui', 'atom-light-syntax']
 
   describe "when the 'core.config' key changes", ->


### PR DESCRIPTION
Basically something must have changed in Chromium 43+ with regards to how `HTMLSelectElement` behaves along with jQuery's `.prop()` function; using `.prop('selected', true)` no longer works as expected, so the workaround is to fall back to good ol' `.attr('selected', true)`.

Similarly e.g. `.val('atom-light-ui')` no longer works as a means of selecting an option, and the solution is use an equivalent workaround as with `.prop()`.

This might be a bug in jQuery and/or the Chromium build (43.0.2357.65) currently used by Electron, but at least this fixes the problem for the time being.

/cc @atom/feedback