### PR TITLE
Dynamically update the updates tooltip

### DIFF
--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -8,7 +8,6 @@ fs = require 'fs-plus'
 PackageCard = require './package-card'
 Client = require './atom-io-client'
 ErrorView = require './error-view'
-PackageManager = require './package-manager'
 
 PackageNameRegex = /config\/install\/(package|theme):([a-z0-9-_]+)/i
 hostedGitInfo = require 'hosted-git-info'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -57,6 +57,7 @@ module.exports =
     packageManager = null
 
   consumeStatusBar: (statusBar) ->
+    packageManager ?= new PackageManager() # TODO: Why is this needed when the package manager is initialized at the top of the file?
     Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) =>
       updates = values[0]
       allPackages = values[1]

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -78,6 +78,7 @@ module.exports =
     settingsView = new SettingsView(params)
 
   showDeprecatedNotification: (packages) ->
+    return unless packages.user?
     deprecatedPackages = packages.user.filter ({name, version}) ->
       atom.packages.isDeprecatedPackage(name, version)
     return unless deprecatedPackages.length

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -53,11 +53,11 @@ module.exports =
 
   consumeStatusBar: (statusBar) ->
     Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) ->
-      updates = values[0].length
+      updates = values[0]
       allPackages = values[1]
-      if updates > 0
-        PackageUpdatesStatusView = require './package-updates-status-view'
-        packageUpdatesStatusView = new PackageUpdatesStatusView(statusBar, packageManager, updates)
+
+      PackageUpdatesStatusView = require './package-updates-status-view'
+      packageUpdatesStatusView = new PackageUpdatesStatusView(statusBar, packageManager, updates)
 
       if allPackages.length > 0 and not localStorage.getItem('hasSeenDeprecatedNotification')
         @showDeprecatedNotification(allPackages)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,9 @@
 SettingsView = null
 settingsView = null
 
+PackageManager = require './package-manager'
+packageManager = new PackageManager()
+
 SnippetsProvider =
   getSnippets: -> atom.config.scopedSettingsStore.propertySets
 
@@ -46,16 +49,15 @@ module.exports =
     settingsView?.dispose()
     settingsView?.remove()
     settingsView = null
+    packageManager = null
 
   consumeStatusBar: (statusBar) ->
-    PackageManager = require './package-manager'
-    packageManager = new PackageManager()
     Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) ->
-      outdatedPackages = values[0]
+      updates = values[0].length
       allPackages = values[1]
-      if outdatedPackages.length > 0
+      if updates > 0
         PackageUpdatesStatusView = require './package-updates-status-view'
-        packageUpdatesStatusView = new PackageUpdatesStatusView(statusBar, outdatedPackages)
+        packageUpdatesStatusView = new PackageUpdatesStatusView(statusBar, packageManager, updates)
 
       if allPackages.length > 0 and not localStorage.getItem('hasSeenDeprecatedNotification')
         @showDeprecatedNotification(allPackages)
@@ -68,6 +70,7 @@ module.exports =
 
   createSettingsView: (params) ->
     SettingsView ?= require './settings-view'
+    params.packageManager = packageManager
     params.snippetsProvider = SnippetsProvider
     settingsView = new SettingsView(params)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -61,8 +61,6 @@ module.exports =
 
       if allPackages.length > 0 and not localStorage.getItem('hasSeenDeprecatedNotification')
         @showDeprecatedNotification(allPackages)
-    .catch (error) ->
-      console.log error.message, error.stack
 
   consumeSnippets: (snippets) ->
     if typeof snippets.getUnparsedSnippets is "function"

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -52,7 +52,7 @@ module.exports =
     packageManager = null
 
   consumeStatusBar: (statusBar) ->
-    Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) ->
+    Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) =>
       updates = values[0]
       allPackages = values[1]
 

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -123,6 +123,9 @@ class PackageManager
           value: packages
           expiry: Date.now() + @CACHE_EXPIRY
 
+        for pack in packages
+          @emitPackageEvent 'update-available', pack
+
         callback(null, packages)
       else
         error = new Error(errorMessage)

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -24,7 +24,7 @@ class PackageUpdatesStatusView extends View
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
 
   onDidUpdatePackage: (pack) ->
-    for update, index in @updates
+    for index, update of @updates
       if update.name is pack.name
         @updates.splice(index, 1)
 

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -14,7 +14,7 @@ class PackageUpdatesStatusView extends View
     packageManager.on 'package-updated theme-updated', ({error, pack}) => @onDidUpdatePackage(pack)
     packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
 
-    if updates.length
+    if @updates.length
       @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
       @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
       @tile = @statusBar.addRightTile(item: this, priority: 0)

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -8,12 +8,23 @@ class PackageUpdatesStatusView extends View
       @span class: 'icon icon-package'
       @span outlet: 'countLabel', class: 'available-updates-status'
 
