### PR TITLE
Fix overflowing of the keybindings panel

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -458,6 +458,7 @@
     flex-flow: column;
     display: flex;
     position: relative;
+    min-width: 0;
 
    .panels-item {
       flex: 1;


### PR DESCRIPTION
Same issue as https://github.com/atom/atom/pull/11866

#### Before

Content that overflows the edge gets cut off and you can't scroll.

![screen shot 2016-06-24 at 3 33 02 pm](https://cloud.githubusercontent.com/assets/378023/16330010/4515d654-3a21-11e6-9ca2-0eef88ca743a.png)

#### After

Content is "responsive" and the table is scrollable again.

![screen shot 2016-06-24 at 3 32 19 pm](https://cloud.githubusercontent.com/assets/378023/16330016/4cd1ea72-3a21-11e6-915b-1015bd4d45b9.png)
