### PR TITLE
Use a better avatar url

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -145,7 +145,7 @@ class AtomIoClient
 
       request ?= require 'request'
       readStream = request({
-        url: "https://github.com/#{login}.png"
+        url: "https://avatars.githubusercontent.com/#{login}"
         headers: DefaultRequestHeaders
       })
       readStream.on 'error', (error) -> callback(error)


### PR DESCRIPTION
Peep this: https://avatars.githubusercontent.com/technoweenie

This URL hits the GitHub CDN directly. The github.com URL actually _redirects_ to this url. 

```bash
$ curl https://github.com/technoweenie.png
<html><body>You are being <a href="https://avatars0.githubusercontent.com/u/21?v=3">redirected</a>.</body></html>
```

