### PR TITLE
Always show view code button

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -152,9 +152,6 @@ class PackageDetailView extends ScrollView
       @startupTime.html("This #{@type} added <span class='highlight'>#{@getStartupTime()}ms</span> to startup time.")
     else
       @startupTime.hide()
-      @openButton.hide()
-
-    @openButton.hide() if atom.packages.isBundledPackage(@pack.name)
 
     @renderReadme()
 


### PR DESCRIPTION
If atom is meant to be a hackable editor why would you hide the button to edit the source code?
There's a bug report by someone else here https://github.com/atom/settings-view/issues/617.