-  initialize: (statusBar, packages) ->
-    @countLabel.text("#{_.pluralize(packages.length, 'update')}")
-    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(packages.length, 'package update')} available")
+  initialize: (statusBar, packageManager, @updates) ->
+    @subscriptions = packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage
+
+    @countLabel.text("#{_.pluralize(@updates, 'update')}")
+    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")
     @tile = statusBar.addRightTile(item: this, priority: 0)
 
-    @on 'click', =>
+    @on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
+
+  @onDidUpdatePackage: =>
+    @updates--
+    if @updates is 0
       @tooltip.dispose()
       @tile.destroy()
+      return
+
+    @countLabel.text("#{_.pluralize(@updates, 'update')}")
+    @tooltip.dispose()
+    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -9,7 +9,7 @@ class PackageUpdatesStatusView extends View
       @span outlet: 'countLabel', class: 'available-updates-status'
 
   initialize: (statusBar, packageManager, @updates) ->
-    @subscriptions = packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage
+    packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage
 
     @countLabel.text("#{_.pluralize(@updates, 'update')}")
     @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -8,23 +8,47 @@ class PackageUpdatesStatusView extends View
       @span class: 'icon icon-package'
       @span outlet: 'countLabel', class: 'available-updates-status'
 
-  initialize: (statusBar, packageManager, @updates) ->
-    packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage()
+  initialize: (@statusBar, packageManager, @updates) ->
+    @destroyed = true
 
-    @countLabel.text("#{_.pluralize(@updates, 'update')}")
-    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")
-    @tile = statusBar.addRightTile(item: this, priority: 0)
+    packageManager.on 'package-updated theme-updated', ({error, pack}) => @onDidUpdatePackage(pack)
+    packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
+
+    if updates.length
+      @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
+      @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
+      @tile = @statusBar.addRightTile(item: this, priority: 0)
+      @destroyed = false
 
     @on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
 
-  onDidUpdatePackage: ->
-    @updates--
-    unless @updates
-      @tooltip.dispose()
+  onDidUpdatePackage: (pack) ->
+    for update, index in @updates
+      if update.name is pack.name
+        @updates.splice(index, 1)
+
+    @tooltip.dispose()
+
+    unless @updates.length
       @tile.destroy()
+      @destroyed = true
       return
 
-    @countLabel.text("#{_.pluralize(@updates, 'update')}")
+    @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
+    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
+
+  onPackageUpdateAvailable: (pack) ->
+    if @destroyed
+      @tile = @statusBar.addRightTile(item: this, priority: 0)
+      @destroyed = false
+
+    for update in @updates
+      if update.name is pack.name
+        return
+
+    @updates.push(pack)
     @tooltip.dispose()
-    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")
+
+    @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
+    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -20,7 +20,7 @@ class PackageUpdatesStatusView extends View
 
   @onDidUpdatePackage: =>
     @updates--
-    if @updates is 0
+    unless @updates
       @tooltip.dispose()
       @tile.destroy()
       return

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -9,7 +9,7 @@ class PackageUpdatesStatusView extends View
       @span outlet: 'countLabel', class: 'available-updates-status'
 
   initialize: (statusBar, packageManager, @updates) ->
-    packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage
+    packageManager.on 'package-updated theme-updated', => @onDidUpdatePackage()
 
     @countLabel.text("#{_.pluralize(@updates, 'update')}")
     @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates, 'package update')} available")
@@ -18,7 +18,7 @@ class PackageUpdatesStatusView extends View
     @on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
 
-  @onDidUpdatePackage: =>
+  onDidUpdatePackage: ->
     @updates--
     unless @updates
       @tooltip.dispose()

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -14,6 +14,7 @@ InstallPanel = require './install-panel'
 ThemesPanel = require './themes-panel'
 InstalledPackagesPanel = require './installed-packages-panel'
 UpdatesPanel = require './updates-panel'
+PackageManager = require './package-manager'
 
 module.exports =
 class SettingsView extends ScrollView
@@ -37,6 +38,7 @@ class SettingsView extends ScrollView
   initialize: ({@uri, @packageManager, @snippetsProvider, activePanelName}={}) ->
     super
 
+    @packageManager ?= new PackageManager()
     @deferredPanel = {name: activePanelName}
     process.nextTick => @initializePanels()
 

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -10,7 +10,6 @@ Client = require './atom-io-client'
 GeneralPanel = require './general-panel'
 PackageDetailView = require './package-detail-view'
 KeybindingsPanel = require './keybindings-panel'
-PackageManager = require './package-manager'
 InstallPanel = require './install-panel'
 ThemesPanel = require './themes-panel'
 InstalledPackagesPanel = require './installed-packages-panel'
@@ -35,9 +34,8 @@ class SettingsView extends ScrollView
       # package card. Phew!
       @div class: 'panels', tabindex: -1, outlet: 'panels'
 
-  initialize: ({@uri, @snippetsProvider, activePanelName}={}) ->
+  initialize: ({@uri, @packageManager, @snippetsProvider, activePanelName}={}) ->
     super
