### PR TITLE
[WIP] Packages star features

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -49,9 +49,7 @@ class AtomIoClient
       return
 
     if callback
-      callback """
-        No Atom.io API token found.
-      """
+      callback()
 
   # Save the given token to the keychain.
   #

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -45,7 +45,7 @@ class InstallPanel extends ScrollView
           @div outlet: 'loadingMessage', class: 'alert alert-info icon icon-hourglass'
           @div outlet: 'featuredContainer', class: 'container package-container'
 
-      @div class: 'section packages', =>
+      @div outlet: 'starredPackagesSection', class: 'section packages', =>
         @div class: 'section-container', =>
           @div outlet: 'starreedHeading', class: 'section-heading icon icon-star', 'Starred Packages'
           @div outlet: 'starreedErrors'
@@ -68,7 +68,15 @@ class InstallPanel extends ScrollView
     @searchType = 'packages'
     @handleSearchEvents()
 
-    @loadStarredPackages()
+    if @showStarredPackages()
+      @loadStarredPackages()
+    else
+      atom.config.observe 'settings-view.enableStarredPackages', (enabled) =>
+        if enabled
+          @loadStarredPackages()
+
+      @starredPackagesSection.hide()
+
     @loadFeaturedPackages()
 
   dispose: ->
@@ -76,6 +84,9 @@ class InstallPanel extends ScrollView
 
   focus: ->
     @searchEditorView.focus()
+
+  showStarredPackages: ->
+    @starredPackages ?= atom.config.get('settings-view.enableStarredPackages')
 
   handleSearchEvents: ->
     @disposables.add @packageManager.on 'package-install-failed', ({pack, error}) =>
@@ -212,7 +223,7 @@ class InstallPanel extends ScrollView
     packageRow.append(packageCard)
 
   getPackageCardView: (pack) ->
-    new PackageCard(pack, @packageManager, {back: 'Install', stats: {downloads: true, stars: true}})
+    new PackageCard(pack, @packageManager, {back: 'Install', stats: {downloads: true, stars: @showStarredPackages()}})
 
   filterPackages: (packages, themes) ->
     packages.filter ({theme}) ->
@@ -223,6 +234,7 @@ class InstallPanel extends ScrollView
 
   # Load starred packages
   loadStarredPackages: ->
+    @starredPackagesSection.show()
     @packageManager.getStarred()
       .then (packages) =>
         @loadingStarredMessage.hide()

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -51,6 +51,10 @@ class InstallPanel extends ScrollView
           @div outlet: 'starreedErrors'
           @div outlet: 'loadingStarredMessage', class: 'alert alert-info icon icon-hourglass'
           @div outlet: 'starredContainer', class: 'container package-container'
+          @div outlet: 'showMoreStarred', =>
+            @span 'Show '
+            @span outlet: 'additionalStarCount'
+            @span ' more'
           @div outlet: 'tokenForm', =>
             @div class: 'text native-key-bindings', tabindex: -1, =>
               @span class: 'icon icon-question'
@@ -67,7 +71,7 @@ class InstallPanel extends ScrollView
     @client = @packageManager.getClient()
     @atomIoURL = 'https://atom.io/packages'
     @enableStarredPackages = atom.config.get('settings-view.enableStarredPackages')
-
+    @maxStarredPackages = 10
     @searchMessage.hide()
     @searchEditorView.getModel().setPlaceholderText('Search packages')
     @setSearchType('packages')
@@ -267,13 +271,30 @@ class InstallPanel extends ScrollView
 
     @tokenForm.show()
 
+  showStarredPackagesList: (packages) ->
+    @loadingStarredMessage.hide()
+    @showMoreStarred.hide()
+
+    if packages.length > @maxStarredPackages
+      @additionalStarCount.text packages.length - @maxStarredPackages
+      @additionalStarrredPackages = packages.slice(@maxStarredPackages)
+
+      @showMoreStarred.on 'click', (e) =>
+        @addPackageViews(@starredContainer, @additionalStarrredPackages)
+        @showMoreStarred.hide()
+        false
+
+      packages = packages.slice(0, @maxStarredPackages)
+      @showMoreStarred.show()
+
+    @addPackageViews(@starredContainer, packages)
+    @starredPackagesSection.show()
+
   # Load starred packages
   loadStarredPackages: ->
