### PR TITLE
Keep Syntax or UI when parts of the actual theme name

### DIFF
--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -270,7 +270,7 @@ class ThemesPanel extends CollapsibleSectionPanel
 
   # Get a human readable title for the given theme name.
   getThemeTitle: (themeName='') ->
-    title = themeName.replace(/-(ui|syntax)/g, '').replace(/-theme$/g, '')
+    title = themeName.replace(/-(ui|syntax)$/g, '').replace(/-theme$/g, '')
     _.undasherize(_.uncamelcase(title))
 
   createPackageCard: (pack) =>

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -117,7 +117,7 @@ describe "ThemesPanel", ->
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
         installCallback = callback
         onWillThrowError: ->
-      spyOn(atom.packages, 'loadPackage').andCallFake (name) =>
+      spyOn(atom.packages, 'loadPackage').andCallFake (name)
         installed.user.push {name, theme: 'ui'}
 
       expect(panel.communityCount.text().trim()).toBe '1'
@@ -137,7 +137,7 @@ describe "ThemesPanel", ->
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
         installCallback = callback
         onWillThrowError: ->
-      spyOn(atom.packages, 'loadPackage').andCallFake (name) =>
+      spyOn(atom.packages, 'loadPackage').andCallFake (name)
         installed.user.push {name, theme: 'syntax'}
 
       packageManager.install({name: 'syntax-theme-with-config', theme: 'syntax'})
@@ -145,7 +145,7 @@ describe "ThemesPanel", ->
 
       advanceClock ThemesPanel.loadPackagesDelay
       waits 1
-      runs ->      
+      runs ->
         expect(panel.find('option[value="atom-dark-syntax"]').text()).toBe 'Atom Dark'
         expect(panel.find('option[value="syntax-theme-with-config"]').text()).toBe 'Syntax Theme With Config'
 

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -132,6 +132,23 @@ describe "ThemesPanel", ->
         expect(panel.communityCount.text().trim()).toBe '2'
         expect(panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
+    it 'displays theme titles correctly', ->
+      [installCallback] = []
+      spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
+        installCallback = callback
+        onWillThrowError: ->
+      spyOn(atom.packages, 'loadPackage').andCallFake (name) =>
+        installed.user.push {name, theme: 'syntax'}
+
+      packageManager.install({name: 'syntax-theme-with-config', theme: 'syntax'})
+      installCallback(0, '', '')
+
+      advanceClock ThemesPanel.loadPackagesDelay
+      waits 1
+      runs ->      
+        expect(panel.find('option[value="atom-dark-syntax"]').text()).toBe 'Atom Dark'
+        expect(panel.find('option[value="syntax-theme-with-config"]').text()).toBe 'Syntax Theme With Config'
+
     it 'collapses/expands a sub-section if its header is clicked', ->
       expect(panel.find('.sub-section-heading.has-items').length).toBe 3
       panel.find('.sub-section.installed-packages .sub-section-heading.has-items').click()

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -117,7 +117,7 @@ describe "ThemesPanel", ->
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
         installCallback = callback
         onWillThrowError: ->
-      spyOn(atom.packages, 'loadPackage').andCallFake (name)
+      spyOn(atom.packages, 'loadPackage').andCallFake (name) =>
         installed.user.push {name, theme: 'ui'}
 
       expect(panel.communityCount.text().trim()).toBe '1'
@@ -137,7 +137,7 @@ describe "ThemesPanel", ->
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
         installCallback = callback
         onWillThrowError: ->
-      spyOn(atom.packages, 'loadPackage').andCallFake (name)
+      spyOn(atom.packages, 'loadPackage').andCallFake (name) =>
         installed.user.push {name, theme: 'syntax'}
 
       packageManager.install({name: 'syntax-theme-with-config', theme: 'syntax'})


### PR DESCRIPTION
Avoids removing Syntax or UI when they are an actual part of the theme name.

For example: https://atom.io/themes/no-syntax-highlighting-syntax
