### PR TITLE
Move away from deprecated Electron require syntax

### DIFF
--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -51,7 +51,9 @@ class InstallPanel extends ScrollView
     @client = @packageManager.getClient()
     @atomIoURL = 'https://atom.io/packages'
     @openAtomIo.on 'click', =>
-      require('shell').openExternal(@atomIoURL)
+      # TODO: Remove the catch once Atom 1.7.0 is released
+      try {shell} = require 'electron' catch then shell = require 'shell'
+      shell.openExternal(@atomIoURL)
       false
 
     @searchMessage.hide()

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -1,7 +1,8 @@
 _ = require 'underscore-plus'
 {View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
-shell = require 'shell'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 marked = null
 {ownerFromRepository} = require './utils'
 

--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -3,7 +3,8 @@ url = require 'url'
 
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
-shell = require 'shell'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 {ScrollView} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 


### PR DESCRIPTION
Required for atom/atom#10983.