### PR TITLE
Hide collapse icon when there are no themes/packages

### DIFF
--- a/lib/collapsible-section-panel.coffee
+++ b/lib/collapsible-section-panel.coffee
@@ -1,0 +1,33 @@
+{$$, TextEditorView, ScrollView} = require 'atom-space-pen-views'
+
+module.exports =
+class CollapsibleSectionPanel extends ScrollView
+  notHiddenCardsLength: (sectionElement) ->
+    sectionElement.find('.package-card:not(.hidden)').length
+
+  updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
+    if totalCount is undefined
+      countElement.text packageCount
+    else
+      countElement.text "#{packageCount}/#{totalCount}"
+
+    headerElement.addClass("has-items") if packageCount > 0
+
+  updateSectionCounts: ->
+    @resetSectionHasItems()
+
+    filterText = @filterEditor.getModel().getText()
+    if filterText is ''
+      @updateUnfilteredSectionCounts()
+    else
+      @updateFilteredSectionCounts()
+
+  handleEvents: ->
+    @on 'click', '.sub-section .has-items', (e) ->
+      e.currentTarget.parentNode.classList.toggle('collapsed')
+
+  resetCollapsibleSections: (headerSections) ->
+    @resetCollapsibleSection headerSection for headerSection in headerSections
+
+  resetCollapsibleSection: (headerSection) ->
+    headerSection.removeClass('has-items')

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -1,8 +1,9 @@
 _ = require 'underscore-plus'
-{$$, TextEditorView, ScrollView} = require 'atom-space-pen-views'
+{$$, TextEditorView} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 fuzzaldrin = require 'fuzzaldrin'
 
+CollapsibleSectionPanel = require './collapsible-section-panel'
 PackageCard = require './package-card'
 ErrorView = require './error-view'
 
@@ -11,7 +12,7 @@ ListView = require './list-view'
 {ownerFromRepository, packageComparatorAscending} = require './utils'
 
 module.exports =
-class InstalledPackagesPanel extends ScrollView
+class InstalledPackagesPanel extends CollapsibleSectionPanel
   @loadPackagesDelay: 300
 
   @content: ->
@@ -181,14 +182,6 @@ class InstalledPackagesPanel extends ScrollView
 
     @updateSectionCounts()
 
-  updateSectionCounts: ->
-    @resetSectionHasItems()
-    filterText = @filterEditor.getModel().getText()
-    if filterText is ''
-      @updateUnfilteredSectionCounts()
-    else
-      @updateFilteredSectionCounts()
-
   updateUnfilteredSectionCounts: ->
     @updateSectionCount(@deprecatedPackagesHeader, @deprecatedCount, @packages.deprecated.length)
     @updateSectionCount(@communityPackagesHeader, @communityCount, @packages.user.length)
@@ -215,26 +208,8 @@ class InstalledPackagesPanel extends ScrollView
     @totalPackages.text "#{shownPackages}/#{totalPackages}"
 
   resetSectionHasItems: ->
-    @deprecatedPackagesHeader.removeClass('has-items')
-    @communityPackagesHeader.removeClass('has-items')
-    @corePackagesHeader.removeClass('has-items')
-    @devPackagesHeader.removeClass('has-items')
-
-  updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
-    if totalCount is undefined
-      countElement.text packageCount
-    else
-      countElement.text "#{packageCount}/#{totalCount}"
-
-    headerElement.addClass("has-items") if packageCount > 0
-
-  notHiddenCardsLength: (sectionElement) ->
-    sectionElement.find('.package-card:not(.hidden)').length
+    @resetCollapsibleSections([@deprecatedPackagesHeader, @communityPackagesHeader, @corePackagesHeader, @devPackagesHeader])
 
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()
     @filterPackageListByText(filterText)
-
-  handleEvents: ->
-    @on 'click', '.sub-section .icon-package.has-items', (e) ->
-      e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -27,7 +27,7 @@ class InstalledPackagesPanel extends ScrollView
           @div outlet: 'updateErrors'
 
           @section outlet: 'deprecatedSection', class: 'sub-section deprecated-packages', =>
