### PR TITLE
Allow to search keybindings using multi-keyword query

### DIFF
--- a/lib/keybindings-panel.coffee
+++ b/lib/keybindings-panel.coffee
@@ -73,10 +73,13 @@ class KeybindingsPanel extends ScrollView
     @keybindingRows.empty()
     for keyBinding in keyBindings
       {selector, keystrokes, command, source} = keyBinding
+      source = KeybindingsPanel.determineSource(source)
       searchString = "#{selector}#{keystrokes}#{command}#{source}".toLowerCase()
       continue unless searchString
 
-      if /^\s*$/.test(filterString) or searchString.indexOf(filterString?.toLowerCase()) isnt -1
+      keywords = filterString.trim().toLowerCase().split(' ')
+      containKeyword = (keyword) -> return /^\s*$/.test(keyword) or searchString.indexOf(keyword) isnt -1
+      if keywords.every containKeyword
         @appendKeyBinding(keyBinding)
 
   appendKeyBindings: (keyBindings) ->

--- a/lib/keybindings-panel.coffee
+++ b/lib/keybindings-panel.coffee
@@ -78,8 +78,7 @@ class KeybindingsPanel extends ScrollView
       continue unless searchString
 
       keywords = filterString.trim().toLowerCase().split(' ')
-      containKeyword = (keyword) -> return /^\s*$/.test(keyword) or searchString.indexOf(keyword) isnt -1
-      if keywords.every containKeyword
+      if keywords.every((keyword) -> searchString.indexOf(keyword) isnt -1)
         @appendKeyBinding(keyBinding)
 
   appendKeyBindings: (keyBindings) ->

--- a/spec/keybindings-panel-spec.coffee
+++ b/spec/keybindings-panel-spec.coffee
@@ -89,3 +89,14 @@ describe "KeybindingsPanel", ->
       expect(row.find('.command').text()).toBe 'window:toggle-full-screen'
       expect(row.find('.source').text()).toBe 'Core'
       expect(row.find('.selector').text()).toBe 'body'
+
+    it "perform a fuzzy match for each keyword", ->
+      panel.filterKeyBindings keyBindings, 'core ctrl-a'
+
+      expect(panel.keybindingRows.children().length).toBe 1
+
+      row = panel.keybindingRows.children(':first')
+      expect(row.find('.keystroke').text()).toBe 'ctrl-a'
+      expect(row.find('.command').text()).toBe 'core:select-all'
+      expect(row.find('.source').text()).toBe 'Core'
+      expect(row.find('.selector').text()).toBe '.editor, .platform-test'


### PR DESCRIPTION
Edit: Sorry for not having included more description about the changes in the PR.

## Problem
Currently, for a keybinding
```
Keystroke: alt-cmd-left
Command: pane:show-previous-item
Source: Core
Selector: body
```
A search like `pane show`, `pane cmd`, `Core`, `pane ` (whitespace at end) would all fail to hit it.

The problem is, for each keybinding, `searchString` is created:
`searchString = "#{selector}#{keystrokes}#{command}#{source}".toLowerCase()`
Then the input is tested to see if it's a substring of it.
This doesn't make sense, as common use cases like the ones I listed above aren't possible with this approach.

Two other small issues:
- Whitespace at the end of input is not trimmed
- `#{source}` refers to the keybinding file location like `/Applications/Atom.app/Contents/Resources/app.asar/keymaps/darwin.json`. On the screen it's displayed as `Core` after processing it with `KeybindingsPanel.determineSource`. It doesn't make sense to use the raw source in the `searchString`.

This PR fixes the two small issues, and breaks down input to keywords and test if each keyword is a substring in the `searchString`.
Sorry for my original misuse of the word "fuzzy match". As @jeancroy pointed out, this has nothing to do with fuzzy matching. I've edited the title to reflect it.

---
## Effect

![image](https://cloud.githubusercontent.com/assets/4033249/14694484/e03de176-0736-11e6-8d87-3108fe989ffe.png)

Haven't been following Atom for a while but it's got much better since I last checked.
Thinking about doing some more contributions :D