### PR TITLE
Avoid duplicating identical setting values

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -120,7 +120,7 @@ class SettingsPanel extends CollapsibleSectionPanel
 
   set: (name, value) ->
     if @options.scopeName
-      if value is undefined
+      if value is undefined or `value == atom.config.get(name)`
         atom.config.unset(name, scopeSelector: @options.scopeName)
       else
         atom.config.set(name, value, scopeSelector: @options.scopeName)


### PR DESCRIPTION
I have my `config.cson` [tracked by version control](https://github.com/Alhadis/Atom-PhoenixTheme/blob/master/.config/config.cson), and whenever I open the settings panel of a grammar package, I get junk like this being added:

```coffee
".awk.source":
  editor:
    tabLength: 4
".fixed.fortran.source":
  editor:
    tabLength: 4
".fortran.free.source":
  editor:
    tabLength: 4
".fortran.modern.source":
  editor:
    tabLength: 4
".fortran.preprocessor.source":
  editor:
    tabLength: 4
".fortran.punchcard.source":
  editor:
    tabLength: 4
```

This is obviously redundant, because my preferred `tabLength` setting (set globally) is already 4. Unsurprisingly, if I set it to Atom's claustrophobia-inducing default of 2, the setting pollution goes away.

This commit fixes that.

These "clones" can be ascertained programmatically by running `atom.config.getRawScopedValue([".scope.whatever"], "editor.tabLength")`, which will return a value other than `undefined` if it's been replicated in the user's config.

Oddly, this doesn't work in the test suite, which *always* returns `undefined`, even when a replicated setting should've been spawned. Ergo, I haven't been able to write a spec that faithfully tests this.