-    @packageManager.getStarred()\
+    @packageManager.getStarred()
       .then (packages) =>
-        @loadingStarredMessage.hide()
-        @addPackageViews(@starredContainer, packages)
-        @starredPackagesSection.show()
+        @showStarredPackagesList(packages)
       .catch (error) =>
         @starreedErrors.append(new ErrorView(@packageManager, error))
 

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -277,7 +277,6 @@ class InstallPanel extends ScrollView
   showStarredPackagesList: (packages) ->
     @loadingStarredMessage.hide()
     @showMoreStarred.hide()
-    @starredContainer.empty()
 
     if packages.length > @maxStarredPackages
       @additionalStarCount.text packages.length - @maxStarredPackages
@@ -296,9 +295,19 @@ class InstallPanel extends ScrollView
 
   # Load starred packages
   loadStarredPackages: ->
+    @starredContainer.empty()
+
+    @loadingStarredMessage.show()
+    @loadingStarredMessage.text('Loading starred packages')
+
     @packageManager.getStarred()
       .then (packages) =>
-        @showStarredPackagesList(packages)
+        if packages.length > 0
+          @showStarredPackagesList(packages)
+        else
+          @starredContainer.text('No packages starred yet')
+          @showMoreStarred.hide()
+          @loadingStarredMessage.hide()
       .catch (error) =>
         @starreedErrors.append(new ErrorView(@packageManager, error))
 

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -286,16 +286,16 @@ class InstallPanel extends ScrollView
 
   showStarredPackagesList: (packages) ->
     @loadingStarredMessage.hide()
+    @additionalStarrredPackages = []
     @showMoreStarred.hide()
 
     if packages.length > @maxStarredPackages
-      @additionalStarCount.text packages.length - @maxStarredPackages
       @additionalStarrredPackages = packages.slice(@maxStarredPackages)
+      @additionalStarCount.text @additionalStarrredPackages.length
 
       @showMoreStarred.on 'click', (e) =>
-        @addPackageViews(@starredContainer, @additionalStarrredPackages)
-        @showMoreStarred.hide()
-        false
+        e.preventDefault()
+        @showAdditionalStarredPackages()
 
       packages = packages.slice(0, @maxStarredPackages)
       @showMoreStarred.show()
@@ -303,10 +303,14 @@ class InstallPanel extends ScrollView
     @addPackageViews(@starredContainer, packages)
     @starredPackagesSection.show()
 
+  showAdditionalStarredPackages: ->
+    @addPackageViews(@starredContainer, @additionalStarrredPackages)
+    @additionalStarrredPackages = []
+    @showMoreStarred.hide()
+
   # Load starred packages
   loadStarredPackages: ->
     @starredContainer.empty()
-    @additionalStarrredPackages = []
     @showMoreStarred.hide()
 
     @loadingStarredMessage.show()

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -262,6 +262,9 @@ class InstallPanel extends ScrollView
 
       @starredPackagesSection.hide()
 
+    @disposables.add @packageManager.on 'package-star package-unstar theme-star theme-unstar', (pkg) =>
+      @loadStarredPackages()
+
   showTokenForm: ->
     @tokenView.getModel().setPlaceholderText('Atom.io account token')
     @loadingStarredMessage.hide()

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -54,7 +54,7 @@ class InstallPanel extends ScrollView
           @div outlet: 'tokenForm', =>
             @div class: 'text native-key-bindings', tabindex: -1, =>
               @span class: 'icon icon-question'
-              @span outlet: 'publishedToText', 'To star packages you need an account on '
+              @span 'To star packages you need an account on '
               @a class: 'link', outlet: 'openAtomIoAccount', 'atom.io/account'
               @div class: 'editor-container', =>
                 @subview 'tokenView', new TextEditorView(mini: true)

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -125,8 +125,12 @@ class InstallPanel extends ScrollView
       null
 
   performSearch: ->
-    if query = @searchEditorView.getText().trim()
+    query = @searchEditorView.getText().trim()
+
+    if query and query isnt ''
       @performSearchForQuery(query)
