### PR TITLE
Ask for confirmation before uninstalling a package

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -144,7 +144,15 @@ class PackageCard extends View
 
     @uninstallButton.on 'click', (event) =>
       event.stopPropagation()
-      @uninstall()
+      if @uninstallButton.hasClass('confirm-uninstall')
+        @uninstallButton.removeClass('confirm-uninstall')
+        @uninstallButton.removeClass('btn-error')
+        @uninstallButton.text('Uninstall')
+        @uninstall()
+      else
+        @uninstallButton.addClass('confirm-uninstall')
+        @uninstallButton.addClass('btn-error')
+        @uninstallButton.text('Yes, uninstall')
 
     @installAlternativeButton.on 'click', (event) =>
       event.stopPropagation()

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -226,7 +226,7 @@ describe "PackageCard", ->
       runs ->
         expect(atom.packages.isPackageDisabled('package-with-config')).toBe true
 
-    it "is uninstalled when the uninstallButton is clicked", ->
+    it "asks for confirmation when the uninstallButton is clicked", ->
       setPackageStatusSpies {installed: true, disabled: false}
 
       [installCallback, uninstallCallback] = []
@@ -245,6 +245,39 @@ describe "PackageCard", ->
       jasmine.attachToDOM(card[0])
 
       expect(card.uninstallButton).toBeVisible()
+      expect(card.enablementButton).toBeVisible()
+      card.uninstallButton.click()
+
+      expect(card.uninstallButton[0].disabled).toBe false
+      expect(card.enablementButton[0].disabled).toBe false
+      expect(card.uninstallButton).toHaveClass('confirm-uninstall')
+
+      expect(packageManager.uninstall).not.toHaveBeenCalled()
+
+    it "is uninstalled when the uninstallButton is clicked twice to confirm", ->
+      setPackageStatusSpies {installed: true, disabled: false}
+
+      [installCallback, uninstallCallback] = []
+      packageManager.runCommand.andCallFake (args, callback) ->
+        if args[0] is 'install'
+          installCallback = callback
+        else if args[0] is 'uninstall'
+          uninstallCallback = callback
+        onWillThrowError: ->
+
+      spyOn(packageManager, 'install').andCallThrough()
+      spyOn(packageManager, 'uninstall').andCallThrough()
+
+      pack = atom.packages.getLoadedPackage('package-with-config')
+      card = new PackageCard(pack, packageManager)
+      jasmine.attachToDOM(card[0])
+
+      expect(card.uninstallButton).toBeVisible()
+      expect(card.enablementButton).toBeVisible()
+      card.uninstallButton.click()
+
+      expect(card.uninstallButton).toBeVisible()
+      expect(card.uninstallButton).toHaveClass('confirm-uninstall')
       expect(card.enablementButton).toBeVisible()
       card.uninstallButton.click()
 


### PR DESCRIPTION
Ask the user for confirmation before uninstalling a package:

![Asking for confirmation](https://cloud.githubusercontent.com/assets/1190974/11971282/5a868130-a919-11e5-9376-135170c2baf5.gif)

Fixes #699

It probably needs a way to undo the operation - ie, if you clicked by mistake, the button will persist that way.

A timeout? How long?
Another 'Cancel' button? Uuggh :hankey: 