### PR TITLE
Avoid using snippets via atom.config

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -76,7 +76,8 @@ module.exports =
       console.log error.message, error.stack
 
   consumeSnippets: (snippets) ->
-    SnippetsProvider.getSnippets = snippets.getUnparsedSnippets.bind(snippets)
+    if typeof snippets.getUnparsedSnippets is "function"
+      SnippetsProvider.getSnippets = snippets.getUnparsedSnippets.bind(snippets)
 
   showDeprecatedNotification: (packages) ->
     deprecatedPackages = packages.user.filter ({name, version}) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,11 +1,15 @@
 SettingsView = null
 settingsView = null
 
+SnippetsProvider =
+  getSnippets: -> atom.config.scopedSettingsStore.propertySets
+
 configUri = 'atom://config'
 uriRegex = /config\/([a-z]+)\/?([a-zA-Z0-9_-]+)?/i
 
 createSettingsView = (params) ->
   SettingsView ?= require './settings-view'
+  params.snippetsProvider ?= SnippetsProvider
   settingsView = new SettingsView(params)
 
 openPanel = (panelName, uri) ->
@@ -70,6 +74,9 @@ module.exports =
         @showDeprecatedNotification(allPackages)
     .catch (error) ->
       console.log error.message, error.stack
+
+  consumeSnippets: (snippets) ->
+    SnippetsProvider.getSnippets = snippets.getUnparsedSnippets.bind(snippets)
 
   showDeprecatedNotification: (packages) ->
     deprecatedPackages = packages.user.filter ({name, version}) ->

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -54,7 +54,7 @@ class PackageDetailView extends ScrollView
 
       @div outlet: 'sections'
 
-  initialize: (@pack, @packageManager) ->
+  initialize: (@pack, @packageManager, @snippetsProvider) ->
     super
     @disposables = new CompositeDisposable()
     @loadPackage()
@@ -147,7 +147,7 @@ class PackageDetailView extends ScrollView
 
       if @pack.path
         @sections.append(new PackageGrammarsView(@pack.path))
-        @sections.append(new PackageSnippetsView(@pack.path))
+        @sections.append(new PackageSnippetsView(@pack.path, @snippetsProvider))
 
       @startupTime.html("This #{@type} added <span class='highlight'>#{@getStartupTime()}ms</span> to startup time.")
     else

--- a/lib/package-snippets-view.coffee
+++ b/lib/package-snippets-view.coffee
@@ -5,7 +5,6 @@ _ = require 'underscore-plus'
 # View to display the snippets that a package has registered.
 module.exports =
 class PackageSnippetsView extends View
-
   @content: ->
     @section class: 'section', =>
       @div class: 'section-heading icon icon-code', 'Snippets'
@@ -17,18 +16,17 @@ class PackageSnippetsView extends View
             @th 'Body'
         @tbody outlet: 'snippets'
 
-  initialize: (packagePath) ->
+  initialize: (packagePath, @snippetsProvider) ->
     @packagePath = path.join(packagePath, path.sep)
     @hide()
     @addSnippets()
 
   getSnippetProperties: ->
     packageProperties = {}
-    for {name, properties} in atom.config.scopedSettingsStore.propertySets
+    for {name, properties} in @snippetsProvider.getSnippets()
       continue unless name?.indexOf?(@packagePath) is 0
       for name, snippet of properties.snippets ? {} when snippet?
         packageProperties[name] ?= snippet
-
 
     _.values(packageProperties).sort (snippet1, snippet2) ->
       prefix1 = snippet1.prefix ? ''
@@ -49,16 +47,17 @@ class PackageSnippetsView extends View
     @getSnippets (snippets) =>
       @snippets.empty()
 
-      for {bodyText, name, prefix} in snippets
+      for {body, bodyText, name, prefix} in snippets
         name ?= ''
         prefix ?= ''
-        bodyText = bodyText?.replace(/\t/g, '\\t').replace(/\n/g, '\\n') ? ''
+        body ?= bodyText
+        body = body?.replace(/\t/g, '\\t').replace(/\n/g, '\\n') ? ''
 
         @snippets.append $$$ ->
           @tr =>
             @td class: 'snippet-prefix', prefix
             @td name
-            @td class: 'snippet-body', bodyText
+            @td class: 'snippet-body', body
 
       if @snippets.children().length > 0
         @show()

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -35,7 +35,7 @@ class SettingsView extends ScrollView
       # package card. Phew!
       @div class: 'panels', tabindex: -1, outlet: 'panels'
 
