### PR TITLE
Package README styling

### DIFF
--- a/styles/package-readme.less
+++ b/styles/package-readme.less
@@ -15,11 +15,26 @@
       color: @text-color-highlight;
     }
 
+    a {
+      color: @text-color-info;
+    }
+
+    hr {
+      border-color: @text-color-subtle;
+    }
+
+    blockquote {
+      border-left-color: @text-color-subtle;
+    }
+
+    pre {
+      margin-bottom: 1em;
+    }
+
     img {
       max-width: 100%;
     }
 
-    // Table
     table {
       display: block;
       margin-bottom: 1em;
@@ -46,7 +61,6 @@
       }
     }
 
-    // Keybindings
     kbd {
       display: inline-block;
       padding: .3em .4em;

--- a/styles/package-readme.less
+++ b/styles/package-readme.less
@@ -19,7 +19,7 @@
       max-width: 100%;
     }
 
-    // Tables
+    // Table
     table {
       display: block;
       margin-bottom: 1em;
@@ -44,6 +44,21 @@
           background-color: @background-color-highlight;
         }
       }
+    }
+
+    // Keybindings
+    kbd {
+      display: inline-block;
+      padding: .3em .4em;
+      font-size: .8em;
+      line-height: 1;
+      color: @text-color-highlight;
+      vertical-align: middle;
+      background-color: lighten(@base-background-color, 10%);
+      border: solid 1px @base-border-color;
+      border-bottom-color: darken(@base-border-color, 10%);
+      border-radius: @component-border-radius;
+      box-shadow: inset 0 -1px 0 darken(@base-border-color, 10%);
     }
 
   }

--- a/styles/package-readme.less
+++ b/styles/package-readme.less
@@ -1,0 +1,50 @@
+// Package README
+
+@import "ui-variables";
+
+.settings-view {
+
+  .package-readme {
+    font-size: 1.25em;
+
+    h1 { font-size: 2em;    margin-top: 1.5em; }
+    h2 { font-size: 1.75em; margin-top: 1.5em; }
+    h3 { font-size: 1.5em;  margin-top: 1.75em; }
+    h4 { font-size: 1.25em; margin-top: 1.25em; }
+    h1, h2, h3, h4 {
+      color: @text-color-highlight;
+    }
+
+    img {
+      max-width: 100%;
+    }
+
+    // Tables
+    table {
+      display: block;
+      margin-bottom: 1em;
+      width: 100%;
+      overflow: auto;
+      word-break: normal;
+
+      th {
+        font-weight: bold;
+        text-align: center;
+      }
+
+      th, td {
+        padding: 6px 13px;
+        border: 1px solid @base-border-color;
+      }
+
+      tr {
+        border-top: 1px solid @base-border-color;
+        background-color: @base-background-color;
+        &:nth-child(2n) {
+          background-color: @background-color-highlight;
+        }
+      }
+    }
+
+  }
+}

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -721,20 +721,6 @@
   .btn-wrap-group .btn {
     margin: 0 @component-padding/2 @component-padding/2 0;
   }
-
-  .package-readme {
-    font-size: 1.25em;
-    h1 { font-size: 2em;    margin-top: 1.5em; }
-    h2 { font-size: 1.75em; margin-top: 1.5em; }
-    h3 { font-size: 1.5em;  margin-top: 1.75em; }
-    h4 { font-size: 1.25em; margin-top: 1.25em; }
-    h1, h2, h3, h4 {
-      color: @text-color-highlight;
-    }
-    img {
-      max-width: 100%;
-    }
-  }
 }
 
 .clearfix {


### PR DESCRIPTION
This PR improves the styling of package READMEs

![screen shot 2015-08-07 at 12 56 53 pm](https://cloud.githubusercontent.com/assets/378023/9128453/d6ccda8c-3d03-11e5-8c25-71365e319132.png)

- [x] `<table>` styling
- [x] `<kbd>` styling
- [x] more fixes like `a`, `hr`, `blockquote`, `pre`

Fixes #620 