-            @h3 class: 'sub-section-heading icon icon-package', =>
+            @h3 outlet: 'deprecatedPackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Deprecated Packages'
               @span outlet: 'deprecatedCount', class: 'section-heading-count badge badge-flexible', '…'
             @p 'Atom does not load deprecated packages. These packages may have updates available.'
@@ -35,21 +35,21 @@ class InstalledPackagesPanel extends ScrollView
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
           @section class: 'sub-section installed-packages', =>
-            @h3 class: 'sub-section-heading icon icon-package', =>
+            @h3 outlet: 'communityPackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Community Packages'
               @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'communityPackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
           @section class: 'sub-section core-packages', =>
-            @h3 class: 'sub-section-heading icon icon-package', =>
+            @h3 outlet: 'corePackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Core Packages'
               @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'corePackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
           @section class: 'sub-section dev-packages', =>
-            @h3 class: 'sub-section-heading icon icon-package', =>
+            @h3 outlet: 'devPackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Development Packages'
               @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'devPackages', class: 'container package-container', =>
@@ -122,7 +122,6 @@ class InstalledPackagesPanel extends ScrollView
     @packageManager.getInstalled()
       .then (packages) =>
         @packages = @sortPackages(@filterPackages(packages))
-
         @devPackages.find('.alert.loading-area').remove()
         @items.dev.setItems(@packages.dev)
 
@@ -186,10 +185,22 @@ class InstalledPackagesPanel extends ScrollView
     filterText = @filterEditor.getModel().getText()
     if filterText is ''
       @totalPackages.text(@packages.user.length + @packages.core.length + @packages.dev.length)
+
       @communityCount.text @packages.user.length
+      if @packages.user.length > 0
+        @communityPackagesHeader.addClass("has-items")
+
       @coreCount.text @packages.core.length
+      if @packages.core.length > 0
+        @corePackagesHeader.addClass("has-items")
+
       @devCount.text @packages.dev.length
+      if @packages.dev.length > 0
+        @devPackagesHeader.addClass("has-items")
+
       @deprecatedCount.text @packages.deprecated.length
+      if @packages.deprecated.length > 0
+        @deprecatedPackagesHeader.addClass("has-items")
     else
       community = @communityPackages.find('.package-card:not(.hidden)').length
       @communityCount.text "#{community}/#{@packages.user.length}"
@@ -209,5 +220,5 @@ class InstalledPackagesPanel extends ScrollView
     @filterPackageListByText(filterText)
 
   handleEvents: ->
-    @on 'click', '.sub-section .icon-package', (e) ->
+    @on 'click', '.sub-section .icon-package.has-items', (e) ->
       e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -198,13 +198,13 @@ class InstalledPackagesPanel extends ScrollView
     @totalPackages.text(@packages.user.length + @packages.core.length + @packages.dev.length)
 
   updateFilteredSectionCounts: ->
-    deprecated = @notHiddenCardsLength @deprecatedPackages
+    deprecated = @notHiddenCardsLength(@deprecatedPackages)
     @updateSectionCount(@deprecatedPackagesHeader, @deprecatedCount, deprecated, @packages.deprecated.length)
 
-    community = @notHiddenCardsLength @communityPackages
+    community = @notHiddenCardsLength(@communityPackages)
     @updateSectionCount(@communityPackagesHeader, @communityCount, community, @packages.user.length)
 
-    core = @notHiddenCardsLength @corePackages
+    core = @notHiddenCardsLength(@corePackages)
     @updateSectionCount(@corePackagesHeader, @coreCount, core, @packages.core.length)
 
     dev = @notHiddenCardsLength @devPackages

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -184,36 +184,45 @@ class InstalledPackagesPanel extends ScrollView
   updateSectionCounts: ->
     filterText = @filterEditor.getModel().getText()
     if filterText is ''
-      @totalPackages.text(@packages.user.length + @packages.core.length + @packages.dev.length)
-
-      @communityCount.text @packages.user.length
-      if @packages.user.length > 0
-        @communityPackagesHeader.addClass("has-items")
-
-      @coreCount.text @packages.core.length
-      if @packages.core.length > 0
-        @corePackagesHeader.addClass("has-items")
-
-      @devCount.text @packages.dev.length
-      if @packages.dev.length > 0
-        @devPackagesHeader.addClass("has-items")
-
-      @deprecatedCount.text @packages.deprecated.length
-      if @packages.deprecated.length > 0
-        @deprecatedPackagesHeader.addClass("has-items")
+      @updateUnfilteredSectionCounts()
     else