-    @packageManager = new PackageManager()
 
     @deferredPanel = {name: activePanelName}
     process.nextTick => @initializePanels()

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -9,7 +9,6 @@ _ = require 'underscore-plus'
 CollapsibleSectionPanel = require './collapsible-section-panel'
 PackageCard = require './package-card'
 ErrorView = require './error-view'
-PackageManager = require './package-manager'
 
 List = require './list'
 ListView = require './list-view'

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -6,7 +6,7 @@ _ = require 'underscore-plus'
 SnippetsProvider =
   getSnippets: -> atom.config.scopedSettingsStore.propertySets
 
-describe "PackageDetailView", ->
+describe "InstalledPackageView", ->
   beforeEach ->
     spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
 

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -2,7 +2,7 @@
 PackageManager = require '../lib/package-manager'
 PackageUpdatesStatusView = require '../lib/package-updates-status-view'
 
-describe "package updates status view", ->
+describe "PackageUpdatesStatusView", ->
   packageManager = null
 
   outdatedPackage1 =

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -22,6 +22,7 @@ describe "package updates status view", ->
 
     runs ->
       atom.packages.emitter.emit('did-activate-all')
+      expect($('status-bar .package-updates-status-view')).toExist()
 
   describe "when packages are outdated", ->
     it "adds a tile to the status bar", ->

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -57,6 +57,14 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('updated', outdatedPackage2)
       expect($('status-bar .package-updates-status-view')).not.toExist()
 
+  describe "when a new update becomes available and the tile is destroyed", ->
+    it "recreates the tile", ->
+      packageManager.emitPackageEvent('updated', outdatedPackage1)
+      packageManager.emitPackageEvent('updated', outdatedPackage2)
+      packageManager.emitPackageEvent('update-available', installedPackage)
+      expect($('status-bar .package-updates-status-view')).toExist()
+      expect($('status-bar .package-updates-status-view').text()).toBe '1 update'
+
   describe "when an update becomes available for a package", ->
     it "updates the tile", ->
       packageManager.emitPackageEvent('update-available', installedPackage)
@@ -67,4 +75,4 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('update-available', outdatedPackage1)
       packageManager.emitPackageEvent('update-available', outdatedPackage1)
       packageManager.emitPackageEvent('update-available', outdatedPackage1)
-      # expect($('status-bar .package-updates-status-view').text()).toBe '2 updates'
+      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates'

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -3,13 +3,15 @@ PackageManager = require '../lib/package-manager'
 
 describe "package updates status view", ->
   beforeEach ->
-    outdatedPackage =
-      name: 'out-dated'
+    outdatedPackage1 =
+      name: 'out-dated-1'
+    outdatedPackage2 =
+      name: 'out-dated-2'
     installedPackage =
       name: 'user-package'
     spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
     spyOn(PackageManager.prototype, 'getInstalled').andCallFake -> Promise.resolve([installedPackage])
-    spyOn(PackageManager.prototype, 'getOutdated').andCallFake -> Promise.resolve([outdatedPackage])
+    spyOn(PackageManager.prototype, 'getOutdated').andCallFake -> Promise.resolve([outdatedPackage1, outdatedPackage2])
     jasmine.attachToDOM(atom.views.getView(atom.workspace))
 
     waitsForPromise ->
@@ -23,4 +25,35 @@ describe "package updates status view", ->
 
   describe "when packages are outdated", ->
     it "adds a tile to the status bar", ->
-      expect($('status-bar .package-updates-status-view').text()).toBe '1 update'
+      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates'
+
+  describe "when the tile is clicked", ->
+    it "opens the Available Updates panel", ->
+      spyOn(atom.commands, 'dispatch').andCallFake ->
+
+      $('status-bar .package-updates-status-view').click()
+      expect(atom.commands.dispatch).toHaveBeenCalledWith(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
+
+    it "does not destroy the tile", ->
+      $('status-bar .package-updates-status-view').click()
+      expect($('status-bar .package-updates-status-view')).toExist()
+
+  describe "when a package is updated", ->
+    it "updates the tile", ->
+      # TODO
+      # expect($('status-bar .package-updates-status-view').text()).toBe '1 update'
+
+  describe "when there are no more updates", ->
+    it "destroys the tile", ->
+      # TODO
+      # expect($('status-bar .package-updates-status-view')).not.toExist()
+
+  describe "when an update becomes available for a package", ->
+    it "updates the tile", ->
+      # TODO
+      # expect($('status-bar .package-updates-status-view').text()).toBe '3 updates'
+
+  describe "when updates are checked for multiple times and no new updates are available", ->
+    it "does not keep updating the tile", ->
+      # TODO
+      # expect($('status-bar .package-updates-status-view').text()).toBe '2 updates'


### PR DESCRIPTION
Instead of removing the updates tooltip as soon as it gets clicked, dynamically update the number of updates left in the tooltip as individual packages get updated.  When there are no outdated packages left, the tooltip will disappear.

Closes #511