+    else
+      @resultsContainer.empty()
 
   performSearchForQuery: (query) ->
     if gitUrlInfo = hostedGitInfo.fromUrl(query)

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -51,7 +51,7 @@ class InstallPanel extends ScrollView
           @div outlet: 'starreedErrors'
           @div outlet: 'loadingStarredMessage', class: 'alert alert-info icon icon-hourglass'
           @div outlet: 'starredContainer', class: 'container package-container'
-          @div outlet: 'showMoreStarred', =>
+          @div outlet: 'showMoreStarred', class: 'container-show-more', =>
             @span 'Show '
             @span outlet: 'additionalStarCount'
             @span ' more'

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -66,7 +66,7 @@ class InstallPanel extends ScrollView
     client = $('.settings-view').view()?.client
     @client = @packageManager.getClient()
     @atomIoURL = 'https://atom.io/packages'
-    @starredPackages = atom.config.get('settings-view.enableStarredPackages')
+    @enableStarredPackages = atom.config.get('settings-view.enableStarredPackages')
 
     @searchMessage.hide()
     @searchEditorView.getModel().setPlaceholderText('Search packages')
@@ -226,7 +226,13 @@ class InstallPanel extends ScrollView
     packageRow.append(packageCard)
 
   getPackageCardView: (pack) ->
-    new PackageCard(pack, @packageManager, {back: 'Install', stats: {downloads: true, stars: @showStarredPackages}})
+    packageCardOptions =
+      back: 'Install',
+      stats:
+        downloads: true,
+        stars: @enableStarredPackages
+
+    new PackageCard(pack, @packageManager, packageCardOptions)
 
   filterPackages: (packages, themes) ->
     packages.filter ({theme}) ->
@@ -238,7 +244,7 @@ class InstallPanel extends ScrollView
   # Shows starred packages if enabled and a token is set
   # If enabled but no token is found it shows a form to set it
   showStarredPackages: ->
-    if @showStarredPackages
+    if @enableStarredPackages
       @tokenForm.hide()
       @client.getToken (token) =>
         if token

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -72,6 +72,8 @@ class InstallPanel extends ScrollView
     @atomIoURL = 'https://atom.io/packages'
     @enableStarredPackages = atom.config.get('settings-view.enableStarredPackages')
     @maxStarredPackages = 10
+    @additionalStarrredPackages = []
+
     @searchMessage.hide()
     @searchEditorView.getModel().setPlaceholderText('Search packages')
     @setSearchType('packages')
@@ -273,6 +275,7 @@ class InstallPanel extends ScrollView
       @loadStarredPackages()
 
   showTokenForm: ->
+    @showMoreStarred.hide()
     @tokenView.getModel().setPlaceholderText('Atom.io account token')
     @loadingStarredMessage.hide()
     @tokenView.getModel().onDidStopChanging =>
@@ -289,7 +292,7 @@ class InstallPanel extends ScrollView
       @additionalStarCount.text packages.length - @maxStarredPackages
       @additionalStarrredPackages = packages.slice(@maxStarredPackages)
 
-      @disposables.add @showMoreStarred.on 'click', (e) =>
+      @showMoreStarred.on 'click', (e) =>
         @addPackageViews(@starredContainer, @additionalStarrredPackages)
         @showMoreStarred.hide()
         false
@@ -303,6 +306,8 @@ class InstallPanel extends ScrollView
   # Load starred packages
   loadStarredPackages: ->
     @starredContainer.empty()
+    @additionalStarrredPackages = []
+    @showMoreStarred.hide()
 
     @loadingStarredMessage.show()
     @loadingStarredMessage.text('Loading starred packages')

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -45,6 +45,13 @@ class InstallPanel extends ScrollView
           @div outlet: 'loadingMessage', class: 'alert alert-info icon icon-hourglass'
           @div outlet: 'featuredContainer', class: 'container package-container'
 
+      @div class: 'section packages', =>
+        @div class: 'section-container', =>
+          @div outlet: 'starreedHeading', class: 'section-heading icon icon-star', 'Starred Packages'
+          @div outlet: 'starreedErrors'
+          @div outlet: 'loadingStarredMessage', class: 'alert alert-info icon icon-hourglass'
+          @div outlet: 'starreedContainer', class: 'container package-container'
+
   initialize: (@packageManager) ->
     super
     @disposables = new CompositeDisposable()