-      community = @communityPackages.find('.package-card:not(.hidden)').length
-      @communityCount.text "#{community}/#{@packages.user.length}"
-      dev = @devPackages.find('.package-card:not(.hidden)').length
-      @devCount.text "#{dev}/#{@packages.dev.length}"
-      core = @corePackages.find('.package-card:not(.hidden)').length
-      @coreCount.text "#{core}/#{@packages.core.length}"
-      deprecated = @deprecatedPackages.find('.package-card:not(.hidden)').length
-      @deprecatedCount.text "#{deprecated}/#{@packages.deprecated.length}"
+      @updateFilteredSectionCounts()
 
-      shownPackages = dev + core + community
-      totalPackages = @packages.user.length + @packages.core.length + @packages.dev.length
-      @totalPackages.text "#{shownPackages}/#{totalPackages}"
+  updateUnfilteredSectionCounts: ->
+    @updateSectionCount @deprecatedPackagesHeader, @deprecatedCount, @packages.deprecated.length
+    @updateSectionCount @communityPackagesHeader, @communityCount, @packages.user.length
+    @updateSectionCount @corePackagesHeader, @coreCount, @packages.core.length
+    @updateSectionCount @devPackagesHeader, @devCount, @packages.dev.length
+
+    @totalPackages.text(@packages.user.length + @packages.core.length + @packages.dev.length)
+
+  updateFilteredSectionCounts: ->
+    deprecated = @notHiddenCardsLength @deprecatedPackages
+    @updateSectionCount @deprecatedPackagesHeader, @deprecatedCount, deprecated, @packages.deprecated.length
+
+    community = @notHiddenCardsLength @communityPackages
+    @updateSectionCount @communityPackagesHeader, @communityCount, community, @packages.user.length
+
+    core = @notHiddenCardsLength @corePackages
+    @updateSectionCount @corePackagesHeader, @coreCount, core, @packages.core.length
+
+    dev = @notHiddenCardsLength @devPackages
+    @updateSectionCount @devPackagesHeader, @devCount, dev, @packages.dev.length
+
+    shownPackages = dev + core + community
+    totalPackages = @packages.user.length + @packages.core.length + @packages.dev.length
+    @totalPackages.text "#{shownPackages}/#{totalPackages}"
+
+  updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
+    if totalCount is undefined
+      countElement.text packageCount
+    else
+      countElement.text "#{packageCount}/#{totalCount}"
+
+    headerElement.addClass("has-items") if packageCount > 0
+
+  notHiddenCardsLength: (sectionElement) ->
+    sectionElement.find('.package-card:not(.hidden)').length
 
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -182,6 +182,7 @@ class InstalledPackagesPanel extends ScrollView
     @updateSectionCounts()
 
   updateSectionCounts: ->
+    @resetSectionHasItems()
     filterText = @filterEditor.getModel().getText()
     if filterText is ''
       @updateUnfilteredSectionCounts()
@@ -189,29 +190,35 @@ class InstalledPackagesPanel extends ScrollView
       @updateFilteredSectionCounts()
 
   updateUnfilteredSectionCounts: ->
-    @updateSectionCount @deprecatedPackagesHeader, @deprecatedCount, @packages.deprecated.length
-    @updateSectionCount @communityPackagesHeader, @communityCount, @packages.user.length
-    @updateSectionCount @corePackagesHeader, @coreCount, @packages.core.length
-    @updateSectionCount @devPackagesHeader, @devCount, @packages.dev.length
+    @updateSectionCount(@deprecatedPackagesHeader, @deprecatedCount, @packages.deprecated.length)
+    @updateSectionCount(@communityPackagesHeader, @communityCount, @packages.user.length)
+    @updateSectionCount(@corePackagesHeader, @coreCount, @packages.core.length)
+    @updateSectionCount(@devPackagesHeader, @devCount, @packages.dev.length)
 
     @totalPackages.text(@packages.user.length + @packages.core.length + @packages.dev.length)
 
   updateFilteredSectionCounts: ->
     deprecated = @notHiddenCardsLength @deprecatedPackages
