### PR TITLE
Wait for updated package to load and then try to activate

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -274,12 +274,13 @@ class PackageManager
     exit = (code, stdout, stderr) =>
       if code is 0
         @clearOutdatedCache()
-        activation = if activateOnSuccess
-          atom.packages.activatePackage(name)
-        else
-          atom.packages.loadPackage(name)
 
-        Promise.resolve(activation).then =>
+        loadedPackage = atom.packages.loadPackage(name)
+
+        Promise.resolve(loadedPackage).then =>
+          if activateOnSuccess
+            atom.packages.activatePackage(name)
+
           callback?()
           @emitPackageEvent 'updated', pack
       else


### PR DESCRIPTION
This is a fix for issue #532 - Package cards in Updates panel don't change state when updates are done installing.

Before this commit, updating a package that had activation commands would cause the package card to display the loading state forever.

The cause of the issue was that the update process was waiting for the updated package to activate. This was a problem because calling `activatePackage` will only immediately activate a package that doesn't have any activationCommands.

The proposed fix is to wait for the package to load and then attempt to activate the package without waiting.