@@ -61,6 +68,7 @@ class InstallPanel extends ScrollView
     @searchType = 'packages'
     @handleSearchEvents()
 
+    @loadStarredPackages()
     @loadFeaturedPackages()
 
   dispose: ->
@@ -193,6 +201,17 @@ class InstallPanel extends ScrollView
         theme
       else
         not theme
+
+  # Load starred packages
+  loadStarredPackages: ->
+    @packageManager.getStarred()
+      .then (packages) =>
+        @loadingStarredMessage.hide()
+        packages
+      .then (packages) =>
+        @addPackageViews(@starreedContainer, packages)
+      .catch (error) =>
+        @starreedErrors.append(new ErrorView(@packageManager, error))
 
   # Load and display the featured packages that are available to install.
   loadFeaturedPackages: (loadThemes) ->

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -40,7 +40,7 @@ class InstallPanel extends ScrollView
 
       @div class: 'section packages', =>
         @div class: 'section-container', =>
-          @div outlet: 'featuredHeading', class: 'section-heading icon icon-star'
+          @div outlet: 'featuredHeading', class: 'section-heading icon icon-megaphone'
           @div outlet: 'featuredErrors'
           @div outlet: 'loadingMessage', class: 'alert alert-info icon icon-hourglass'
           @div outlet: 'featuredContainer', class: 'container package-container'

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -212,7 +212,7 @@ class InstallPanel extends ScrollView
     packageRow.append(packageCard)
 
   getPackageCardView: (pack) ->
-    new PackageCard(pack, @packageManager, back: 'Install')
+    new PackageCard(pack, @packageManager, {back: 'Install', stats: {downloads: true, stars: true}})
 
   filterPackages: (packages, themes) ->
     packages.filter ({theme}) ->

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -283,7 +283,7 @@ class InstallPanel extends ScrollView
       @additionalStarCount.text packages.length - @maxStarredPackages
       @additionalStarrredPackages = packages.slice(@maxStarredPackages)
 
-      @showMoreStarred.on 'click', (e) =>
+      @disposables.add @showMoreStarred.on 'click', (e) =>
         @addPackageViews(@starredContainer, @additionalStarrredPackages)
         @showMoreStarred.hide()
         false

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -277,6 +277,7 @@ class InstallPanel extends ScrollView
   showStarredPackagesList: (packages) ->
     @loadingStarredMessage.hide()
     @showMoreStarred.hide()
+    @starredContainer.empty()
 
     if packages.length > @maxStarredPackages
       @additionalStarCount.text packages.length - @maxStarredPackages

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -269,13 +269,11 @@ class InstallPanel extends ScrollView
 
   # Load starred packages
   loadStarredPackages: ->
-    @starredPackagesSection.show()
-    @packageManager.getStarred()
+    @packageManager.getStarred()\
       .then (packages) =>
         @loadingStarredMessage.hide()
-        packages
-      .then (packages) =>
         @addPackageViews(@starredContainer, packages)
+        @starredPackagesSection.show()
       .catch (error) =>
         @starreedErrors.append(new ErrorView(@packageManager, error))
 

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -42,13 +42,6 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
             @div outlet: 'communityPackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
-          @section class: 'sub-section starred-packages', =>
-            @h3 outlet: 'starredPackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Starred Packages'
-              @span outlet: 'starredCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'starredPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
-
           @section class: 'sub-section core-packages', =>
             @h3 outlet: 'corePackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Core Packages'
@@ -77,14 +70,12 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
       core: new List('name')
       user: new List('name')
       git: new List('name')
-      starred: new List('name')
       deprecated: new List('name')
     @itemViews =
       dev: new ListView(@items.dev, @devPackages, @createPackageCard)
       core: new ListView(@items.core, @corePackages, @createPackageCard)
       user: new ListView(@items.user, @communityPackages, @createPackageCard)
       git: new ListView(@items.git, @gitPackages, @createPackageCard)