-  initialize: ({@uri, activePanelName}={}) ->
+  initialize: ({@uri, @snippetsProvider, activePanelName}={}) ->
     super
     @packageManager = new PackageManager()
 
@@ -136,7 +136,7 @@ class SettingsView extends ScrollView
           unless options.pack.metadata
             metadata = _.clone(options.pack)
             options.pack.metadata = metadata
-          new PackageDetailView(options.pack, @packageManager)
+          new PackageDetailView(options.pack, @packageManager, @snippetsProvider)
 
       if callback
         panel = callback()

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "snippets": {
+      "versions": {
+        "0.1.0": "consumeSnippets"
+      }
     }
   },
   "devDependencies": {

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -36,6 +36,8 @@ describe "PackageDetailView", ->
 
     waitsForPromise ->
       atom.packages.activatePackage('snippets').then (p) ->
+        return unless p.mainModule.provideSnippets().getUnparsedSnippets?
+
         SnippetsProvider =
           getSnippets: -> p.mainModule.provideSnippets().getUnparsedSnippets()
 

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -3,6 +3,8 @@ PackageDetailView = require '../lib/package-detail-view'
 PackageManager = require '../lib/package-manager'
 PackageKeymapView = require '../lib/package-keymap-view'
 _ = require 'underscore-plus'
+SnippetsProvider =
+  getSnippets: -> atom.config.scopedSettingsStore.propertySets
 
 describe "PackageDetailView", ->
   beforeEach ->
@@ -16,7 +18,7 @@ describe "PackageDetailView", ->
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')
-      view = new PackageDetailView(pack, new PackageManager())
+      view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
       settingsPanels = view.find('.package-grammars .settings-panel')
 
     waitsFor ->
@@ -31,12 +33,10 @@ describe "PackageDetailView", ->
 
   it "displays the snippets registered by the package", ->
     snippetsTable = null
-    snippetsProvider =
-      getSnippets: -> atom.config.scopedSettingsStore.propertySets
 
     waitsForPromise ->
       atom.packages.activatePackage('snippets').then (p) ->
-        snippetsProvider =
+        SnippetsProvider =
           getSnippets: -> p.mainModule.provideSnippets().getUnparsedSnippets()
 
     waitsForPromise ->
@@ -44,7 +44,7 @@ describe "PackageDetailView", ->
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')
-      view = new PackageDetailView(pack, new PackageManager(), snippetsProvider)
+      view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
       snippetsTable = view.find('.package-snippets-table tbody')
 
     waitsFor ->
@@ -67,7 +67,7 @@ describe "PackageDetailView", ->
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')
-      view = new PackageDetailView(pack, new PackageManager())
+      view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
       keybindingsTable = view.find('.package-keymap-table tbody')
       expect(keybindingsTable.children().length).toBe 1
 
@@ -130,7 +130,7 @@ describe "PackageDetailView", ->
       runs ->
         expect(atom.packages.isPackageActive('status-bar')).toBe(true)
         pack = atom.packages.getLoadedPackage('status-bar')
-        view = new PackageDetailView(pack, new PackageManager())
+        view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
         packageCard = view.find('.package-card')
 
       runs ->
@@ -146,7 +146,7 @@ describe "PackageDetailView", ->
       atom.packages.loadPackage('status-bar')
       expect(atom.packages.isPackageActive('status-bar')).toBe(false)
       pack = atom.packages.getLoadedPackage('status-bar')
-      view = new PackageDetailView(pack, new PackageManager())
+      view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
       packageCard = view.find('.package-card')
 
       # Trigger observeDisabledPackages() here
@@ -166,7 +166,7 @@ describe "PackageDetailView", ->
         expect(atom.config.get('package-with-config.setting')).toBe undefined
 
         pack = atom.packages.getLoadedPackage('package-with-config')
-        view = new PackageDetailView(pack, new PackageManager())
+        view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
 
         expect(atom.config.get('package-with-config.setting')).toBe 'something'
 
@@ -183,6 +183,6 @@ describe "PackageDetailView", ->
         pack = atom.packages.getLoadedPackage('package-with-readme')
         expect(pack.metadata.readme).toBe normalizePackageDataReadmeError
 
-        view = new PackageDetailView(pack, new PackageManager())
+        view = new PackageDetailView(pack, new PackageManager(), SnippetsProvider)
         expect(view.sections.find('.package-readme').text()).not.toBe normalizePackageDataReadmeError
         expect(view.sections.find('.package-readme').text().trim()).toBe 'I am a Readme!'

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -31,16 +31,20 @@ describe "PackageDetailView", ->
 
   it "displays the snippets registered by the package", ->
     snippetsTable = null
+    snippetsProvider =
+      getSnippets: -> atom.config.scopedSettingsStore.propertySets
 
     waitsForPromise ->
-      atom.packages.activatePackage('snippets')
+      atom.packages.activatePackage('snippets').then (p) ->
+        snippetsProvider =
+          getSnippets: -> p.mainModule.provideSnippets().getUnparsedSnippets()
 
     waitsForPromise ->
       atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')
-      view = new PackageDetailView(pack, new PackageManager())
+      view = new PackageDetailView(pack, new PackageManager(), snippetsProvider)
       snippetsTable = view.find('.package-snippets-table tbody')
 
     waitsFor ->

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -4,6 +4,8 @@ path = require 'path'
 PackageDetailView = require '../lib/package-detail-view'
 PackageManager = require '../lib/package-manager'
 AtomIoClient = require '../lib/atom-io-client'
+SnippetsProvider =
+  getSnippets: -> {}
 
 describe "PackageDetailView", ->
   packageManager = null
@@ -23,20 +25,20 @@ describe "PackageDetailView", ->
       packageData = require(path.join(__dirname, 'fixtures', 'package-with-readme', 'package.json'))
       packageData.readme = fs.readFileSync(path.join(__dirname, 'fixtures', 'package-with-readme', 'README.md'), 'utf8')
       cb(null, packageData)
-    view = new PackageDetailView({name: 'package-with-readme'}, packageManager)
+    view = new PackageDetailView({name: 'package-with-readme'}, packageManager, SnippetsProvider)
     view.beforeShow(opts)
 
   it "renders a package when provided in `initialize`", ->
     atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-config'))
     pack = atom.packages.getLoadedPackage('package-with-config')
-    view = new PackageDetailView(pack, packageManager)
+    view = new PackageDetailView(pack, packageManager, SnippetsProvider)
 
     # Perhaps there are more things to assert here.
     expect(view.title.text()).toBe('Package With Config')
 
   it "does not call the atom.io api for package metadata when present", ->
     packageManager.client = createClientSpy()
-    view = new PackageDetailView({name: 'package-with-config'}, packageManager)
+    view = new PackageDetailView({name: 'package-with-config'}, packageManager, SnippetsProvider)
 
     # PackageCard is a subview, and it calls AtomIoClient::package once to load
     # metadata from the cache.
@@ -54,7 +56,7 @@ describe "PackageDetailView", ->
       error = new Error('API error')
       cb(error, null)
 
-    view = new PackageDetailView({name: 'nonexistent-package'}, packageManager)
+    view = new PackageDetailView({name: 'nonexistent-package'}, packageManager, SnippetsProvider)
 
     expect(view.errorMessage[0].classList.contains('hidden')).not.toBe(true)
     expect(view.loadingMessage[0].classList.contains('hidden')).toBe(true)
@@ -68,7 +70,7 @@ describe "PackageDetailView", ->
       # and there's no connectivity
       cb(null, {})
 
-    view = new PackageDetailView({name: 'some-package'}, packageManager)
+    view = new PackageDetailView({name: 'some-package'}, packageManager, SnippetsProvider)
 
     expect(AtomIoClient.prototype.fetchFromCache).toHaveBeenCalled()
     expect(AtomIoClient.prototype.request).not.toHaveBeenCalled()

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -1,12 +1,14 @@
 path = require 'path'
 {$, $$} = require 'atom-space-pen-views'
 SettingsView = require '../lib/settings-view'
+SnippetsProvider =
+  getSnippets: -> {}
 
 describe "SettingsView", ->
   settingsView = null
 
   beforeEach ->
-    settingsView = new SettingsView
+    settingsView = new SettingsView({snippetsProvider: SnippetsProvider})
     spyOn(settingsView, "initializePanels").andCallThrough()
     window.advanceClock(10000)
     waitsFor ->


### PR DESCRIPTION
This PR introduces a backward-compatible change to use in conjunction with https://github.com/atom/snippets/pull/182, since we've stopped using `atom.config` as a storage for snippets.

/cc: @nathansobo 