### PR TITLE
Add collapsable section for option groups

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -1,11 +1,12 @@
 {CompositeDisposable} = require 'atom'
 {$, $$, TextEditorView, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
+CollapsibleSectionPanel = require './collapsible-section-panel'
 
 {getSettingDescription} = require './rich-description'
 
 module.exports =
-class SettingsPanel extends View
+class SettingsPanel extends CollapsibleSectionPanel
   @content: ->
     @section class: 'section settings-panel'
 
@@ -39,6 +40,8 @@ class SettingsPanel extends View
     @bindInputFields()
     @bindSelectFields()
     @bindEditors()
+    @handleEvents()
+
 
   dispose: ->
     @disposables.dispose()
@@ -290,8 +293,10 @@ appendObject = (namespace, name, value) ->
 
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
-  @div class: 'sub-section', =>
-    @div class: 'sub-section-heading', title
+
+  @section class: 'sub-section', =>
+    @h3 class: 'sub-section-heading has-items', =>
+      @text title
     @div class: 'sub-section-body', =>
       for key in _.keys(value).sort()
         appendSetting.call(this, namespace, "#{name}.#{key}", value[key])

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -70,7 +70,7 @@ class SettingsPanel extends CollapsibleSectionPanel
             appendSetting.call(this, namespace, name, settings[name])
 
   sortSettings: (namespace, settings) ->
-    _.chain(settings).keys().sortBy((name) -> name).sortBy((name) -> atom.config.getSchema("#{namespace}.#{name}")?.order).value()
+    sortSettings(namespace, settings)
 
   bindInputFields: ->
     @find('input[id]').toArray().forEach (input) =>
@@ -186,6 +186,9 @@ isEditableArray = (array) ->
     return false unless _.isString(item)
   true
 
+sortSettings = (namespace, settings) ->
+  _.chain(settings).keys().sortBy((name) -> name).sortBy((name) -> atom.config.getSchema("#{namespace}.#{name}")?.order).value()
+
 appendSetting = (namespace, name, value) ->
   if namespace is 'core'
     return if name is 'themes' # Handled in the Themes panel
@@ -299,5 +302,6 @@ appendObject = (namespace, name, value) ->
     @h3 class: 'sub-section-heading has-items', =>
       @text title
     @div class: 'sub-section-body', =>
-      for key in _.keys(value).sort()
+      sortedSettings = sortSettings(keyPath, value)
+      for key in sortedSettings
         appendSetting.call(this, namespace, "#{name}.#{key}", value[key])

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -293,8 +293,9 @@ appendObject = (namespace, name, value) ->
 
   keyPath = "#{namespace}.#{name}"
   title = getSettingTitle(keyPath, name)
-
-  @section class: 'sub-section', =>
+  schema = atom.config.getSchema(keyPath)
+  isCollapsed = schema.collapsed is true
+  @section class: "sub-section#{if isCollapsed then ' collapsed' else ''}", =>
     @h3 class: 'sub-section-heading has-items', =>
       @text title
     @div class: 'sub-section-body', =>

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -67,6 +67,7 @@ describe "SettingsPanel", ->
                 default: false
           bazGroup:
             type: 'object'
+            collapsed: true
             properties:
               baz:
                 title: 'Baz'
@@ -99,3 +100,18 @@ describe "SettingsPanel", ->
       thirdControlGroup = sectionBody.find('>.control-group:nth(2)')
       expect(thirdControlGroup.find('.sub-section')).toHaveLength 0
       expect(thirdControlGroup.find('.sub-section-heading')).toHaveLength 0
+
+    it 'ensures grouped settings are collapsable', ->
+      expect(settingsPanel.find('.section-container > .section-body')).toHaveLength 1
+      sectionBody = settingsPanel.find('.section-body:first')
+      expect(sectionBody.find('>.control-group')).toHaveLength 3
+      firstControlGroup = sectionBody.find('>.control-group:nth(0)')
+      # Bar group
+      expect(firstControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
+      expect(firstControlGroup.find('.sub-section .sub-section-heading:first').hasClass('has-items')).toBe true
+      # Baz Group
+      secondControlGroup = sectionBody.find('>.control-group:nth(1)')
+      expect(secondControlGroup.find('.sub-section .sub-section-heading')).toHaveLength 1
+      expect(secondControlGroup.find('.sub-section .sub-section-heading:first').hasClass('has-items')).toBe true
+      # Should be already collapsed
+      expect(secondControlGroup.find('.sub-section .sub-section-heading:first').parent().hasClass('collapsed')).toBe true

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -326,8 +326,8 @@
       .sub-section-heading:after {
         content: @unfold;
       }
-
-      .package-container .package-card {
+      .package-container .package-card,
+      .sub-section-body .control-group {
         display: none !important;
       }
     }


### PR DESCRIPTION
### About

For a package that has a lot of options, such as [`Atom Beautify`](https://github.com/Glavin001/atom-beautify), it appears to be very difficult for users to find the options they want.

I propose that the groups be collapsable.

#### Features

- [x] Groups of options are collapsable
  - Open by default
- [x] Force group to be collapsed

```javascript
{
  group1: {
    title: 'Group 1',
    type: 'object',
    collapsed: true
  }
}
```

- ~~"Collapse all sections" button (like the styleguide has)~~
  - ~~Only show "Collapse All" button when there are collapsable sub-sections~~

### Screenshots

Open `Group 1`:
![image](https://cloud.githubusercontent.com/assets/1885333/13205898/2c60c222-d8c9-11e5-80b3-0a59342e4da2.png)

Collapsed `Group 1`:
![image](https://cloud.githubusercontent.com/assets/1885333/13205899/34ce2634-d8c9-11e5-9834-cdd784f4d3b1.png)


### Options used

```
  _group1: {
    title: 'Group 1',
    type: 'object',
    order: 1,
    properties: {
      prop1: {
        type: 'integer',
        title: 'Prop1',
        default: 1
      },
      prop2: {
        title: 'Prop2'
        default: 1
      },
    },
  },
  _group2: {
    title: 'Group 2',
    type: 'object',
    order: 2,
    properties: {
      prop1: {
        type: 'integer',
        title: 'Prop1',
        default: 1
      },
      prop2: {
        title: 'Prop2'
        default: 1
      },
    },
  }
```



/cc https://github.com/atom/settings-view/issues/597 https://github.com/Glavin001/atom-beautify/issues/620 https://github.com/Glavin001/atom-beautify/issues/405