### PR TITLE
add optional sub-section heading if the settings group has an explicit title

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -292,6 +292,6 @@ appendObject = (namespace, name, value) ->
   title = getSettingTitle(keyPath, name)
   @div class: 'sub-section', =>
     @div class: 'sub-section-heading', title
-    @div class: 'section-body', =>
+    @div class: 'sub-section-body', =>
       for key in _.keys(value).sort()
         appendSetting.call(this, namespace, "#{name}.#{key}", value[key])

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -290,5 +290,6 @@ appendObject = (namespace, name, value) ->
   title = getSettingTitle(keyPath, name)
   @div class: 'sub-section', =>
     @div class: 'sub-section-heading', title
-    for key in _.keys(value).sort()
-      appendSetting.call(this, namespace, "#{name}.#{key}", value[key])
+    @div class: 'section-body', =>
+      for key in _.keys(value).sort()
+        appendSetting.call(this, namespace, "#{name}.#{key}", value[key])

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -286,6 +286,8 @@ appendArray = (namespace, name, value) ->
       @subview keyPath.replace(/\./g, ''), new TextEditorView(mini: true, attributes: {id: keyPath, type: 'array'})
 
 appendObject = (namespace, name, value) ->
+  return unless _.keys(value).length
+
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
   @div class: 'sub-section', =>

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -286,5 +286,9 @@ appendArray = (namespace, name, value) ->
       @subview keyPath.replace(/\./g, ''), new TextEditorView(mini: true, attributes: {id: keyPath, type: 'array'})
 
 appendObject = (namespace, name, value) ->
-  for key in _.keys(value).sort()
-    appendSetting.call(this, namespace, "#{name}.#{key}", value[key])
+  keyPath = "#{namespace}.#{name}"
+  title = getSettingTitle(keyPath, name)
+  @div class: 'sub-section', =>
+    @div class: 'sub-section-heading', title
+    for key in _.keys(value).sort()
+      appendSetting.call(this, namespace, "#{name}.#{key}", value[key])

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -81,17 +81,21 @@ describe "SettingsPanel", ->
       settingsPanel = new SettingsPanel('foo', {includeTitle: false})
 
     it 'ensures that only grouped settings have a group title', ->