-      starred: new ListView(@items.starred, @starredPackages, @createPackageCard)
       deprecated: new ListView(@items.deprecated, @deprecatedPackages, @createPackageCard)
 
     @filterEditor.getModel().onDidStopChanging => @matchPackages()
@@ -139,11 +130,6 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
       for {name, latestVersion} in packages
         packagesWithUpdates[name] = latestVersion
       @displayPackageUpdates(packagesWithUpdates)
-
-    @packageManager.getStarred().then (packages) =>
-      @items.starred.setItems(packages)
-      @starredPackages.find('.alert.loading-area').remove()
-      @updateSectionCount(@starredPackagesHeader, @starredCount, packages.length)
 
     @packageManager.getInstalled()
       .then (packages) =>

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -42,6 +42,13 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
             @div outlet: 'communityPackages', class: 'container package-container', =>
               @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
+          @section class: 'sub-section starred-packages', =>
+            @h3 outlet: 'starredPackagesHeader', class: 'sub-section-heading icon icon-package', =>
+              @text 'Starred Packages'
+              @span outlet: 'starredCount', class: 'section-heading-count badge badge-flexible', '…'
+            @div outlet: 'starredPackages', class: 'container package-container', =>
+              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+
           @section class: 'sub-section core-packages', =>
             @h3 outlet: 'corePackagesHeader', class: 'sub-section-heading icon icon-package', =>
               @text 'Core Packages'
@@ -70,12 +77,14 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
       core: new List('name')
       user: new List('name')
       git: new List('name')
+      starred: new List('name')
       deprecated: new List('name')
     @itemViews =
       dev: new ListView(@items.dev, @devPackages, @createPackageCard)
       core: new ListView(@items.core, @corePackages, @createPackageCard)
       user: new ListView(@items.user, @communityPackages, @createPackageCard)
       git: new ListView(@items.git, @gitPackages, @createPackageCard)
+      starred: new ListView(@items.starred, @starredPackages, @createPackageCard)
       deprecated: new ListView(@items.deprecated, @deprecatedPackages, @createPackageCard)
 
     @filterEditor.getModel().onDidStopChanging => @matchPackages()
@@ -130,6 +139,11 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
       for {name, latestVersion} in packages
         packagesWithUpdates[name] = latestVersion
       @displayPackageUpdates(packagesWithUpdates)
+
+    @packageManager.getStarred().then (packages) =>
+      @items.starred.setItems(packages)
+      @starredPackages.find('.alert.loading-area').remove()
+      @updateSectionCount(@starredPackagesHeader, @starredCount, packages.length)
 
     @packageManager.getInstalled()
       .then (packages) =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,7 +26,7 @@ module.exports =
       type: 'boolean'
       default: false
       description: """
-        Enables listing your starred packages from http://atom.io. It requires access to your systems keychachain
+        Enables listing your starred packages from http://atom.io. It requires access to your systems keychain
         to save your access token or an `ATOM_ACCESS_TOKEN` environment variable set to retrieve them.
       """
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,6 +21,15 @@ openPanel = (settingsView, panelName, uri) ->
   settingsView.showPanel(panelName, options)
 
 module.exports =
+  config:
+    enableStarredPackages:
+      type: 'boolean'
+      default: false
+      description: """
+        Enables listing your starred packages from http://atom.io. It requires access to your systems keychachain
+        to save your access token or an `ATOM_ACCESS_TOKEN` environment variable set to retrieve them.
+      """
+
   activate: ->
     atom.workspace.addOpener (uri) =>
       if uri.startsWith(configUri)

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -315,23 +315,19 @@ class PackageCard extends View
       @packageStars.hide()
 
   enableStarPackage: ->
