### PR TITLE
Add notes to Settings panel to point users to package settings

### DIFF
--- a/lib/general-panel.coffee
+++ b/lib/general-panel.coffee
@@ -13,11 +13,11 @@ class GeneralPanel extends View
 
     @subPanels = [
       new SettingsPanel('core', note: '''
-        <div class="alert alert-info" id="core-settings-note">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages might have additional config settings of their own. Check individual package settings by clicking its package card in the <a class="packages-open">Packages list</a>.</div>
+        <div class="text icon icon-question" id="core-settings-note" tabindex="-1">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages might have additional config settings of their own. Check individual package settings by clicking its package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
 
       new SettingsPanel('editor', note: '''
-        <div class="alert alert-info" id="editor-settings-note">These config settings are related to text editing. Some of these settings can be overriden on a per-language basis. Check language settings by clicking the language's package card in the <a class="packages-open">Packages list</a>.</div>
+        <div class="text icon icon-question" id="editor-settings-note" tabindex="-1">These config settings are related to text editing. Some of these settings can be overriden on a per-language basis. Check language settings by clicking the language's package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
     ]
 

--- a/lib/general-panel.coffee
+++ b/lib/general-panel.coffee
@@ -12,12 +12,21 @@ class GeneralPanel extends View
     @loadingElement.remove()
 
     @subPanels = [
-      new SettingsPanel('core')
-      new SettingsPanel('editor')
+      new SettingsPanel('core', note: '''
+        <div class="alert alert-info" id="core-settings-note">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages might have additional config settings of their own. Check individual package settings by selecting the package in the <a class="packages-open">Packages list</a>.</div>
+      ''')
+
+      new SettingsPanel('editor', note: '''
+        <div class="alert alert-info" id="editor-settings-note">These config settings are related to text editing. Some of these settings can be overriden on a per-language basis. Check language package settings by selecting the package for a specific language in the <a class="packages-open">Packages list</a>.</div>
+      ''')
     ]
 
     for subPanel in @subPanels
       @append(subPanel)
+
+    @on 'click', '.packages-open', ->
+      atom.workspace.open('atom://config/packages')
+
     return
 
   dispose: ->

--- a/lib/general-panel.coffee
+++ b/lib/general-panel.coffee
@@ -13,11 +13,11 @@ class GeneralPanel extends View
 
     @subPanels = [
       new SettingsPanel('core', note: '''
-        <div class="alert alert-info" id="core-settings-note">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages might have additional config settings of their own. Check individual package settings by selecting the package in the <a class="packages-open">Packages list</a>.</div>
+        <div class="alert alert-info" id="core-settings-note">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages might have additional config settings of their own. Check individual package settings by clicking its package card in the <a class="packages-open">Packages list</a>.</div>
       ''')
 
       new SettingsPanel('editor', note: '''
-        <div class="alert alert-info" id="editor-settings-note">These config settings are related to text editing. Some of these settings can be overriden on a per-language basis. Check language package settings by selecting the package for a specific language in the <a class="packages-open">Packages list</a>.</div>
+        <div class="alert alert-info" id="editor-settings-note">These config settings are related to text editing. Some of these settings can be overriden on a per-language basis. Check language settings by clicking the language's package card in the <a class="packages-open">Packages list</a>.</div>
       ''')
     ]
 

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -54,12 +54,14 @@ class SettingsPanel extends View
       title ?= "Settings"
 
     icon = @options.icon ? 'gear'
+    note = @options.note
 
     sortedSettings = @sortSettings(namespace, settings)
 
     @append $$ ->
       @div class: 'section-container', =>
         @div class: "block section-heading icon icon-#{icon}", title
+        @raw note if note
         @div class: 'section-body', =>
           for name in sortedSettings
             appendSetting.call(this, namespace, name, settings[name])

--- a/spec/general-panel-spec.coffee
+++ b/spec/general-panel-spec.coffee
@@ -133,3 +133,10 @@ describe "GeneralPanel", ->
 
     expect(atom.config.get('editor.simpleArray')).toEqual ['a', 'd']
     expect(atom.config.get('editor.complexArray')).toEqual ['a', 'b', {c: true}]
+
+  it "shows the package settings notes for core and editor settings", ->
+    expect(panel.find('#core-settings-note')).toExist()
+    expect(panel.find('#core-settings-note').text()).toContain('Check individual package settings')
+
+    expect(panel.find('#editor-settings-note')).toExist()
+    expect(panel.find('#editor-settings-note').text()).toContain('Check language package settings')

--- a/spec/general-panel-spec.coffee
+++ b/spec/general-panel-spec.coffee
@@ -139,4 +139,4 @@ describe "GeneralPanel", ->
     expect(panel.find('#core-settings-note').text()).toContain('Check individual package settings')
 
     expect(panel.find('#editor-settings-note')).toExist()
-    expect(panel.find('#editor-settings-note').text()).toContain('Check language package settings')
+    expect(panel.find('#editor-settings-note').text()).toContain('Check language settings')

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -287,6 +287,10 @@
     margin-left: .5em;
   }
 
+  .section-body {
+    margin-top: 20px;
+  }
+
   .sub-section {
     margin: @section-padding 0;
 


### PR DESCRIPTION
While we wait for https://github.com/atom/settings-view/issues/284 to be implemented, I think users would find it helpful if they were told that packages have settings of their own, while they're looking at the config settings in the Settings panel.

This pull requests adds two such notes: the first one tells users that packages have additional settings, and the other one tells users the some editor settings can be overridden on a per-language basis. Here's how that looks:

<img width="691" alt="screen shot 2015-10-04 at 22 01 06" src="https://cloud.githubusercontent.com/assets/38924/10270306/65e382e0-6aed-11e5-9e74-9760ab2f2e04.png">

<img width="694" alt="screen shot 2015-10-04 at 22 01 14" src="https://cloud.githubusercontent.com/assets/38924/10270307/65e3f72a-6aed-11e5-9d87-4622d96c7aae.png">

My non-native-English-speaking brain couldn't come up with better text for the notes -- I'd appreciate any suggestions about that.

What do you think, @atom/feedback? :thought_balloon: 