### PR TITLE
Show error in PackageDetailView when network is unavailable and package is not in cache

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -87,7 +87,7 @@ class PackageDetailView extends View
   fetchPackage: ->
     @showLoadingMessage()
     @packageManager.getClient().package @pack.name, (err, packageData) =>
-      if err || !(packageData?.name?)
+      if err or not(packageData?.name?)
         @hideLoadingMessage()
         @showErrorMessage()
       else

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -87,7 +87,7 @@ class PackageDetailView extends View
   fetchPackage: ->
     @showLoadingMessage()
     @packageManager.getClient().package @pack.name, (err, packageData) =>
-      if err
+      if err || !(packageData?.name?)
         @hideLoadingMessage()
         @showErrorMessage()
       else


### PR DESCRIPTION
This fixes https://github.com/atom/settings-view/issues/634. It seems that `AtomIoClient.fetchFromCache` calls the callback with [a special combination of values](https://github.com/atom/settings-view/blob/86699fbf3e237b6d659ed28990964c943d05f49a/lib/atom-io-client.coffee#L110-L113) in case the network is unavailable and the package was not found in cache. This special value was handled elsewhere, but needed to be handled in PackageDetailView as well.

 068ce24 adds a failing spec, which triggers this error:

```
PackageDetailView
  it shows an error when package metadata cannot be loaded from the cache and the network is unavailable
    TypeError: Cannot read property 'on' of undefined
      at PackageCard.module.exports.PackageCard.handleButtonEvents (/Users/izuzak/github/settings-view/lib/package-card.coffee:157:17)
      at PackageCard.module.exports.PackageCard.initialize (/Users/izuzak/github/settings-view/lib/package-card.coffee:69:6)
      at PackageCard.View (/Users/izuzak/github/settings-view/node_modules/atom-space-pen-views/node_modules/space-pen/lib/space-pen.js:184:25)
      at new PackageCard (/Users/izuzak/github/settings-view/lib/package-card.coffee:11:3)
      at PackageDetailView.module.exports.PackageDetailView.completeInitialzation (/Users/izuzak/github/settings-view/lib/package-detail-view.coffee:63:26)
      at /Users/izuzak/github/settings-view/lib/package-detail-view.coffee:98:10
      at /Users/izuzak/github/settings-view/lib/atom-io-client.coffee:32:9
      at AtomIoClient.<anonymous> (/Users/izuzak/github/settings-view/spec/package-detail-view-spec.coffee:69:7)
      at AtomIoClient.module.exports.AtomIoClient.package (/Users/izuzak/github/settings-view/lib/atom-io-client.coffee:30:6)
      at PackageDetailView.module.exports.PackageDetailView.fetchPackage (/Users/izuzak/github/settings-view/lib/package-detail-view.coffee:89:5)
      at PackageDetailView.module.exports.PackageDetailView.loadPackage (/Users/izuzak/github/settings-view/lib/package-detail-view.coffee:83:10)
      at PackageDetailView.module.exports.PackageDetailView.initialize (/Users/izuzak/github/settings-view/lib/package-detail-view.coffee:59:6)
      at PackageDetailView.View (/Users/izuzak/github/settings-view/node_modules/atom-space-pen-views/node_modules/space-pen/lib/space-pen.js:184:25)
      at new PackageDetailView (/Users/izuzak/github/settings-view/lib/package-detail-view.coffee:22:3)
      at [object Object].<anonymous> (/Users/izuzak/github/settings-view/spec/package-detail-view-spec.coffee:71:16)
```

d8cc61f fixes the problem by checking the data returned by `AtomIoClient` and verifying that it has at least the package's `name` property before showing the package card.

cc @kevinsawicki and @thedaniel for :eyes: 