-      expect(settingsPanel.find('.section-body')).toHaveLength 1
+      expect(settingsPanel.find('.section-container > .section-body')).toHaveLength 1
       sectionBody = settingsPanel.find('.section-body:first')
       expect(sectionBody.find('>.control-group')).toHaveLength 3
       firstControlGroup = sectionBody.find('>.control-group:nth(0)')
       expect(firstControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
       expect(firstControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Bar group'
-      expect(firstControlGroup.find('.sub-section .control-group')).toHaveLength 1
+      expect(firstControlGroup.find('.sub-section .section-body')).toHaveLength 1
+      subsectionBody = firstControlGroup.find('.sub-section .section-body:first')
+      expect(subsectionBody.find('.control-group')).toHaveLength 1
       secondControlGroup = sectionBody.find('>.control-group:nth(1)')
       expect(secondControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
       expect(secondControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Baz Group'
-      expect(secondControlGroup.find('.sub-section .control-group')).toHaveLength 1
+      expect(secondControlGroup.find('.sub-section .section-body')).toHaveLength 1
+      subsectionBody = secondControlGroup.find('.sub-section .section-body:first')
+      expect(subsectionBody.find('.control-group')).toHaveLength 1
       thirdControlGroup = sectionBody.find('>.control-group:nth(2)')
       expect(thirdControlGroup.find('.sub-section')).toHaveLength 0
       expect(thirdControlGroup.find('.sub-section-heading')).toHaveLength 0

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -50,3 +50,48 @@ describe "SettingsPanel", ->
       sortedSettings = settingsPanel.sortSettings("foo", null)
       expect(sortedSettings).not.toBeNull
       expect(_.size(sortedSettings)).toBe 0
+
+  describe 'grouped settings', ->
+    beforeEach ->
+      config =
+        type: 'object'
+        properties:
+          barGroup:
+            type: 'object'
+            title: 'Bar group'
+            properties:
+              bar:
+                title: 'Bar'
+                description: 'The bar setting'
+                type: 'boolean'
+                default: false
+          bazGroup:
+            type: 'object'
+            properties:
+              baz:
+                title: 'Baz'
+                description: 'The baz setting'
+                type: 'boolean'
+                default: false
+          zing:
+            type: 'string'
+            default: ''
+      atom.config.setSchema('foo', config)
+      expect(_.size(atom.config.get('foo'))).toBe 3
+      settingsPanel = new SettingsPanel('foo', {includeTitle: false})
+
+    it 'ensures that only grouped settings have a group title', ->
+      expect(settingsPanel.find('.section-body')).toHaveLength 1
+      sectionBody = settingsPanel.find('.section-body:first')
+      expect(sectionBody.find('>.control-group')).toHaveLength 3
+      firstControlGroup = sectionBody.find('>.control-group:nth(0)')
+      expect(firstControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
+      expect(firstControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Bar group'
+      expect(firstControlGroup.find('.sub-section .control-group')).toHaveLength 1
+      secondControlGroup = sectionBody.find('>.control-group:nth(1)')
+      expect(secondControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
+      expect(secondControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Baz Group'
+      expect(secondControlGroup.find('.sub-section .control-group')).toHaveLength 1
+      thirdControlGroup = sectionBody.find('>.control-group:nth(2)')
+      expect(thirdControlGroup.find('.sub-section')).toHaveLength 0
+      expect(thirdControlGroup.find('.sub-section-heading')).toHaveLength 0

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -87,14 +87,14 @@ describe "SettingsPanel", ->
       firstControlGroup = sectionBody.find('>.control-group:nth(0)')
       expect(firstControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
       expect(firstControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Bar group'
-      expect(firstControlGroup.find('.sub-section .section-body')).toHaveLength 1
-      subsectionBody = firstControlGroup.find('.sub-section .section-body:first')
+      expect(firstControlGroup.find('.sub-section .sub-section-body')).toHaveLength 1
+      subsectionBody = firstControlGroup.find('.sub-section .sub-section-body:first')
       expect(subsectionBody.find('.control-group')).toHaveLength 1
       secondControlGroup = sectionBody.find('>.control-group:nth(1)')
       expect(secondControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
       expect(secondControlGroup.find('.sub-section .sub-section-heading:first').text()).toBe 'Baz Group'
-      expect(secondControlGroup.find('.sub-section .section-body')).toHaveLength 1
-      subsectionBody = secondControlGroup.find('.sub-section .section-body:first')
+      expect(secondControlGroup.find('.sub-section .sub-section-body')).toHaveLength 1
+      subsectionBody = secondControlGroup.find('.sub-section .sub-section-body:first')
       expect(subsectionBody.find('.control-group')).toHaveLength 1
       thirdControlGroup = sectionBody.find('>.control-group:nth(2)')
       expect(thirdControlGroup.find('.sub-section')).toHaveLength 0

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -318,6 +318,10 @@
       }
     }
 
+    .sub-section-body {
+      margin-top: 20px;
+    }
+
     &.collapsed {
       .sub-section-heading:after {
         content: @unfold;


### PR DESCRIPTION
While package settings can have grouped options (see the below example) they are not visually separated. This patch adds a `sub-section-headline` if the group has an explicit `title` set. The visual grouping together with a reasonable title provides a better overview over the settings of a package if the number of options increases.

I didn't use `getSettingTitle` since that would introduce the new headlines where none have been before and I wanted to keep the changes to existing settings minimal.

    config:
      groupA:
        type: 'object'
        title: 'Options related to A'
        properties:
          optionA:
            type: 'string'
            default: 'default A'
          optionB:
            type: 'boolean'
            default: false
      groupB:
        type: 'object'
        title: 'Options related to B'
        properties:
          optionC:
            type: 'string'
            default: ''
          optionD:
            type: 'boolean'
            default: false

Since I haven't contributed to atom packages much yet I am not sure if the added html structure makes sense here or should not be changed in that way?