-    new Promise (resolve, reject) =>
-      if @packageManager.starredPackages
-        resolve(@packageManager.starredPackages)
-      else
-        resolve(@packageManager.getStarred())
-    .then (packages) =>
-      @starred = _.filter(packages, (pkg) =>
-        pkg.name is @pack.name).length > 0
-    .then =>
-      @packageStars.addClass('active') if @starred
-    .then =>
-      @packageStars.on 'click', (e) =>
-        @packageManager.toggleStar(@pack)
-        @packageStars.toggleClass('active')
-        e.stopPropagation()
-    .catch (error) ->
-      console.log error
+    @packageManager.getStarred()
+      .then (packages) =>
+        @starred = _.filter(packages, (pkg) =>
+          pkg.name is @pack.name).length > 0
+      .then =>
+        @packageStars.addClass('active') if @starred
+      .then =>
+        @packageStars.on 'click', (e) =>
+          @packageManager.toggleStar(@pack)
+          @packageStars.toggleClass('active')
+          e.stopPropagation()
+      .catch (error) ->
+        console.log error
 
   displayUndeprecatedState: ->
     @removeClass('deprecated')

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -305,19 +305,23 @@ class PackageCard extends View
       @packageStars.hide()
 
   enableStarPackage: ->
-    @packageManager.getStarred()
-      .then (packages) =>
-        @starred = _.filter(packages, (pkg) =>
-          pkg.name is @pack.name).length > 0
-      .then =>
-        @packageStars.addClass('active') if @starred
-      .then =>
-        @packageStars.on 'click', (e) =>
-          @packageManager.toggleStar(@pack)
-          @packageStars.toggleClass('active')
-          e.stopPropagation()
-      .catch (error) ->
-        console.log error
+    new Promise (resolve, reject) =>
+      if @packageManager.starredPackages
+        resolve(@packageManager.starredPackages)
+      else
+        resolve(@packageManager.getStarred())
+    .then (packages) =>
+      @starred = _.filter(packages, (pkg) =>
+        pkg.name is @pack.name).length > 0
+    .then =>
+      @packageStars.addClass('active') if @starred
+    .then =>
+      @packageStars.on 'click', (e) =>
+        @packageManager.toggleStar(@pack)
+        @packageStars.toggleClass('active')
+        e.stopPropagation()
+    .catch (error) ->
+      console.log error
 
   displayUndeprecatedState: ->
     @removeClass('deprecated')

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -291,8 +291,24 @@ class PackageCard extends View
 
     if options?.stats?.stars
       @packageStars.show()
+      @enableStarPackage()
     else
       @packageStars.hide()
+
+  enableStarPackage: ->
+    @packageManager.getStarred()
+      .then (packages) =>
+        @starred = _.filter(packages, (pkg) =>
+          pkg.name is @pack.name).length > 0
+      .then =>
+        @packageStars.addClass('active') if @starred
+      .then =>
+        @packageStars.on 'click', (e) =>
+          @packageManager.toggleStar(@pack)
+          @packageStars.toggleClass('active')
+          e.stopPropagation()
+      .catch (error) ->
+        console.log error
 
   displayUndeprecatedState: ->
     @removeClass('deprecated')

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -217,8 +217,6 @@ class PackageManager
           reject(error)
         else
           resolve(result)
-    .then (packages) =>
-      packages
 
   getFeatured: (loadThemes) ->
     new Promise (resolve, reject) =>

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -12,6 +12,7 @@ class PackageManager
   constructor: ->
     @packagePromises = []
     @availablePackageCache = null
+    @starredPackages = null
     @apmCache =
       loadOutdated:
         value: null
@@ -210,14 +211,14 @@ class PackageManager
     args = ['stars']
     errorMessage = 'Fetching starred packages failed.'
 
-    new Promise (resolve, reject) =>
+    @starredPackages ?= new Promise (resolve, reject) =>
       @loadPackagesJson args, errorMessage, (error, result) ->
         if error
           reject(error)
         else
           resolve(result)
     .then (packages) =>
-      @starredPackages = packages
+      packages
 
   getFeatured: (loadThemes) ->
     new Promise (resolve, reject) =>
@@ -428,6 +429,8 @@ class PackageManager
       args.unshift('unstar')
     else
       args.unshift('star')
+
+    @starredPackages = null
 
     errorMessage = "Unable to #{args.join(' ')}"
     @runCommand args, (code, stdout, stderr) ->

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -93,11 +93,6 @@ class PackageManager
 
     handleProcessErrors(apmProcess, errorMessage, callback)
 
-  loadStarred: (callback) ->
-    args = ['stars']
-    errorMessage = 'Fetching starred packages failed.'
-    @starredPackages = @loadPackagesJson(args, errorMessage, callback)
-
   loadFeatured: (loadThemes, callback) ->
     unless callback
       callback = loadThemes
