### PR TITLE
Do not enable packages on update

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -409,9 +409,6 @@ class PackageCard extends View
     @packageManager.update @installablePack ? @pack, @newVersion, (error) =>
       if error?
         console.error("Updating #{@type} #{@pack.name} to v#{@newVersion} failed", error.stack ? error, error.stderr)
-      else
-        # if a package was disabled before installing it, re-enable it
-        atom.packages.enablePackage(@pack.name) if @isDisabled()
 
   uninstall: ->
     @packageManager.uninstall @pack, (error) =>


### PR DESCRIPTION
If a user clicks the update button for a disabled package, the package should not be enabled after the update. This closes #603. Found this in the [Quality Initiative](https://github.com/atom/atom/issues/7995) post. This affects the Update All button as well.

### Demo
![example](https://cloud.githubusercontent.com/assets/3977054/9698079/cae03502-535b-11e5-939b-d911be226641.gif)