### PR TITLE
Use metadata returned from atom.io API when creating package card in detail view

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -93,9 +93,6 @@ class PackageDetailView extends ScrollView
         @showErrorMessage()
       else
         @pack = packageData
-        # TODO: this should match Package.loadMetadata from core, but this is
-        # an acceptable hacky workaround
-        @pack.metadata = _.clone(@pack)
         @completeInitialzation()
 
   showLoadingMessage: ->

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -93,6 +93,9 @@ class PackageDetailView extends ScrollView
         @showErrorMessage()
       else
         @pack = packageData
+        # TODO: this should match Package.loadMetadata from core, but this is
+        # an acceptable hacky workaround
+        @pack.metadata = _.extend(@pack.metadata ? {}, @pack)
         @completeInitialzation()
 
   showLoadingMessage: ->


### PR DESCRIPTION
This fixes https://github.com/atom/settings-view/issues/638.

@thedaniel do you remember why you added this in https://github.com/atom/settings-view/pull/614/files#diff-078cae2173fad78e9ce04ce50aa4cf96R95 ? As far as I can tell, the response from the Atom.io API will include a `metadata` hash which has all the required properties, including the missing `version` (e.g. see https://atom.io/api/packages/pdf-view). 