### PR TITLE
align search and error messages

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -570,13 +570,12 @@
       }
     }
 
-    .search-message,
-    .featured-message {
-      margin: @component-padding @component-padding 0 @component-padding;
+    .search-message {
+      margin: @component-padding 0 0;
     }
 
     .error-message {
-      padding: @component-padding;
+      padding: @component-padding 0;
     }
 
   }


### PR DESCRIPTION
<b>Before:</b>
![screen shot 2015-11-26 at 23 11 33](https://cloud.githubusercontent.com/assets/7414026/11430930/c8fb5420-9496-11e5-9197-0f05762056c6.png)
![screen shot 2015-11-26 at 23 21 20](https://cloud.githubusercontent.com/assets/7414026/11430931/c9e2baf4-9496-11e5-9164-050486681420.png)

<b>After:</b>
![screen shot 2015-11-26 at 23 23 28](https://cloud.githubusercontent.com/assets/7414026/11430934/d211f47e-9496-11e5-94dd-a0eccdcf8956.png)
