### PR TITLE
Don't overwrite path module variable

### DIFF
--- a/lib/package-keymap-view.coffee
+++ b/lib/package-keymap-view.coffee
@@ -42,7 +42,7 @@ class PackageKeymapView extends View
     @updateKeyBindingView()
 
     hasKeymaps = false
-    for [path, map] in atom.packages.getLoadedPackage(@namespace).keymaps
+    for [packageKeymapsPath, map] in atom.packages.getLoadedPackage(@namespace).keymaps
       if map.length > 0
         hasKeymaps = true
         break


### PR DESCRIPTION
This fixes https://github.com/atom/settings-view/issues/648 and fixes https://github.com/atom/settings-view/issues/652. 

The reason why that `path.extname(...)` call was failing is that the `path` variable with the `require`d `path` Node module was being overwritten here. This fixes the problem by using a different name for the variable in the function.

Friendly cc to @tmunro @maxbrunsfeld @benogle since this code was added in https://github.com/atom/settings-view/pull/610 as far as I can tell. :v: