### PR TITLE
Set active panel with name and options

### DIFF
--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -35,11 +35,10 @@ class SettingsView extends ScrollView
       # package card. Phew!
       @div class: 'panels', tabindex: -1, outlet: 'panels'
 
-  initialize: ({@uri, @snippetsProvider, activePanelName}={}) ->
+  initialize: ({@uri, @snippetsProvider, activePanel}={}) ->
     super
     @packageManager = new PackageManager()
-
-    @deferredPanel = {name: activePanelName}
+    @deferredPanel = activePanel
     process.nextTick => @initializePanels()
 
   dispose: ->
@@ -72,13 +71,13 @@ class SettingsView extends ScrollView
     @addCorePanel 'Install', 'plus', => new InstallPanel(@packageManager)
 
     @showDeferredPanel()
-    @showPanel('Settings') unless @activePanelName
+    @showPanel('Settings') unless @activePanel
     @sidebar.width(@sidebar.width()) if @isOnDom()
 
   serialize: ->
     deserializer: 'SettingsView'
     version: 2
-    activePanelName: @activePanelName ? @deferredPanel?.name
+    activePanel: @activePanel ? @deferredPanel
     uri: @uri
 
   getPackages: ->
@@ -174,16 +173,22 @@ class SettingsView extends ScrollView
   #   * `uri` the URI the panel was launched from
   showPanel: (name, options) ->
     if panel = @getOrCreatePanel(name, options)
-      @panels.children().hide()
-      @panels.append(panel) unless $.contains(@panels[0], panel[0])
-      panel.beforeShow?(options)
-      panel.show()
-      panel.focus()
+      @appendPanel(panel, options)
       @makePanelMenuActive(name)
-      @activePanelName = name
+      @setActivePanel(name, options)
       @deferredPanel = null
     else
       @deferredPanel = {name, options}
+
+  appendPanel: (panel, options) ->
+    @panels.children().hide()
+    @panels.append(panel) unless $.contains(@panels[0], panel[0])
+    panel.beforeShow?(options)
+    panel.show()
+    panel.focus()
+
+  setActivePanel: (name, options = {}) ->
+    @activePanel = {name, options}
 
   removePanel: (name) ->
     if panel = @panelsByName?[name]

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -21,7 +21,7 @@ describe "SettingsView", ->
       settingsView.remove()
       jasmine.attachToDOM(newSettingsView.element)
       newSettingsView.initializePanels()
-      expect(newSettingsView.activePanelName).toBe 'Themes'
+      expect(newSettingsView.activePanel).toEqual {name: 'Themes', options: {}}
 
     it "shows the previously active panel if it is added after deserialization", ->
       settingsView.addCorePanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
@@ -30,7 +30,7 @@ describe "SettingsView", ->
       newSettingsView.addPanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
       newSettingsView.initializePanels()
       jasmine.attachToDOM(newSettingsView.element)
-      expect(newSettingsView.activePanelName).toBe 'Panel 1'
+      expect(newSettingsView.activePanel).toEqual {name: 'Panel 1', options: {}}
 
     it "shows the Settings panel if the last saved active panel name no longer exists", ->
       settingsView.addCorePanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
@@ -39,7 +39,7 @@ describe "SettingsView", ->
       settingsView.remove()
       jasmine.attachToDOM(newSettingsView.element)
       newSettingsView.initializePanels()
-      expect(newSettingsView.activePanelName).toBe 'Settings'
+      expect(newSettingsView.activePanel).toEqual {name: 'Settings', options: {}}
 
     it "serializes the active panel name even when the panels were never initialized", ->
       settingsView.showPanel('Themes')
@@ -47,7 +47,7 @@ describe "SettingsView", ->
       settingsView3 = new SettingsView(settingsView2.serialize())
       jasmine.attachToDOM(settingsView3.element)
       settingsView3.initializePanels()
-      expect(settingsView3.activePanelName).toBe 'Themes'
+      expect(settingsView3.activePanel).toEqual {name: 'Themes', options: {}}
 
   describe ".addCorePanel(name, iconName, view)", ->
     it "adds a menu entry to the left and a panel that can be activated by clicking it", ->
