### PR TITLE
Sort packages search

### DIFF
--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -159,6 +159,8 @@ class InstallPanel extends ScrollView
 
     opts = {}
     opts[@searchType] = true
+    opts['sortBy'] = "downloads"
+
     @packageManager.search(query, opts)
       .then (packages=[]) =>
         if packages.length is 0

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -163,18 +163,35 @@ class InstallPanel extends ScrollView
 
     @packageManager.search(query, opts)
       .then (packages=[]) =>
-        if packages.length is 0
-          @searchMessage.text("No #{@searchType.replace(/s$/, '')} results for \u201C#{query}\u201D").show()
-        else
-          @searchMessage.hide()
+        @resultsContainer.empty()
+        packages
+      .then (packages=[]) =>
+        @searchMessage.hide()
+        @showNoResultMessage if packages.length is 0
+        packages
+      .then (packages=[]) =>
+        @highlightExactMatch(@resultsContainer, query, packages)
+      .then (packages=[]) =>
         @addPackageViews(@resultsContainer, packages)
       .catch (error) =>
         @searchMessage.hide()
         @searchErrors.append(new ErrorView(@packageManager, error))
 
-  addPackageViews: (container, packages) ->
-    container.empty()
+  showNoResultMessage: ->
+    @searchMessage.text("No #{@searchType.replace(/s$/, '')} results for \u201C#{query}\u201D").show()
 
+  highlightExactMatch: (container, query, packages) ->
+    exactMatch = _.filter packages, (pkg) ->
+      pkg.name is query
+
+    if exactMatch.length > 0
+      packageCard = @getPackageCardView(exactMatch[0])
+      @addPackageCardView(container, packageCard)
+      packages.splice(packages.indexOf(exactMatch), 1)
+
+    packages
+
+  addPackageViews: (container, packages) ->
     for pack, index in packages
       packageCard = @getPackageCardView(pack)
       @addPackageCardView(container, packageCard)

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -181,11 +181,11 @@ class InstallPanel extends ScrollView
     @searchMessage.text("No #{@searchType.replace(/s$/, '')} results for \u201C#{query}\u201D").show()
 
   highlightExactMatch: (container, query, packages) ->
-    exactMatch = _.filter packages, (pkg) ->
-      pkg.name is query
+    exactMatch = _.filter(packages, (pkg) ->
+      pkg.name is query)[0]
 
-    if exactMatch.length > 0
-      packageCard = @getPackageCardView(exactMatch[0])
+    if exactMatch
+      packageCard = @getPackageCardView(exactMatch)
       @addPackageCardView(container, packageCard)
       packages.splice(packages.indexOf(exactMatch), 1)
 

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -26,9 +26,9 @@ class PackageCard extends View
 
       @div class: 'body', =>
         @h4 class: 'card-name', =>
-          @a outlet: 'packageName', displayName
+          @a class: 'package-name', outlet: 'packageName', displayName
           @span ' '
-          @span =>
+          @span class: 'package-version', =>
             @span outlet: 'versionValue', class: 'value', String(version)
 
           @span class: 'deprecation-badge highlight-warning inline-block', 'Deprecated'

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -16,11 +16,11 @@ class PackageCard extends View
 
     @div class: 'package-card col-lg-8', =>
       @div outlet: 'statsContainer', class: 'stats pull-right', =>
-        @span class: 'stats-item', =>
+        @span outlet: 'packageStars', class: 'stats-item', =>
           @span outlet: 'stargazerIcon', class: 'icon icon-star'
           @span outlet: 'stargazerCount', class: 'value'
 
-        @span class: 'stats-item', =>
+        @span outlet: 'packageDownloads', class: 'stats-item', =>
           @span outlet: 'downloadIcon', class: 'icon icon-cloud-download'
           @span outlet: 'downloadCount', class: 'value'
 
@@ -72,6 +72,13 @@ class PackageCard extends View
     if @pack.apmInstallSource?.type is 'git'
       @newSha = @pack.latestSha unless @pack.apmInstallSource.sha is @pack.latestSha
 
