### PR TITLE
Allow Markdown in setting descriptions

### DIFF
--- a/lib/rich-description.coffee
+++ b/lib/rich-description.coffee
@@ -1,18 +1,12 @@
 marked = require 'marked'
 
 renderer = new marked.Renderer()
-renderer.code = ->
-  ''
-renderer.blockquote = ->
-  ''
-renderer.heading = ->
-  ''
-renderer.html = ->
-  ''
-renderer.image = ->
-  ''
-renderer.list = ->
-  ''
+renderer.code = -> ''
+renderer.blockquote = -> ''
+renderer.heading = -> ''
+renderer.html = -> ''
+renderer.image = -> ''
+renderer.list = -> ''
 
 markdown = (text) ->
   marked(text, renderer: renderer).replace(/<p>(.*)<\/p>/, "$1").trim()

--- a/lib/rich-description.coffee
+++ b/lib/rich-description.coffee
@@ -1,0 +1,23 @@
+marked = require 'marked'
+
+renderer = new marked.Renderer()
+renderer.code = ->
+  ''
+renderer.blockquote = ->
+  ''
+renderer.heading = ->
+  ''
+renderer.html = ->
+  ''
+renderer.image = ->
+  ''
+renderer.list = ->
+  ''
+
+markdown = (text) ->
+  marked(text, renderer: renderer).replace(/<p>(.*)<\/p>/, "$1").trim()
+
+module.exports =
+  getSettingDescription: (keyPath) ->
+    description = atom.config.getSchema(keyPath)?.description or ''
+    markdown(description)

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -210,16 +210,22 @@ getSettingDescription = (keyPath) ->
 appendOptions = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
-  description = getSettingDescription(keyPath)
+  description = markdown(getSettingDescription(keyPath))
   options = atom.config.getSchema(keyPath)?.enum ? []
 
   @label class: 'control-label', =>
     @div class: 'setting-title', title
-    @div class: 'setting-description', description
+    @div class: 'setting-description', =>
+      @raw(description)
 
   @select id: keyPath, class: 'form-control', =>
     for option in options
       @option value: option, option