-    @updateSectionCount @deprecatedPackagesHeader, @deprecatedCount, deprecated, @packages.deprecated.length
+    @updateSectionCount(@deprecatedPackagesHeader, @deprecatedCount, deprecated, @packages.deprecated.length)
 
     community = @notHiddenCardsLength @communityPackages
-    @updateSectionCount @communityPackagesHeader, @communityCount, community, @packages.user.length
+    @updateSectionCount(@communityPackagesHeader, @communityCount, community, @packages.user.length)
 
     core = @notHiddenCardsLength @corePackages
-    @updateSectionCount @corePackagesHeader, @coreCount, core, @packages.core.length
+    @updateSectionCount(@corePackagesHeader, @coreCount, core, @packages.core.length)
 
     dev = @notHiddenCardsLength @devPackages
-    @updateSectionCount @devPackagesHeader, @devCount, dev, @packages.dev.length
+    @updateSectionCount(@devPackagesHeader, @devCount, dev, @packages.dev.length)
 
     shownPackages = dev + core + community
     totalPackages = @packages.user.length + @packages.core.length + @packages.dev.length
     @totalPackages.text "#{shownPackages}/#{totalPackages}"
+
+  resetSectionHasItems: ->
+    @deprecatedPackagesHeader.removeClass('has-items')
+    @communityPackagesHeader.removeClass('has-items')
+    @corePackagesHeader.removeClass('has-items')
+    @devPackagesHeader.removeClass('has-items')
 
   updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
     if totalCount is undefined

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -299,13 +299,13 @@ class ThemesPanel extends ScrollView
     @totalPackages.text "#{@packages.user.length + @packages.core.length + @packages.dev.length}"
 
   updateFilteredSectionCounts: ->
-    community = @communityPackages.find('.package-card:not(.hidden)').length
+    community = @notHiddenCardsLength(@communityPackages)
     @updateSectionCount(@communityThemesHeader, @communityCount, community, @packages.user.length)
 
-    dev = @devPackages.find('.package-card:not(.hidden)').length
+    dev = @notHiddenCardsLength(@devPackages)
     @updateSectionCount(@developmentThemesHeader, @devCount, dev, @packages.dev.length)
 
-    core = @corePackages.find('.package-card:not(.hidden)').length
+    core = @notHiddenCardsLength(@corePackages)
     @updateSectionCount(@coreThemesHeader, @coreCount, core, @packages.core.length)
 
   resetSectionHasItems: ->
@@ -321,6 +321,8 @@ class ThemesPanel extends ScrollView
 
     headerElement.addClass("has-items") if packageCount > 0
 
+  notHiddenCardsLength: (sectionElement) ->
+    sectionElement.find('.package-card:not(.hidden)').length
 
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -58,21 +58,21 @@ class ThemesPanel extends ScrollView
           @div outlet: 'themeErrors'
 
           @section class: 'sub-section installed-packages', =>
-            @h3 class: 'sub-section-heading icon icon-paintcan', =>
+            @h3 outlet: 'communityThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
               @text 'Community Themes'
               @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'communityPackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
           @section class: 'sub-section core-packages', =>
-            @h3 class: 'sub-section-heading icon icon-paintcan', =>
+            @h3 outlet: 'coreThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
               @text 'Core Themes'
               @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'corePackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
           @section class: 'sub-section dev-packages', =>
-            @h3 class: 'sub-section-heading icon icon-paintcan', =>
+            @h3 outlet: 'developmentThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
               @text 'Development Themes'
               @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
             @div outlet: 'devPackages', class: 'container package-container', =>
@@ -139,7 +139,6 @@ class ThemesPanel extends ScrollView
     for packageType in ['dev', 'core', 'user']
       for pack in packages[packageType]
         pack.owner = ownerFromRepository(pack.repository)
-
     packages
 
   sortThemes: (packages) ->
@@ -286,22 +285,38 @@ class ThemesPanel extends ScrollView
   updateSectionCounts: ->
     filterText = @filterEditor.getModel().getText()
     if filterText is ''
-      @totalPackages.text "#{@packages.user.length + @packages.core.length + @packages.dev.length}"
-      @communityCount.text "#{@packages.user.length}"
-      @coreCount.text "#{@packages.core.length}"
-      @devCount.text "#{@packages.dev.length}"
+      @updateUnfilteredSectionCounts()
     else