@@ -213,12 +208,17 @@ class PackageManager
           resolve(result)
 
   getStarred: ->
+    args = ['stars']
+    errorMessage = 'Fetching starred packages failed.'
+
     new Promise (resolve, reject) =>
-      @loadStarred (error, result) ->
+      @loadPackagesJson args, errorMessage, (error, result) ->
         if error
           reject(error)
         else
           resolve(result)
+    .then (packages) =>
+      @starredPackages = packages
 
   getFeatured: (loadThemes) ->
     new Promise (resolve, reject) =>

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -431,19 +431,17 @@ class PackageManager
 
     @getStarred()
       .then (packages) ->
-        packages.indexOf(pkg) is not -1
+        _.filter(packages, (starredPkg) ->
+          starredPkg.name is pkg.name).length > 0
       .then (starred) =>
-        @starOrUnstar(not starred, pkg.name)
-      .then (action) =>
-
-        @starred = []
+        @starOrUnstar(starred, pkg.name)
 
   starOrUnstar: (star, pack) ->
     args = [pack]
     if star
-      args.unshift('star')
-    else
       args.unshift('unstar')
+    else
+      args.unshift('star')
 
     errorMessage = "Unable to #{args.join(' ')}"
     @runCommand args, (code, stdout, stderr) ->

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -435,6 +435,8 @@ class PackageManager
           starredPkg.name is pkg.name).length > 0
       .then (starred) =>
         @starOrUnstar(starred, pkg.name)
+      .then (apmProcess) =>
+        @emitPackageEvent(apmProcess.process.spawnargs[1], pkg)
 
   starOrUnstar: (star, pack) ->
     args = [pack]

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -11,7 +11,6 @@ class PackageManager
 
   constructor: ->
     @packagePromises = []
-    @starredPackages = []
     @availablePackageCache = null
     @apmCache =
       loadOutdated:

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -53,24 +53,6 @@ class PackageManager
     args.push('--no-color')
     new BufferedProcess({command, args, stdout, stderr, exit})
 
-  loadPackagesJson: (args, callback) ->
-    args.push('--json')
-
-    @runCommand args, (code, stdout, stderr) ->
-      if code is 0
-        try
-          packages = JSON.parse(stdout) ? []
-        catch parseError
-          error = createJsonParseError(errorMessage, parseError, stdout)
-          return callback(error)
-
-        callback(null, packages)
-      else
-        error = new Error(errorMessage)
-        error.stdout = stdout
-        error.stderr = stderr
-        callback(error)
-
   loadInstalled: (callback) ->
     args = ['ls', '--json']
     errorMessage = 'Fetching local packages failed.'
@@ -118,11 +100,6 @@ class PackageManager
         callback(error)
 
     handleProcessErrors(apmProcess, errorMessage, callback)
-
-  loadStarred: (callback) ->
-    args = ['starred']
-    errorMessage = 'Fetching local packages failed.'
-    handleProcessErrors(@loadPackagesJson(args, callback))
 
   loadOutdated: (callback) ->
     # Short circuit if we have cached data.
@@ -213,14 +190,6 @@ class PackageManager
   getFeatured: (loadThemes) ->
     new Promise (resolve, reject) =>
       @loadFeatured !!loadThemes, (error, result) ->
-        if error
-          reject(error)
-        else
-          resolve(result)
-
-  getStarred: ->
-    new Promise (resolve, reject) =>
-      @loadStarred (error, result) ->
         if error
           reject(error)
         else

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -39,6 +39,11 @@ class SettingsView extends ScrollView
     super
     @packageManager = new PackageManager()
     @deferredPanel = activePanel
+
+    atom.config.observe 'settings-view.enableStarredPackages', (value) =>
+      if value
+        @packageManager.getClient().getToken()
+
     process.nextTick => @initializePanels()
 
   dispose: ->

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fuzzaldrin": "^2.1",
     "glob": "4.3.1",
     "hosted-git-info": "^2.1.4",
+    "keytar": "^3.0.2",
     "marked": "^0.3.3",
     "request": "^2.40",
     "roaster": "^1.1.2",

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -113,6 +113,7 @@ describe 'InstallPanel', ->
     beforeEach ->
       atom.config.set('settings-view.enableStarredPackages', true)
       @panel = new InstallPanel(@packageManager)
