### PR TITLE
Cache results of ::loadOutdated

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -21,8 +21,6 @@ class PackageManager
         expiry: 0
 
     @emitter = new Emitter
-    @emitter.on 'updated', @clearOutdatedCache
-    @emitter.on 'installed', @clearOutdatedCache
 
   getClient: ->
     @client ?= new Client(this)
@@ -249,6 +247,7 @@ class PackageManager
     args = ['install', "#{name}@#{newVersion}"]
     exit = (code, stdout, stderr) =>
       if code is 0
+        @clearOutdatedCache()
         activation = if activateOnSuccess
           atom.packages.activatePackage(name)
         else
@@ -292,6 +291,7 @@ class PackageManager
 
     exit = (code, stdout, stderr) =>
       if code is 0
+        @clearOutdatedCache()
         if activateOnSuccess
           atom.packages.activatePackage(name)
         else
@@ -324,6 +324,7 @@ class PackageManager
     @emitPackageEvent('uninstalling', pack)
     apmProcess = @runCommand ['uninstall', '--hard', name], (code, stdout, stderr) =>
       if code is 0
+        @clearOutdatedCache()
         @unload(name)
         @removePackageFromAvailablePackageNames(name)
         @removePackageNameFromDisabledPackages(name)

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -224,10 +224,10 @@ describe "package manager", ->
     packageManager.loadOutdated ->
     expect(packageManager.runCommand.calls.length).toBe(1)
 
-    packageManager.emitPackageEvent 'updated'
+    packageManager.emitPackageEvent 'updated', {}
     packageManager.loadOutdated ->
     expect(packageManager.runCommand.calls.length).toBe(2)
 
-    packageManager.emitPackageEvent 'installed'
+    packageManager.emitPackageEvent 'installed', {}
     packageManager.loadOutdated ->
     expect(packageManager.runCommand.calls.length).toBe(3)

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -184,7 +184,7 @@ describe "package manager", ->
       atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'language-test'))
       expect(packageManager.packageHasSettings('language-test')).toBe false
 
-  fdescribe "::loadOutdated", ->
+  describe "::loadOutdated", ->
     it "caches results", ->
       [runArgs, runCallback] = []
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -220,14 +220,22 @@ describe "package manager", ->
       callback(0, '["boop"]', '')
       onWillThrowError: ->
 
-    packageManager.loadOutdated ->
-    packageManager.loadOutdated ->
-    expect(packageManager.runCommand.calls.length).toBe(1)
+    # Just prevent this stuff from calling through, it doesn't matter for this test
+    spyOn(atom.packages, 'deactivatePackage').andReturn(true)
+    spyOn(atom.packages, 'activatePackage').andReturn(true)
+    spyOn(atom.packages, 'unloadPackage').andReturn(true)
+    spyOn(atom.packages, 'loadPackage').andReturn(true)
 
-    packageManager.emitPackageEvent 'updated', {}
     packageManager.loadOutdated ->
+    expect(packageManager.runCommand.calls.length).toBe(0)
+
+    packageManager.update {}, {}, -> # +1 runCommand call to update the package
+    packageManager.loadOutdated -> # +1 runCommand call to load outdated because the cache should be wiped
     expect(packageManager.runCommand.calls.length).toBe(2)
 
-    packageManager.emitPackageEvent 'installed', {}
-    packageManager.loadOutdated ->
-    expect(packageManager.runCommand.calls.length).toBe(3)
+    packageManager.install {}, -> # +1 runCommand call to install the package
+    packageManager.loadOutdated -> # +1 runCommand call to load outdated because the cache should be wiped
+    expect(packageManager.runCommand.calls.length).toBe(4)
+
+    packageManager.loadOutdated -> # +0 runCommand call, should be cached
+    expect(packageManager.runCommand.calls.length).toBe(4)


### PR DESCRIPTION
~~~In progress. One of the specs fails when unfocused, and the cache isn't actually cleared when updating packages thru the API - maybe we're holding on to a bunch of instances of PackageManager or something. We can move the cache somewhere global if that's the case.~~~

Should be fine, I made a point to keep it pretty simple and testable.

cf. #632 