### PR TITLE
:bug: Short GitHub URIs missing author info

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -8,6 +8,10 @@ ownerFromRepository = (repository) ->
     if repo.match 'git@github'
       repoName = repo.split(':')[1]
       repo = "https://github.com/#{repoName}"
+
+  unless repo.match("github.com/")
+    repo = "https://github.com/#{repo}"
+
   repo.match(loginRegex)?[1] ? ''
 
 packageComparatorAscending = (left, right) ->

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -58,6 +58,19 @@ describe "PackageCard", ->
     expect(card.updateButton).toBeVisible()
     expect(card.updateButton.text()).toContain 'Update to 1.2.0'
 
+  it "shows the author details", ->
+    authorName = "authorName"
+    pack =
+      name: 'some-package'
+      version: '0.1.0'
+      repository: "https://github.com/#{authorName}/some-package"
+    card = new PackageCard(pack, packageManager)
+
+    jasmine.attachToDOM(card[0])
+
+    expect(card.loginLink.text()).toBe(authorName)
+    expect(card.loginLink.attr("href")).toBe("https://atom.io/users/#{authorName}")
+
   describe "when the package is not installed", ->
     it "shows the settings, uninstall, and disable buttons", ->
       pack =

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -1,0 +1,11 @@
+{ownerFromRepository} = require '../lib/utils'
+
+describe "Utils", ->
+  describe "ownerFromRepository", ->
+    it "handles a long github url", ->
+      owner = ownerFromRepository("http://github.com/omgwow/some-package")
+      expect(owner).toBe("omgwow")
+
+    it "handles a short github url", ->
+      owner = ownerFromRepository("omgwow/some-package")
+      expect(owner).toBe("omgwow")


### PR DESCRIPTION
If an author of a package specified 'authorName/packageName' instead
of 'https://github.com/authorName/packageName', the link to the author
and the avatar image would be broken when looking at the package card.

Now the short GitHub URI is converted to a long one and it works.

Before when going to Install and searching for jshint:
<img width="670" alt="screen shot 2015-10-17 at 10 09 02 pm" src="https://cloud.githubusercontent.com/assets/18362/10558751/a7f85f7c-7527-11e5-9c06-304fea4b4f43.png">

After:
<img width="761" alt="screen shot 2015-10-17 at 11 14 34 pm" src="https://cloud.githubusercontent.com/assets/18362/10558754/aba0116a-7527-11e5-8378-e914dfa61584.png">


Fixes #543