+    # Default to displaying the download count
+    unless options?.stats
+      options.stats = {
+        downloads: true
+      }
+
+    @displayStats(options)
     @handlePackageEvents()
     @handleButtonEvents(options)
     @loadCachedMetadata()
@@ -276,6 +283,17 @@ class PackageCard extends View
       @displayDeprecatedState()
     else if @hasClass('deprecated')
       @displayUndeprecatedState()
+
+  displayStats: (options) ->
+    if options?.stats?.downloads
+      @packageDownloads.show()
+    else
+      @packageDownloads.hide()
+
+    if options?.stats?.stars
+      @packageStars.show()
+    else
+      @packageStars.hide()
 
   displayUndeprecatedState: ->
     @removeClass('deprecated')

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -55,7 +55,7 @@ class PackageCard extends View
                 @span class: 'disable-text', 'Disable'
               @button type: 'button', class: 'btn status-indicator', tabindex: -1, outlet: 'statusIndicator'
 
-  initialize: (@pack, @packageManager, options) ->
+  initialize: (@pack, @packageManager, options={}) ->
     @disposables = new CompositeDisposable()
 
     # It might be useful to either wrap @pack in a class that has a ::validate

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -16,9 +16,9 @@ class PackageCard extends View
 
     @div class: 'package-card col-lg-8', =>
       @div outlet: 'statsContainer', class: 'stats pull-right', =>
-        @span class: "stats-item", =>
-          @span class: 'icon icon-versions'
-          @span outlet: 'versionValue', class: 'value', String(version)
+        @span class: 'stats-item', =>
+          @span outlet: 'stargazerIcon', class: 'icon icon-star'
+          @span outlet: 'stargazerCount', class: 'value'
 
         @span class: 'stats-item', =>
           @span outlet: 'downloadIcon', class: 'icon icon-cloud-download'
@@ -28,6 +28,9 @@ class PackageCard extends View
         @h4 class: 'card-name', =>
           @a outlet: 'packageName', displayName
           @span ' '
+          @span =>
+            @span outlet: 'versionValue', class: 'value', String(version)
+
           @span class: 'deprecation-badge highlight-warning inline-block', 'Deprecated'
         @span outlet: 'packageDescription', class: 'package-description', description
         @div outlet: 'packageMessage', class: 'package-message'
@@ -187,6 +190,7 @@ class PackageCard extends View
           @downloadIcon.addClass('icon-git-branch')
           @downloadCount.text @pack.apmInstallSource.sha.substr(0, 8)
         else
+          @stargazerCount.text data.stargazers_count?.toLocaleString()
           @downloadCount.text data.downloads?.toLocaleString()
 
   updateInterfaceState: ->

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -233,6 +233,10 @@ class PackageManager
         if code is 0
           try
             packages = JSON.parse(stdout) ? []
+            if options.sortBy
+              packages = _.sortBy packages, (pkg) ->
+                return pkg[options.sortBy]*-1
+
             resolve(packages)
           catch parseError
             error = createJsonParseError(errorMessage, parseError, stdout)

--- a/styles/package-card.less
+++ b/styles/package-card.less
@@ -77,13 +77,12 @@
       }
     }
     .package-name {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 100%;
+      font-weight: bolder;
       color: @text-color-highlight;
-      overflow: hidden;
-      line-height: 20px;
-      margin: 5px 0;
+    }
+
+    .package-version {
+      font-size: .8em
     }
 
     .description {


### PR DESCRIPTION
This implements sorting of packages based on #384.

Currently it sorts package and theme search results based on downloads count. 

![screen shot 2016-04-05 at 15 07 23](https://cloud.githubusercontent.com/assets/7757/14282809/6158ce9a-fb40-11e5-8ae7-796c7879be00.png)

![screen shot 2016-04-05 at 15 06 51](https://cloud.githubusercontent.com/assets/7757/14282798/568c4f46-fb40-11e5-9303-871b6c26e966.png)