+
+marked = null
+markdown = (text) ->
+  marked ?= require 'marked'
+  marked(text).replace(/<p>(.*)<\/p>/, "$1")
 
 appendCheckbox = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -2,6 +2,8 @@
 {$, $$, TextEditorView, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
 
+{getSettingDescription} = require './rich-description'
+
 module.exports =
 class SettingsPanel extends View
   @content: ->
@@ -204,10 +206,6 @@ getSettingTitle = (keyPath, name='') ->
   title = atom.config.getSchema(keyPath)?.title
   title or _.uncamelcase(name).split('.').map(_.capitalize).join(' ')
 
-getSettingDescription = (keyPath) ->
-  description = atom.config.getSchema(keyPath)?.description or ''
-  markdown(description)
-
 appendOptions = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
@@ -222,11 +220,6 @@ appendOptions = (namespace, name, value) ->
   @select id: keyPath, class: 'form-control', =>
     for option in options
       @option value: option, option
-
-marked = null
-markdown = (text) ->
-  marked ?= require 'marked'
-  marked(text).replace(/<p>(.*)<\/p>/, "$1")
 
 appendCheckbox = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -205,12 +205,13 @@ getSettingTitle = (keyPath, name='') ->
   title or _.uncamelcase(name).split('.').map(_.capitalize).join(' ')
 
 getSettingDescription = (keyPath) ->
-  atom.config.getSchema(keyPath)?.description or ''
+  description = atom.config.getSchema(keyPath)?.description or ''
+  markdown(description)
 
 appendOptions = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
-  description = markdown(getSettingDescription(keyPath))
+  description = getSettingDescription(keyPath)
   options = atom.config.getSchema(keyPath)?.enum ? []
 
   @label class: 'control-label', =>
@@ -236,7 +237,8 @@ appendCheckbox = (namespace, name, value) ->
     @label for: keyPath, =>
       @input id: keyPath, type: 'checkbox'
       @div class: 'setting-title', title
-    @div class: 'setting-description', description
+    @div class: 'setting-description', =>
+      @raw(description)
 
 appendColor = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"
@@ -247,7 +249,8 @@ appendColor = (namespace, name, value) ->
     @label for: keyPath, =>
       @input id: keyPath, type: 'color'
       @div class: 'setting-title', title
-    @div class: 'setting-description', description
+    @div class: 'setting-description', =>
+      @raw(description)
 
 appendEditor = (namespace, name, value) ->
   keyPath = "#{namespace}.#{name}"
@@ -261,7 +264,8 @@ appendEditor = (namespace, name, value) ->
 
   @label class: 'control-label', =>
     @div class: 'setting-title', title
-    @div class: 'setting-description', description
+    @div class: 'setting-description', =>
+      @raw(description)
 
   @div class: 'controls', =>
     @div class: 'editor-container', =>
@@ -274,7 +278,8 @@ appendArray = (namespace, name, value) ->
 
   @label class: 'control-label', =>
     @div class: 'setting-title', title
-    @div class: 'setting-description', description
+    @div class: 'setting-description', =>
+      @raw(description)
 
   @div class: 'controls', =>
     @div class: 'editor-container', =>

--- a/spec/rich-description-spec.coffee
+++ b/spec/rich-description-spec.coffee
@@ -1,0 +1,159 @@
+{getSettingDescription} = require '../lib/rich-description'
+
+fdescribe "Rich descriptions", ->
+  beforeEach ->
+    config =
+      type: 'object'
+      properties:
+        plainText:
+          description: 'Plain text description'
+          type: 'string'
+          default: ''
+        italics:
+          description: 'Description *with* italics'
+          type: 'string'
+          default: ''
+        bold:
+          description: 'Description **with** bold'
+          type: 'string'
+          default: ''
+        link:
+          description: 'Description [with](http://www.example.com) link'
+          type: 'string'
+          default: ''
+        inlineCode:
+          description: 'Description `with` inline code'
+          type: 'string'
+          default: ''
+        lineBreak:
+          description: 'Description with<br/> line break'
+          type: 'string'
+          default: ''
+        strikethrough:
+          description: 'Description ~~with~~ strikethrough'
+          type: 'string'
+          default: ''
+        image:
+          description: 'Description without ![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1") image'
+          type: 'string'
+          default: ''
+        fencedBlockCode:
+          description: '''Description without fenced block code
+          ```
+          Test
+          ```
+          '''
+          type: 'string'
+          default: ''
+        indentedBlockCode:
+          description: '''
+          Description without indented block code
+
+              Test
+          '''
+          type: 'string'
+          default: ''
+        blockquote:
+          description: '''
+          Description without blockquote
+
+          > Test
+          '''
+          type: 'string'
+          default: ''
+        html:
+          description: '''
+          Description without html
+
+          <html>Test</html>
+          '''
+          type: 'string'
+          default: ''
+        heading:
+          description: '''
+          Description without heading
+
+          ## Test
+          '''
+          type: 'string'
+          default: ''
+        orderedList:
+          description: '''
+          Description without ordered list
+
+          1. Test
+          2. Test
+          3. Test
+          '''
+          type: 'string'
+          default: ''
+        unorderedList:
+          description: '''
+          Description without unordered list
+
+          * Test
+          * Test
+          * Test
+          '''
+          type: 'string'
+          default: ''
+        table:
+          description: '''
+          Description without table
+
+          <table><tr><td>Test</td></tr></table>
+          '''
+          type: 'string'
+          default: ''
+
+    atom.config.setSchema("foo", config)
+
+  describe 'supported Markdown', ->
+    it 'handles plain text', ->
+      expect(getSettingDescription('foo.plainText')).toEqual 'Plain text description'
+
+    it 'handles italics', ->
+      expect(getSettingDescription('foo.italics')).toEqual 'Description <em>with</em> italics'
+
+    it 'handles bold', ->
+      expect(getSettingDescription('foo.bold')).toEqual 'Description <strong>with</strong> bold'
+
+    it 'handles links', ->
+      expect(getSettingDescription('foo.link')).toEqual 'Description <a href="http://www.example.com">with</a> link'
+
+    it 'handles inline code', ->
+      expect(getSettingDescription('foo.inlineCode')).toEqual 'Description <code>with</code> inline code'
+
+    it 'handles line breaks', ->
+      expect(getSettingDescription('foo.lineBreak')).toEqual 'Description with<br/> line break'
+
+    it 'handles strikethrough', ->
+      expect(getSettingDescription('foo.strikethrough')).toEqual 'Description <del>with</del> strikethrough'
+
+  describe 'unsupported Markdown', ->
+    it 'strips images', ->
+      expect(getSettingDescription('foo.image')).toEqual 'Description without  image'
+
+    it 'strips fenced code blocks', ->
+      expect(getSettingDescription('foo.fencedBlockCode')).toEqual 'Description without fenced block code'
+
+    it 'strips indented code blocks', ->
+      expect(getSettingDescription('foo.indentedBlockCode')).toEqual 'Description without indented block code'
+
+    it 'strips blockquotes', ->
+      expect(getSettingDescription('foo.blockquote')).toEqual 'Description without blockquote'
+
+    it 'strips html elements', ->
+      expect(getSettingDescription('foo.html')).toEqual 'Description without html'
+
+    it 'strips headings', ->
+      expect(getSettingDescription('foo.heading')).toEqual 'Description without heading'
+
+    it 'strips ordered lists', ->
+      expect(getSettingDescription('foo.orderedList')).toEqual 'Description without ordered list'
+
+    it 'strips unordered lists', ->
+      expect(getSettingDescription('foo.unorderedList')).toEqual 'Description without unordered list'
+
+    it 'strips tables', ->
+      expect(getSettingDescription('foo.table')).toEqual 'Description without table'

--- a/spec/rich-description-spec.coffee
+++ b/spec/rich-description-spec.coffee
@@ -1,6 +1,6 @@
 {getSettingDescription} = require '../lib/rich-description'
 
-fdescribe "Rich descriptions", ->
+describe "Rich descriptions", ->
   beforeEach ->
     config =
       type: 'object'


### PR DESCRIPTION
Allows Markdown in setting descriptions, for example from my [tabs-to-spaces package](https://atom.io/packages/tabs-to-spaces) ...

**Before:**

<img width="573" alt="screen shot 2015-08-17 at 7 46 26 pm" src="https://cloud.githubusercontent.com/assets/1038121/9321248/b12b78d4-4518-11e5-947b-ee11cd715ac0.png">

**After:**

<img width="573" alt="screen shot 2015-08-17 at 7 47 13 pm" src="https://cloud.githubusercontent.com/assets/1038121/9321256/cda7c508-4518-11e5-8a60-00e3de25aeb9.png">

Fixes #618 