@@ -93,52 +93,59 @@ describe "SettingsView", ->
         it "opens the settings view", ->
           openWithCommand('settings-view:open')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Settings'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Settings', options: {}
 
       describe "settings-view:show-keybindings", ->
         it "opens the settings view to the keybindings page", ->
           openWithCommand('settings-view:show-keybindings')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Keybindings'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Keybindings', options: uri: 'atom://config/keybindings'
 
       describe "settings-view:change-themes", ->
         it "opens the settings view to the themes page", ->
           openWithCommand('settings-view:change-themes')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Themes'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Themes', options: uri: 'atom://config/themes'
 
       describe "settings-view:uninstall-themes", ->
         it "opens the settings view to the themes page", ->
           openWithCommand('settings-view:uninstall-themes')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Themes'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Themes', options: uri: 'atom://config/themes'
 
       describe "settings-view:uninstall-packages", ->
         it "opens the settings view to the install page", ->
           openWithCommand('settings-view:uninstall-packages')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Packages'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Packages', options: uri: 'atom://config/packages'
 
       describe "settings-view:install-packages-and-themes", ->
         it "opens the settings view to the install page", ->
           openWithCommand('settings-view:install-packages-and-themes')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Install'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Install', options: uri: 'atom://config/install'
 
       describe "settings-view:check-for-package-updates", ->
         it "opens the settings view to the install page", ->
           openWithCommand('settings-view:check-for-package-updates')
           runs ->
-            expect(atom.workspace.getActivePaneItem().activePanelName).toBe 'Updates'
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Updates', options: uri: 'atom://config/updates'
 
     describe "when atom.workspace.open() is used with a config URI", ->
       focusIsWithinActivePanel = ->
-        activePanel = settingsView.panelsByName[settingsView.activePanelName]
+        activePanel = settingsView.panelsByName[settingsView.activePanel.name]
         # Return true if the element that has the focus, or its ancestors, is the activePanel
         $(document.activeElement).parents().addBack().toArray().indexOf(activePanel.element) isnt -1
 
       expectActivePanelToBeKeyboardScrollable = ->
-        activePanel = settingsView.panelsByName[settingsView.activePanelName]
+        activePanel = settingsView.panelsByName[settingsView.activePanel.name]
         spyOn(activePanel, 'pageDown')
         atom.commands.dispatch(activePanel.element, 'core:page-down')
         expect(activePanel.pageDown).toHaveBeenCalled()
@@ -156,7 +163,8 @@ describe "SettingsView", ->
 
         waitsFor (done) -> process.nextTick(done)
         runs ->
-          expect(settingsView.activePanelName).toBe 'Settings'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Settings', options: {}
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -165,7 +173,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Keybindings'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Keybindings', options: uri: 'atom://config/keybindings'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -174,7 +183,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Packages'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Packages', options: uri: 'atom://config/packages'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -183,7 +193,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Themes'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Themes', options: uri: 'atom://config/themes'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -192,7 +203,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Updates'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Updates', options: uri: 'atom://config/updates'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -201,7 +213,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Install'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Install', options: uri: 'atom://config/install'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -214,7 +227,15 @@ describe "SettingsView", ->
 
         waitsFor (done) -> process.nextTick(done)
         runs ->
-          expect(settingsView.activePanelName).toBe 'package-with-readme'
+          expect(settingsView.activePanel)
+            .toEqual name: 'package-with-readme', options: {
+              uri: 'atom://config/packages/package-with-readme',
+              pack:
+                name: 'package-with-readme'
+                metadata:
+                  name: 'package-with-readme'
+              back: 'Packages'
+            }
 
       it "passes the URI to a pane's beforeShow() method on settings view initialization", ->
         InstallPanel = require '../lib/install-panel'
@@ -225,7 +246,8 @@ describe "SettingsView", ->
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Install'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Install', options: uri: 'atom://config/install/package:something'
           expect(InstallPanel::beforeShow).toHaveBeenCalledWith {uri: 'atom://config/install/package:something'}
 
       it "passes the URI to a pane's beforeShow() method after initialization", ->
@@ -238,14 +260,15 @@ describe "SettingsView", ->
         waitsFor (done) -> process.nextTick(done)
 
         runs ->
-          expect(settingsView.activePanelName).toBe 'Settings'
+          expect(settingsView.activePanel).toEqual {name: 'Settings', options: {}}
 
         waitsForPromise ->
           atom.workspace.open('atom://config/install/package:something').then (s) -> settingsView = s
 
         waits 1
         runs ->
-          expect(settingsView.activePanelName).toBe 'Install'
+          expect(settingsView.activePanel)
+            .toEqual name: 'Install', options: uri: 'atom://config/install/package:something'
           expect(InstallPanel::beforeShow).toHaveBeenCalledWith {uri: 'atom://config/install/package:something'}
 
     describe "when the package is then deactivated", ->


### PR DESCRIPTION
This is to allow InstalledPackagesPanel to initialise with a previously viewed package and fixes #626.

I renamed `activePanelName` to reflect that it is now a panel object not just the name.
