### PR TITLE
Show settings button on package cards for packages with grammars

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -22,7 +22,7 @@ class PackageManager
     else
       false
 
-  packageHasSettings: (packageName) ->
+  packageHasSettings: _.memoize((packageName) ->
     grammars = atom.grammars.getGrammars() ? []
     for grammar in grammars when grammar.path
       return true if grammar.packageName is packageName
@@ -31,6 +31,7 @@ class PackageManager
     pack.activateConfig() if pack? and not atom.packages.isPackageActive(packageName)
     schema = atom.config.getSchema(packageName)
     schema? and (schema.type isnt 'any')
+  )
 
   runCommand: (args, callback) ->
     command = atom.packages.getApmPath()

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -23,6 +23,10 @@ class PackageManager
       false
 
   packageHasSettings: (packageName) ->
+    grammars = atom.grammars.getGrammars() ? []
+    for grammar in grammars when grammar.path
+      return true if grammar.packageName is packageName
+
     pack = atom.packages.getLoadedPackage(packageName)
     pack.activateConfig() if pack? and not atom.packages.isPackageActive(packageName)
     schema = atom.config.getSchema(packageName)

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -178,8 +178,14 @@ describe "package manager", ->
       atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-config'))
       expect(packageManager.packageHasSettings('package-with-config')).toBe true
 
-    it "returns false when the pacakge does not have config", ->
+    it "returns false when the pacakge does not have config and doesn't define language grammars", ->
       expect(packageManager.packageHasSettings('random-package')).toBe false
 
-      atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'language-test'))
-      expect(packageManager.packageHasSettings('language-test')).toBe false
+    it "returns true when the pacakge does not have config, but does define language grammars", ->
+      packageName = 'language-test'
+      
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', packageName))
+
+      runs ->
+        expect(packageManager.packageHasSettings(packageName)).toBe true


### PR DESCRIPTION
This is an attempt to close https://github.com/atom/settings-view/issues/645. 

The problem with that package is that it doesn't have any config settings of it own, but it [does define a grammar](https://github.com/sindresorhus/atom-editorconfig/tree/master/grammars) so it has scoped settings as any other language package.

* 2af57d1 adds a failing spec to demonstrate the problem with the `packageHasSettings` method:

  ```
package manager
  ::packageHasSettings
    it returns true when the pacakge does not have config, but does define language grammars
      Expected false to be true. (spec/package-manager-spec.coffee:191:64)
```

* 9842dd1 modifies `packageHasSettings` so that it returns `true` if a grammar was loaded from that package, using a similar approach as in [`PackageGrammarsView.getPackageGrammars`](https://github.com/atom/settings-view/blob/cb09a2d80fcab4c91b3cf47e7d6fe02174a4b1c0/lib/package-grammars-view.coffee#L27-L29)

  ```
Finished in 21.308 seconds
134 tests, 505 assertions, 0 failures, 0 skipped
```

With this change, all packages which define a grammar will have a "Settings" button on the package card, which I think is good since those packages do have (scoped) settings.

cc @benogle (I noticed you made [some changes in this area](https://github.com/atom/settings-view/commit/e5069ac4617ee065a9eefb788da8da1496a77548) a few months back, @thedaniel @kevinsawicki for :thought_balloon: 

Before:

<img width="670" alt="screen shot 2015-10-05 at 09 05 34" src="https://cloud.githubusercontent.com/assets/38924/10274653/55c5c884-6b40-11e5-8545-d804442fd03e.png">
<img width="669" alt="screen shot 2015-10-05 at 09 05 59" src="https://cloud.githubusercontent.com/assets/38924/10274654/55c6c9dc-6b40-11e5-9705-45d86d5b2c3e.png">

After:

<img width="687" alt="screen shot 2015-10-05 at 09 04 15" src="https://cloud.githubusercontent.com/assets/38924/10274623/1ee3e580-6b40-11e5-91f1-dfecae28314b.png">
<img width="671" alt="screen shot 2015-10-05 at 09 04 31" src="https://cloud.githubusercontent.com/assets/38924/10274624/1ee3fa84-6b40-11e5-8dc9-211fe76f2f52.png">