### PR TITLE
Improve input selection color

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -229,14 +229,14 @@
     atom-text-editor[mini], atom-text-editor[mini]::shadow {
       opacity: .75;
       .selection .region {
-        background-color: rgba(0, 0, 0, .2);
+        background-color: contrast(@input-background-color, lighten(@input-background-color, 8%), darken(@input-background-color, 8%) );
       }
     }
 
     atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
       opacity: 1;
       .selection .region {
-        background-color: lighten(@background-color-info, 30%);
+      background-color: contrast(@input-background-color, lighten(@input-background-color, 12%), darken(@input-background-color, 12%) );
       }
     }
   }


### PR DESCRIPTION
__Before__: Selection made it hard to read in most dark themes.

![screen shot 2015-08-07 at 4 15 27 pm](https://cloud.githubusercontent.com/assets/378023/9130708/17a22c62-3d20-11e5-8c1b-ace5a9555285.png)

__After__: Uses `contrast()` to make sure it works for light and dark themes

![screen shot 2015-08-07 at 5 32 07 pm](https://cloud.githubusercontent.com/assets/378023/9131850/40451bc0-3d2a-11e5-9146-fda04eca9efa.png)

Fixes https://github.com/atom/atom/issues/8258