+      jasmine.attachToDOM(@panel.element)
 
     it 'shows the starred packages section', ->
       expect(@panel.starredPackagesSection).toBeVisible()

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -108,3 +108,11 @@ describe 'InstallPanel', ->
         spyOn(@panel, 'updateGitPackageCard')
         @packageManager.emitter.emit('package-installed', {pack: newPack})
         expect(@panel.updateGitPackageCard).toHaveBeenCalledWith newPack
+
+  describe "when starred packages are enabled", ->
+    beforeEach ->
+      atom.config.set('settings-view.enableStarredPackages', true)
+      @panel = new InstallPanel(@packageManager)
+
+    it 'shows the starred packages section', ->
+      expect(@panel.starredPackagesSection).toBeVisible()

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -56,6 +56,17 @@ describe 'InstallPanel', ->
       expect(@panel.searchType).toBe 'themes'
       expect(@panel.search.callCount).toBe 3
 
+  describe "when the search is empty it clears the results", ->
+    beforeEach ->
+      spyOn(@panel, 'search')
+      @panel.searchEditorView.setText('')
+      @panel.resultsContainer.append('<div/>')
+
+    it "performs a search for the contents of the input", ->
+      @panel.searchPackagesButton.click()
+      expect(@panel.search.callCount).toBe 0
+      expect(@panel.resultsContainer.children().length).toBe 0
+
   describe "searching git packages", ->
     beforeEach ->
       spyOn(@panel, 'showGitInstallPackageCard').andCallThrough()

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -77,6 +77,34 @@ describe "PackageCard", ->
     expect(card.loginLink.text()).toBe(authorName)
     expect(card.loginLink.attr("href")).toBe("https://atom.io/users/#{authorName}")
 
+  describe "when stats options are given", ->
+    [pack] = []
+
+    beforeEach ->
+      pack = {theme: 'syntax', name: 'test-theme'}
+
+    describe "for downloads", ->
+      it "shows the downloads count", ->
+        card = new PackageCard(pack, packageManager, {
+          stats: {
+            downloads: true
+          }
+        })
+        jasmine.attachToDOM(card[0])
+
+        expect(card.packageDownloads).toBeVisible()
+
+    describe "for stars", ->
+      it "shows the star count", ->
+        card = new PackageCard(pack, packageManager, {
+          stats: {
+            stars: true
+          }
+        })
+        jasmine.attachToDOM(card[0])
+
+        expect(card.packageStars).toBeVisible()
+
   describe "when the package is not installed", ->
     it "shows the settings, uninstall, and disable buttons", ->
       pack =

--- a/styles/package-card.less
+++ b/styles/package-card.less
@@ -150,6 +150,12 @@
         .icon {
           color: @text-color-subtle;
         }
+
+        &.active,
+        &.active .icon:before {
+          font-weight: bold;
+          color: @text-color-highlight;
+        }
       }
 
       .star-box {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -333,6 +333,13 @@
     }
   }
 
+  .container-show-more {
+    cursor: pointer;
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+  }
+
   .control-label {
     -webkit-user-select: none;
     cursor: default;


### PR DESCRIPTION
This PR is to implement #141 and add features to star packages and make them available to install.
- [x] Clear results on empty search
- [x] Make starred packages available in "Install" panel
- [x] Show package stars in PackageCard
- [x] Implement token authentication for `apm` (see [auth.coffee](https://github.com/atom/apm/blob/master/src/auth.coffee))
- [x] Allow to star/unstar packages in PackageCard
- [x] Limit starred packages to a reasonable number and allow showing more on demand.
- [x] Reload starred packages on star and unstar
- [x] Show hint when no packages are starred and hint to star some
- [x] Polish style
- [x] Ensure responsive interaction
- [ ] Specs for starred packages feature

As a start the first commit adds a starred packages section to "Packages"

![screen shot 2016-06-23 at 13 05 13](https://cloud.githubusercontent.com/assets/7757/16300998/2f020e02-3943-11e6-8253-b63cd66bd09a.png)
