### PR TITLE
Hide config settings defined by language packages

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -189,6 +189,9 @@ appendSetting = (namespace, name, value) ->
     return if name is 'disabledPackages' # Handled in the Packages panel
     return if name is 'customFileTypes'
 
+  if namespace is 'editor'
+    return if name in ['commentStart', 'commentEnd', 'increaseIndentPattern', 'decreaseIndentPattern', 'foldEndPattern'] # There's no global default for these, they are defined by language packages
+
   @div class: 'control-group', =>
     @div class: 'controls', =>
       schema = atom.config.getSchema("#{namespace}.#{name}")

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -190,7 +190,8 @@ appendSetting = (namespace, name, value) ->
     return if name is 'customFileTypes'
 
   if namespace is 'editor'
-    return if name in ['commentStart', 'commentEnd', 'increaseIndentPattern', 'decreaseIndentPattern', 'foldEndPattern'] # There's no global default for these, they are defined by language packages
+    # There's no global default for these, they are defined by language packages
+    return if name in ['commentStart', 'commentEnd', 'increaseIndentPattern', 'decreaseIndentPattern', 'foldEndPattern']
 
   @div class: 'control-group', =>
     @div class: 'controls', =>


### PR DESCRIPTION
This hides the following config settings from the Settings panel so that it doesn't confuse users: `commentStart`, `commentEnd`, `increaseIndentPattern`, `decreaseIndentPattern`, `foldEndPattern`. As mentioned [here](https://github.com/atom/atom/blob/1d5fa01dc46c52ab352622dcc6456fcbcfc7079c/src/config-schema.coffee#L100), these settings are used only by specific languages -- there are no global defaults.

@benogle @kevinsawicki Does this look okay to you? 

Also, I'm wondering if these config settings should be visible in language package settings? Currently, they are not visible, i.e. they're not listed [here](https://github.com/atom/settings-view/blob/b9567cd50448b91eb8f8f09f1dfe2efff156573b/lib/settings-panel.coffee#L16-L30). From the comment I linked to above it _seems_ as if they should be visible, but I'm not sure. Perhaps it's something that packages defined and shouldn't be touched by users? :thought_balloon: 

Before:

<img width="882" alt="screen shot 2015-10-09 at 14 03 29" src="https://cloud.githubusercontent.com/assets/38924/10393884/cd69560c-6e93-11e5-920d-237f31d986f4.png">

After:

<img width="885" alt="screen shot 2015-10-09 at 14 03 04" src="https://cloud.githubusercontent.com/assets/38924/10393887/d44c2148-6e93-11e5-8fed-b68cad428e16.png">