-      community = @communityPackages.find('.package-card:not(.hidden)').length
-      @communityCount.text "#{community}/#{@packages.user.length}"
-      dev = @devPackages.find('.package-card:not(.hidden)').length
-      @devCount.text "#{dev}/#{@packages.dev.length}"
-      core = @corePackages.find('.package-card:not(.hidden)').length
-      @coreCount.text "#{core}/#{@packages.core.length}"
+      @updateFilteredSectionCounts()
+
+  updateUnfilteredSectionCounts: ->
+    @updateSectionCount @communityThemesHeader, @communityCount, @packages.user.length
+    @updateSectionCount @coreThemesHeader, @coreCount, @packages.core.length
+    @updateSectionCount @developmentThemesHeader, @devCount, @packages.dev.length
+
+    @totalPackages.text "#{@packages.user.length + @packages.core.length + @packages.dev.length}"
+
+  updateFilteredSectionCounts: ->
+    community = @communityPackages.find('.package-card:not(.hidden)').length
+    @communityCount.text "#{community}/#{@packages.user.length}"
+    dev = @devPackages.find('.package-card:not(.hidden)').length
+    @devCount.text "#{dev}/#{@packages.dev.length}"
+    core = @corePackages.find('.package-card:not(.hidden)').length
+    @coreCount.text "#{core}/#{@packages.core.length}"
+
+  updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
+    if totalCount is undefined
+      countElement.text packageCount
+    else
+      countElement.text "#{packageCount}/#{totalCount}"
+
+    headerElement.addClass("has-items") if packageCount > 0
+
 
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()
     @filterPackageListByText(filterText)
 
   handleEvents: ->
-    @on 'click', '.sub-section .icon-paintcan', (e) ->
+    @on 'click', '.sub-section .icon-paintcan.has-items', (e) ->
       e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -4,8 +4,9 @@ fs = require 'fs-plus'
 fuzzaldrin = require 'fuzzaldrin'
 _ = require 'underscore-plus'
 {CompositeDisposable} = require 'atom'
-{$$, TextEditorView, ScrollView} = require 'atom-space-pen-views'
+{$$, TextEditorView} = require 'atom-space-pen-views'
 
+CollapsibleSectionPanel = require './collapsible-section-panel'
 PackageCard = require './package-card'
 ErrorView = require './error-view'
 PackageManager = require './package-manager'
@@ -15,7 +16,7 @@ ListView = require './list-view'
 {ownerFromRepository, packageComparatorAscending} = require './utils'
 
 module.exports =
-class ThemesPanel extends ScrollView
+class ThemesPanel extends CollapsibleSectionPanel
   @loadPackagesDelay: 300
 
   @content: ->
@@ -282,15 +283,6 @@ class ThemesPanel extends ScrollView
 
     @updateSectionCounts()
 
-  updateSectionCounts: ->
-    @resetSectionHasItems()
-
-    filterText = @filterEditor.getModel().getText()
-    if filterText is ''
-      @updateUnfilteredSectionCounts()
-    else
-      @updateFilteredSectionCounts()
-
   updateUnfilteredSectionCounts: ->
     @updateSectionCount(@communityThemesHeader, @communityCount, @packages.user.length)
     @updateSectionCount(@coreThemesHeader, @coreCount, @packages.core.length)
@@ -309,25 +301,8 @@ class ThemesPanel extends ScrollView
     @updateSectionCount(@coreThemesHeader, @coreCount, core, @packages.core.length)
 
   resetSectionHasItems: ->
-    @communityThemesHeader.removeClass('has-items')
-    @coreThemesHeader.removeClass('has-items')
-    @developmentThemesHeader.removeClass('has-items')
-
-  updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
-    if totalCount is undefined
-      countElement.text packageCount
-    else
-      countElement.text "#{packageCount}/#{totalCount}"
-
-    headerElement.addClass("has-items") if packageCount > 0
-
-  notHiddenCardsLength: (sectionElement) ->
-    sectionElement.find('.package-card:not(.hidden)').length
+    @resetCollapsibleSections([@communityThemesHeader, @coreThemesHeader, @developmentThemesHeader])
 
   matchPackages: ->
     filterText = @filterEditor.getModel().getText()
     @filterPackageListByText(filterText)
