### PR TITLE
Show default in tooltip when present in settings - Resolves #268

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -39,6 +39,7 @@ class SettingsPanel extends CollapsibleSectionPanel
     @bindInputFields()
     @bindSelectFields()
     @bindEditors()
+    @bindTooltips()
     @handleEvents()
 
   dispose: ->
@@ -173,6 +174,15 @@ class SettingsPanel extends CollapsibleSectionPanel
 
       editor.onDidStopChanging =>
         @set(name, @parseValue(type, editor.getText()))
+
+  bindTooltips: ->
+    @find('input[id], select[id], atom-text-editor[id]').views().forEach (view) =>
+      if defaultValue = @valueToString(@getDefault(view.attr('id')))
+        @disposables.add atom.tooltips.add view,
+          title: 'Default: ' + defaultValue
+          delay:
+            show: 100
+          placement: 'auto left'
 
   valueToString: (value) ->
     if _.isArray(value)


### PR DESCRIPTION
Add a tooltip with the default value to the settings view.

Couple questions:
- At the moment i add the tooltips to the left. This means that the appear in roughly the same location for each setting, however, for input field with long defaults, this also means that the tooltip might fall outside the screen. Especially with the tree view 'off'.
- I don't know how to write tests to check if the tooltips are present when there is a default value.

Anyone got a couple pointers to help me finish this?
