### PR TITLE
Show settings after install

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -193,6 +193,8 @@ class PackageCard extends View
     @versionValue.text(@installablePack?.version ? @pack.version)
     if @pack.apmInstallSource?.type is 'git'
       @downloadCount.text @pack.apmInstallSource.sha.substr(0, 8)
+    if @hasSettings()
+      @settingsButton.show()
     @updateInstalledState()
     @updateDisabledState()
     @updateDeprecatedState()

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -65,6 +65,8 @@ class PackageCard extends View
 
     {@name} = @pack
 
+    @onSettingsView = options?.onSettingsView
+
     @newVersion = @pack.latestVersion unless @pack.latestVersion is @pack.version
     if @pack.apmInstallSource?.type is 'git'
       @newSha = @pack.latestSha unless @pack.apmInstallSource.sha is @pack.latestSha
@@ -84,7 +86,6 @@ class PackageCard extends View
       @statusIndicator.remove()
       @enablementButton.remove()
 
-    @settingsButton.hide() unless @hasSettings()
     if atom.packages.isBundledPackage(@pack.name)
       @installButtonGroup.remove()
       @uninstallButton.remove()
@@ -193,11 +194,17 @@ class PackageCard extends View
     @versionValue.text(@installablePack?.version ? @pack.version)
     if @pack.apmInstallSource?.type is 'git'
       @downloadCount.text @pack.apmInstallSource.sha.substr(0, 8)
-    if @hasSettings()
-      @settingsButton.show()
+
+    @updateSettingsState()
     @updateInstalledState()
     @updateDisabledState()
     @updateDeprecatedState()
+
+  updateSettingsState: ->
+    if @hasSettings() and not @onSettingsView
+      @settingsButton.show()
+    else
+      @settingsButton.hide()
 
   # Section: disabled state updates
 

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -84,7 +84,7 @@ class PackageCard extends View
       @statusIndicator.remove()
       @enablementButton.remove()
 
-    @settingsButton.remove() unless @hasSettings()
+    @settingsButton.hide() unless @hasSettings()
     if atom.packages.isBundledPackage(@pack.name)
       @installButtonGroup.remove()
       @uninstallButton.remove()
@@ -134,7 +134,7 @@ class PackageCard extends View
 
   handleButtonEvents: (options) ->
     if options?.onSettingsView
-      @settingsButton.remove()
+      @settingsButton.hide()
     else
       @on 'click', =>
         @parents('.settings-view').view()?.showPanel(@pack.name, {back: options?.back, pack: @pack})

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -30,7 +30,7 @@ class PackageManager
     else
       false
 
-  packageHasSettings: _.memoize((packageName) ->
+  packageHasSettings: (packageName) ->
     grammars = atom.grammars.getGrammars() ? []
     for grammar in grammars when grammar.path
       return true if grammar.packageName is packageName
@@ -39,7 +39,6 @@ class PackageManager
     pack.activateConfig() if pack? and not atom.packages.isPackageActive(packageName)
     schema = atom.config.getSchema(packageName)
     schema? and (schema.type isnt 'any')
-  )
 
   runCommand: (args, callback) ->
     command = atom.packages.getApmPath()

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -32,6 +32,12 @@ describe "PackageCard", ->
     jasmine.attachToDOM(card[0])
     expect(card.settingsButton).not.toBeVisible()
 
+  it "doesn't show the settings button on the settings view", ->
+    setPackageStatusSpies {installed: true, disabled: false, hasSettings: true}
+    card = new PackageCard {name: 'test-package'}, packageManager, {onSettingsView: true}
+    jasmine.attachToDOM(card[0])
+    expect(card.settingsButton).not.toBeVisible()
+
   it "removes the settings button if a package has no settings", ->
     setPackageStatusSpies {installed: true, disabled: false, hasSettings: false}
     card = new PackageCard {name: 'test-package'}, packageManager


### PR DESCRIPTION
This PR fixes #650 by not removing the settings button and show after a package has been installed that has settings.

For this I had to remove `_.memoize` for `PackageManager#packageHasSettings` as it returned a wrong result, this may effect rendering of longer package lists, but so far I have not noticed any negative effect. 