-
-  handleEvents: ->
-    @on 'click', '.sub-section .icon-paintcan.has-items', (e) ->
-      e.currentTarget.parentNode.classList.toggle('collapsed')

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -283,6 +283,8 @@ class ThemesPanel extends ScrollView
     @updateSectionCounts()
 
   updateSectionCounts: ->
+    @resetSectionHasItems()
+
     filterText = @filterEditor.getModel().getText()
     if filterText is ''
       @updateUnfilteredSectionCounts()
@@ -290,19 +292,26 @@ class ThemesPanel extends ScrollView
       @updateFilteredSectionCounts()
 
   updateUnfilteredSectionCounts: ->
-    @updateSectionCount @communityThemesHeader, @communityCount, @packages.user.length
-    @updateSectionCount @coreThemesHeader, @coreCount, @packages.core.length
-    @updateSectionCount @developmentThemesHeader, @devCount, @packages.dev.length
+    @updateSectionCount(@communityThemesHeader, @communityCount, @packages.user.length)
+    @updateSectionCount(@coreThemesHeader, @coreCount, @packages.core.length)
+    @updateSectionCount(@developmentThemesHeader, @devCount, @packages.dev.length)
 
     @totalPackages.text "#{@packages.user.length + @packages.core.length + @packages.dev.length}"
 
   updateFilteredSectionCounts: ->
     community = @communityPackages.find('.package-card:not(.hidden)').length
-    @communityCount.text "#{community}/#{@packages.user.length}"
+    @updateSectionCount(@communityThemesHeader, @communityCount, community, @packages.user.length)
+
     dev = @devPackages.find('.package-card:not(.hidden)').length
-    @devCount.text "#{dev}/#{@packages.dev.length}"
+    @updateSectionCount(@developmentThemesHeader, @devCount, dev, @packages.dev.length)
+
     core = @corePackages.find('.package-card:not(.hidden)').length
-    @coreCount.text "#{core}/#{@packages.core.length}"
+    @updateSectionCount(@coreThemesHeader, @coreCount, core, @packages.core.length)
+
+  resetSectionHasItems: ->
+    @communityThemesHeader.removeClass('has-items')
+    @coreThemesHeader.removeClass('has-items')
+    @developmentThemesHeader.removeClass('has-items')
 
   updateSectionCount: (headerElement, countElement, packageCount, totalCount) ->
     if totalCount is undefined

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -214,10 +214,13 @@ describe 'InstalledPackagesPanel', ->
       waitsFor ->
         @packageManager.getInstalled.callCount is 1 and @panel.communityCount.text().indexOf('…') < 0
 
-    it 'can not collapse and expand any of the sub-sections', ->
-      expect(@panel.find('.sub-section-heading.has-items').length).toBe 0
+    it 'has a count of zero in all headings', ->
+      expect(@panel.find('.section-heading-count').text()).toMatch /^0+$/
+      expect(@panel.find('.sub-section .icon-package').length).toBe 4
+      expect(@panel.find('.sub-section .icon-package.has-items').length).toBe 0
 
