### PR TITLE
Added styles to status bar notification to make the interaction more obvious

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -698,6 +698,13 @@
   }
 }
 
+.package-updates-status-view {
+  cursor: pointer;
+  &:hover .available-updates-status {
+    text-decoration: underline;
+  }
+}
+
 .available-updates-status {
   padding-left: 2px;
 }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -698,10 +698,11 @@
   }
 }
 
-.package-updates-status-view {
-  cursor: pointer;
-  &:hover .available-updates-status {
-    text-decoration: underline;
+.package-updates-status-view
+  &:hover {
+    .available-updates-status {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -698,12 +698,8 @@
   }
 }
 
-.package-updates-status-view
-  &:hover {
-    .available-updates-status {
-      text-decoration: underline;
-    }
-  }
+.package-updates-status-view:hover {
+  text-decoration: underline;
 }
 
 .available-updates-status {


### PR DESCRIPTION
All other interactable items in the status bar have a pointer cursor and text underline on hover. It makes sense to apply that style to the package update notification as well since clicking it opens a new tab.

This is similar to https://github.com/atom/about/pull/32, which adds a pointer to the squirrel icon.

I understand there is a PR to _remove_ all `cursor:pointers` but until that happens I think it's worth having consistency across the status bar modules. [The branch](https://github.com/atom/atom/pull/7698) has definitely gotten a little stale.