### PR TITLE
Prevent accessing panelCreateCallbacks before it is defined

### DIFF
--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -132,7 +132,7 @@ class SettingsView extends ScrollView
         panel = callback()
         @panelsByName ?= {}
         @panelsByName[name] = panel
-        delete @panelCreateCallbacks[name]
+        delete @panelCreateCallbacks?[name]
 
     panel
 

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -155,6 +155,17 @@ describe "SettingsView", ->
         runs ->
           expect(settingsView.activePanelName).toBe 'Install'
 
+      it "opens the package settings view with atom://config/packages/<package-name>", ->
+        waitsForPromise ->
+          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'package-with-readme'))
+
+        waitsForPromise ->
+          atom.workspace.open('atom://config/packages/package-with-readme').then (s) -> settingsView = s
+
+        waitsFor (done) -> process.nextTick(done)
+        runs ->
+          expect(settingsView.activePanelName).toBe 'package-with-readme'
+
       it "passes the URI to a pane's beforeShow() method on settings view initialization", ->
         InstallPanel = require '../lib/install-panel'
         spyOn(InstallPanel::, 'beforeShow')


### PR DESCRIPTION
This fixes https://github.com/atom/settings-view/issues/655.

e38bfa5 adds a failing test to demonstrate the problem from the issue. At that commit, running the specs outputs this error:

```
SettingsView
  when the package is activated
    when atom.workspace.open() is used with a config URI
      it opens the package settings view with atom://config/packages/<package-name>
        TypeError: Cannot convert undefined or null to object
          at SettingsView.module.exports.SettingsView.getOrCreatePanel (/Users/izuzak/github/settings-view/lib/settings-view.coffee:135:38)
```

11c5417 fixes the problem by preventing access to items of `panelCreateCallbacks` when it's not defined, similar to how it's done in other places in that function. Running the specs at this commit outputs 0 failures.

cc @kevinsawicki @thedaniel for :eyes: 