-      @panel.find('.sub-section-heading').click()
+    it 'can not collapse and expand any of the sub-sections', ->
+      @panel.find('.sub-section .icon-package').click()
       expect(@panel.find('.sub-section.deprecated-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -159,6 +159,22 @@ describe 'InstalledPackagesPanel', ->
         expect(@panel.deprecatedCount.text().trim()).toBe '0'
         expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 0
 
+  describe 'expanding and collapsing sub-sections', ->
+    beforeEach ->
+      @packageManager = new PackageManager
+      @installed = JSON.parse fs.readFileSync(path.join(__dirname, 'fixtures', 'installed.json'))
+      spyOn(@packageManager, 'getOutdated').andReturn new Promise ->
+      spyOn(@packageManager, 'loadCompatiblePackageVersion').andCallFake ->
+      spyOn(@packageManager, 'getInstalled').andReturn Promise.resolve(@installed)
+      spyOn(atom.packages, 'isDeprecatedPackage').andCallFake =>
+        return true if @installed.user[0].version is '1.0.0'
+        false
+
+      @panel = new InstalledPackagesPanel(@packageManager)
+
+      waitsFor ->
+        @packageManager.getInstalled.callCount is 1 and @panel.communityCount.text().indexOf('…') < 0
+
     it 'collapses and expands a sub-section if its header is clicked', ->
       @panel.find('.sub-section.installed-packages .sub-section-heading').click()
       expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
@@ -171,11 +187,35 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
 
     it 'can collapse and expand any of the sub-sections', ->
-      @panel.find('.sub-section-heading').click()
+      @panel.find('.sub-section-heading.has-items').click()
       expect(@panel.find('.sub-section.deprecated-packages')).toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'
+
+      @panel.find('.sub-section-heading.has-items').click()
+      expect(@panel.find('.sub-section.deprecated-packages')).not.toHaveClass 'collapsed'
+      expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+      expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+      expect(@panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+  describe 'when there are no packages', ->
+    beforeEach ->
+      @packageManager = new PackageManager
+      @installed =
+        dev: []
+        user: []
+        core: []
+      spyOn(@packageManager, 'getOutdated').andReturn new Promise ->
+      spyOn(@packageManager, 'loadCompatiblePackageVersion').andCallFake ->
+      spyOn(@packageManager, 'getInstalled').andReturn Promise.resolve(@installed)
+      @panel = new InstalledPackagesPanel(@packageManager)
+
+      waitsFor ->
+        @packageManager.getInstalled.callCount is 1 and @panel.communityCount.text().indexOf('…') < 0
+
+    it 'can not collapse and expand any of the sub-sections', ->
+      expect(@panel.find('.sub-section-heading.has-items').length).toBe 0
 
       @panel.find('.sub-section-heading').click()
       expect(@panel.find('.sub-section.deprecated-packages')).not.toHaveClass 'collapsed'

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -187,6 +187,8 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
 
     it 'can collapse and expand any of the sub-sections', ->
+      expect(@panel.find('.sub-section-heading.has-items').length).toBe 4
+
       @panel.find('.sub-section-heading.has-items').click()
       expect(@panel.find('.sub-section.deprecated-packages')).toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
@@ -198,6 +200,15 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+    it 'can collapse sub-sections when filtering', ->
+      @panel.filterEditor.getModel().setText('user-')
+      window.advanceClock(@panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
+
+      hasItems = @panel.find('.sub-section-heading.has-items')
+      expect(hasItems.length).toBe 2
+      expect(hasItems.text()).toMatch /Deprecated Packages/
+      expect(hasItems.text()).toMatch /Community Packages/
 
   describe 'when there are no packages', ->
     beforeEach ->
@@ -225,3 +236,11 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
       expect(@panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+    it 'does not allow collapsing on any section when filtering', ->
+      @panel.filterEditor.getModel().setText('user-')
+      window.advanceClock(@panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
+
+      expect(@panel.find('.section-heading-count').text()).toMatch /^(0\/0)+$/
+      expect(@panel.find('.sub-section .icon-package').length).toBe 4
+      expect(@panel.find('.sub-section .icon-paintcan.has-items').length).toBe 0

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -133,21 +133,50 @@ describe "ThemesPanel", ->
         expect(panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
     it 'collapses/expands a sub-section if its header is clicked', ->
-      panel.find('.sub-section.installed-packages .sub-section-heading').click()
+      expect(panel.find('.sub-section-heading.has-items').length).toBe 3
+      panel.find('.sub-section.installed-packages .sub-section-heading.has-items').click()
       expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
 
       expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
 
-      panel.find('.sub-section.installed-packages .sub-section-heading').click()
+      panel.find('.sub-section.installed-packages .sub-section-heading.has-items').click()
       expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
 
     it 'can collapse and expand any of the sub-sections', ->
-      panel.find('.sub-section-heading').click()
+      panel.find('.sub-section-heading.has-items').click()
       expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
       expect(panel.find('.sub-section.dev-packages')).toHaveClass 'collapsed'
 
+      panel.find('.sub-section-heading.has-items').click()
+      expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
+      expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+  describe 'when there are no themes', ->
+    beforeEach ->
+      installed =
+        dev: []
+        user: []
+        core: []
+
+      spyOn(packageManager, 'loadCompatiblePackageVersion').andCallFake ->
+      spyOn(packageManager, 'getInstalled').andReturn Promise.resolve(installed)
+      panel = new ThemesPanel(packageManager)
+
+      waitsFor ->
+        packageManager.getInstalled.callCount is 1 and panel.communityCount.text().indexOf('…') < 0
+
+    afterEach ->
+      atom.themes.deactivateThemes()
+
+    it 'has a count of zero in all headings', ->
+      expect(panel.find('.section-heading-count').text()).toMatch /^0+$/
+      expect(panel.find('.sub-section .icon-paintcan').length).toBe 3
+      expect(panel.find('.sub-section .icon-paintcan.has-items').length).toBe 0
+
+    it 'can collapse and expand any of the sub-sections', ->
       panel.find('.sub-section-heading').click()
       expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -144,6 +144,8 @@ describe "ThemesPanel", ->
       expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
 
     it 'can collapse and expand any of the sub-sections', ->
+      expect(panel.find('.sub-section-heading.has-items').length).toBe 3
+
       panel.find('.sub-section-heading.has-items').click()
       expect(panel.find('.sub-section.installed-packages')).toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).toHaveClass 'collapsed'
@@ -153,6 +155,14 @@ describe "ThemesPanel", ->
       expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+    it 'can collapse sub-sections when filtering', ->
+      panel.filterEditor.getModel().setText('user-')
+      window.advanceClock(panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
+
+      hasItems = panel.find('.sub-section-heading.has-items')
+      expect(hasItems.length).toBe 1
+      expect(hasItems.text()).toMatch /^Community Themes/
 
   describe 'when there are no themes', ->
     beforeEach ->
@@ -181,3 +191,11 @@ describe "ThemesPanel", ->
       expect(panel.find('.sub-section.installed-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.core-packages')).not.toHaveClass 'collapsed'
       expect(panel.find('.sub-section.dev-packages')).not.toHaveClass 'collapsed'
+
+    it 'does not allow collapsing on any section when filtering', ->
+      panel.filterEditor.getModel().setText('user-')
+      window.advanceClock(panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
+
+      expect(panel.find('.section-heading-count').text()).toMatch /^0(0\/0)+$/
+      expect(panel.find('.sub-section .icon-paintcan').length).toBe 3
+      expect(panel.find('.sub-section .icon-paintcan.has-items').length).toBe 0

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -300,18 +300,21 @@
       font-weight: bold;
       line-height: 1;
       -webkit-user-select: none;
-      cursor: pointer;
 
-      &:after {
-        .icon(16px);
-        content: @fold;
-        position: absolute;
-        right: 0;
-        color: @text-color-subtle;
-      }
+      &.has-items {
+        cursor: pointer;
 
-      &:hover:after {
-        color: @text-color-highlight;
+        &:after {
+          .icon(16px);
+          content: @fold;
+          position: absolute;
+          right: 0;
+          color: @text-color-subtle;
+        }
+
+        &:hover:after {
+          color: @text-color-highlight;
+        }
       }
     }
 


### PR DESCRIPTION
If there are no packages or themes in a section, don't show it as collapsible and don't do anything if you click on it.

Packages before:
<img width="784" alt="screen shot 2015-10-25 at 8 18 31 pm" src="https://cloud.githubusercontent.com/assets/18362/10714894/897498ec-7b56-11e5-87a6-74f2b10da402.png">

Packages after:
<img width="804" alt="screen shot 2015-10-25 at 8 18 05 pm" src="https://cloud.githubusercontent.com/assets/18362/10714893/8399e8aa-7b56-11e5-9e87-b34f7f044aee.png">

Themes before:
<img width="827" alt="screen shot 2015-10-25 at 8 19 10 pm" src="https://cloud.githubusercontent.com/assets/18362/10714897/ac9f6022-7b56-11e5-95b5-d12819929c5a.png">

Themes after:
<img width="779" alt="screen shot 2015-10-25 at 8 17 49 pm" src="https://cloud.githubusercontent.com/assets/18362/10714898/b287231c-7b56-11e5-8b10-e9a20b70c3fb.png">

Fixes #636