### PR TITLE
Minor fix for before pseudo element

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -133,8 +133,8 @@
       background-color: @background-color-success;
     }
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       content: "";
       position: absolute;
       top: 1.1em;
@@ -147,11 +147,11 @@
       opacity: 0;
       transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
     }
-    &:before {
+    &::before {
       width: .45em;
       transform: rotate(225deg) scale(0);
     }
-    &:after {
+    &::after {
       width: .9em;
       margin: -1px;
       transform: rotate(-45deg) scale(0);
@@ -163,15 +163,15 @@
       &:active {
         background-color: @text-color-subtle;
       }
-      &:before,
-      &:after {
+      &::before,
+      &::after {
         opacity: 1;
       }
-      &:before {
+      &::before {
         transform: rotate(225deg) scale(1);
         transition-delay: .05s;
       }
-      &:after {
+      &::after {
         transform: rotate(-45deg) scale(1);
         transition-delay: 0;
       }
@@ -304,7 +304,7 @@
       &.has-items {
         cursor: pointer;
 
-        &:after {
+        &::after {
           .icon(16px);
           content: @fold;
           position: absolute;
@@ -605,7 +605,7 @@
 
   .loading-area {
     span {
-      &:before {
+      &::before {
         font-size: 1.1em;
         width: 1.1em;
         height: 1.1em;
@@ -734,12 +734,12 @@
 }
 
 .clearfix {
-  &:before {
+  &::before {
     display: table;
     content: "";
   }
 
-  &:after {
+  &::after {
     display: table;
     clear: both;
     content: "";


### PR DESCRIPTION
CSS code style. `::` is more preference, than `:`

```css
/* CSS3 syntax */
element::before { style properties }

/* CSS2 obsolete syntax (only needed to support IE8) */
element:before  { style properties }
```

https://developer.mozilla.org/en/docs/Web/CSS/::before