### PR TITLE
Add test for copying keybinding to clipboard from Package Keymap view

### DIFF
--- a/spec/fixtures/language-test/keymaps/test.cson
+++ b/spec/fixtures/language-test/keymaps/test.cson
@@ -1,2 +1,4 @@
 '.platform-n64':
   'cmd-g': 'language-test:run'
+'test':
+  'cmd-g': 'language-test:run'

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -65,7 +65,7 @@ describe "PackageDetailView", ->
       pack = atom.packages.getActivePackage('language-test')
       view = new PackageDetailView(pack, new PackageManager())
       keybindingsTable = view.find('.package-keymap-table tbody')
-      expect(keybindingsTable.children().length).toBe 0
+      expect(keybindingsTable.children().length).toBe 1
 
   describe "when the keybindings toggle is clicked", ->
     it "sets the packagesWithKeymapsDisabled config to include the package name", ->
@@ -85,6 +85,42 @@ describe "PackageDetailView", ->
         card.keybindingToggle.click()
         expect(card.keybindingToggle.prop('checked')).toBe true
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe false
+
+  describe "when a keybinding is copied", ->
+    describe "when the keybinding file ends in .cson", ->
+      it "writes a CSON snippet to the clipboard", ->
+
+        waitsForPromise ->
+          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+        runs ->
+          pack = atom.packages.getActivePackage('language-test')
+          card = new PackageKeymapView(pack)
+
+          spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.cson'
+          card.find('.copy-icon').click()
+          expect(atom.clipboard.read()).toBe """
+            'test':
+              'cmd-g': 'language-test:run'
+          """
+
+    describe "when the keybinding file ends in .json", ->
+      it "writes a JSON snippet to the clipboard", ->
+
+        waitsForPromise ->
+          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+        runs ->
+          pack = atom.packages.getActivePackage('language-test')
+          card = new PackageKeymapView(pack)
+
+          spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.json'
+          card.find('.copy-icon').click()
+          expect(atom.clipboard.read()).toBe """
+            "test": {
+              "cmd-g": "language-test:run"
+            }
+          """
 
   describe "when the package is active", ->
     it "displays the correct enablement state", ->


### PR DESCRIPTION
:white_check_mark:  Supports #657 by adding test coverage.