### PR TITLE
Fix 100% CPU use on startup. Fixes #555 for me.

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -46,7 +46,7 @@ class PackageManager
     apmProcess = @runCommand args, (code, stdout, stderr) =>
       if code is 0
         try
-          packages = JSON.parse(stdout)
+          packages = JSON.parse(stdout) ? []
         catch parseError
           error = createJsonParseError(errorMessage, parseError, stdout)
           return callback(error)

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -171,7 +171,7 @@ class PackageManager
 
   getOutdated: ->
     new Promise (resolve, reject) =>
-      @loadInstalled (error, result) ->
+      @loadOutdated (error, result) ->
         if error
           reject(error)
         else

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -5,7 +5,10 @@ describe "package updates status view", ->
   beforeEach ->
     outdatedPackage =
       name: 'out-dated'
+    installedPackage =
+      name: 'user-package'
     spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
+    spyOn(PackageManager.prototype, 'getInstalled').andCallFake -> Promise.resolve([installedPackage])
     spyOn(PackageManager.prototype, 'getOutdated').andCallFake -> Promise.resolve([outdatedPackage])
     jasmine.attachToDOM(atom.views.getView(atom.workspace))
 


### PR DESCRIPTION
This was causing a 100% cpu spike on launch with many packages (like Nuclide). Completely fixed my `Atom Helper` CPU issues on launch!