### PR TITLE
Move the editor settings to their own tab

### DIFF
--- a/lib/editor-panel.coffee
+++ b/lib/editor-panel.coffee
@@ -2,7 +2,7 @@
 SettingsPanel = require './settings-panel'
 
 module.exports =
-class GeneralPanel extends ScrollView
+class EditorPanel extends ScrollView
   @content: ->
     @div tabindex: 0, class: 'panels-item', =>
       @form class: 'general-panel section', =>
@@ -13,8 +13,8 @@ class GeneralPanel extends ScrollView
     @loadingElement.remove()
 
     @subPanels = [
-      new SettingsPanel('core', note: '''
-        <div class="text icon icon-question" id="core-settings-note" tabindex="-1">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages may have their own additional settings found within their package card in the <a class="link packages-open">Packages list</a>.</div>
+      new SettingsPanel('editor', note: '''
+        <div class="text icon icon-question" id="editor-settings-note" tabindex="-1">These settings are related to text editing. Some of these can be overriden on a per-language basis. Check language settings by clicking its package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
     ]
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,6 +33,7 @@ module.exports =
 
     atom.commands.add 'atom-workspace',
       'settings-view:open': -> atom.workspace.open(configUri)
+      'settings-view:editor': -> atom.workspace.open("#{configUri}/editor")
       'settings-view:show-keybindings': -> atom.workspace.open("#{configUri}/keybindings")
       'settings-view:change-themes': -> atom.workspace.open("#{configUri}/themes")
       'settings-view:install-packages-and-themes': -> atom.workspace.open("#{configUri}/install")

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -8,6 +8,7 @@ fuzzaldrin = require 'fuzzaldrin'
 
 Client = require './atom-io-client'
 GeneralPanel = require './general-panel'
+EditorPanel = require './editor-panel'
 PackageDetailView = require './package-detail-view'
 KeybindingsPanel = require './keybindings-panel'
 PackageManager = require './package-manager'
@@ -63,7 +64,8 @@ class SettingsView extends ScrollView
     @openDotAtom.on 'click', ->
       atom.open(pathsToOpen: [atom.getConfigDirPath()])
 
-    @addCorePanel 'Settings', 'settings', -> new GeneralPanel
+    @addCorePanel 'Core', 'settings', -> new GeneralPanel
+    @addCorePanel 'Editor', 'file-text', -> new EditorPanel
     @addCorePanel 'Keybindings', 'keyboard', -> new KeybindingsPanel
     @addCorePanel 'Packages', 'package', => new InstalledPackagesPanel(@packageManager)
     @addCorePanel 'Themes', 'paintcan', => new ThemesPanel(@packageManager)
@@ -71,7 +73,7 @@ class SettingsView extends ScrollView
     @addCorePanel 'Install', 'plus', => new InstallPanel(@packageManager)
 
     @showDeferredPanel()
-    @showPanel('Settings') unless @activePanel
+    @showPanel('Core') unless @activePanel
     @sidebar.width(@sidebar.width()) if @isOnDom()
 
   serialize: ->

--- a/spec/editor-panel-spec.coffee
+++ b/spec/editor-panel-spec.coffee
@@ -1,0 +1,108 @@
+EditorPanel = require '../lib/editor-panel'
+
+describe "EditorPanel", ->
+  panel = null
+
+  getValueForId = (id) ->
+    element = panel.find("##{id.replace(/\./g, '\\.')}")
+    if element.is("input")
+      element.prop('checked')
+    else if element.is("select")
+      element.val()
+    else
+      element.view()?.getText()
+
+  setValueForId = (id, value) ->
+    element = panel.find("##{id.replace(/\./g, '\\.')}")
+    if element.is("input")
+      element.prop('checked', value)
+      element.change()
+    else if element.is("select")
+      element.val(value)
+      element.change()
+    else
+      element.view().setText(value?.toString())
+      window.advanceClock(10000) # wait for contents-modified to be triggered
+
+  beforeEach ->
+    atom.config.set('editor.boolean', true)
+    atom.config.set('editor.string', 'hey')
+    atom.config.set('editor.object', {boolean: true, int: 3, string: 'test'})
+    atom.config.set('editor.simpleArray', ['a', 'b', 'c'])
+    atom.config.set('editor.complexArray', ['a', 'b', {c: true}])
+
+    atom.config.setSchema('', type: 'object')
+
+    panel = new EditorPanel()
+
+  it "automatically binds named fields to their corresponding config keys", ->
+    expect(getValueForId('editor.boolean')).toBeTruthy()
+    expect(getValueForId('editor.string')).toBe 'hey'
+    expect(getValueForId('editor.object.boolean')).toBeTruthy()
+    expect(getValueForId('editor.object.int')).toBe '3'
+    expect(getValueForId('editor.object.string')).toBe 'test'
+
+    atom.config.set('editor.boolean', false)
+    atom.config.set('editor.string', 'hey again')
+    atom.config.set('editor.object.boolean', false)
+    atom.config.set('editor.object.int', 6)
+    atom.config.set('editor.object.string', 'hi')
+
+    expect(getValueForId('editor.boolean')).toBeFalsy()
+    expect(getValueForId('editor.string')).toBe 'hey again'
+    expect(getValueForId('editor.object.boolean')).toBeFalsy()
+    expect(getValueForId('editor.object.int')).toBe '6'
+    expect(getValueForId('editor.object.string')).toBe 'hi'
+
+    setValueForId('editor.string', "oh hi")
+    setValueForId('editor.boolean', true)
+    setValueForId('editor.object.boolean', true)
+    setValueForId('editor.object.int', 9)
+    setValueForId('editor.object.string', 'yo')
+
+    expect(atom.config.get('editor.boolean')).toBe true
+    expect(atom.config.get('editor.string')).toBe 'oh hi'
+    expect(atom.config.get('editor.object.boolean')).toBe true
+    expect(atom.config.get('editor.object.int')).toBe 9
+    expect(atom.config.get('editor.object.string')).toBe 'yo'
+
+    setValueForId('editor.string', '')
+    setValueForId('editor.object.int', '')
+    setValueForId('editor.object.string', '')
+
+    expect(atom.config.get('editor.string')).toBeUndefined()
+    expect(atom.config.get('editor.object.int')).toBeUndefined()
+    expect(atom.config.get('editor.object.string')).toBeUndefined()
+
+  it "does not save the config value until it has been changed to a new value", ->
+    observeHandler = jasmine.createSpy("observeHandler")
+    atom.config.observe "editor.simpleArray", observeHandler
+    observeHandler.reset()
+
+    window.advanceClock(10000) # wait for contents-modified to be triggered
+    expect(observeHandler).not.toHaveBeenCalled()
+
+    setValueForId('editor.simpleArray', 2)
+    expect(observeHandler).toHaveBeenCalled()
+    observeHandler.reset()
+
+    setValueForId('editor.simpleArray', 2)
+    expect(observeHandler).not.toHaveBeenCalled()
+
+  it "does not update the editor text unless the value it parses to changes", ->
+    setValueForId('editor.simpleArray', "a, b,")
+    expect(atom.config.get('editor.simpleArray')).toEqual ['a', 'b']
+    expect(getValueForId('editor.simpleArray')).toBe 'a, b,'
+
+  it "only adds editors for arrays when all the values in the array are strings", ->
+    expect(getValueForId('editor.simpleArray')).toBe 'a, b, c'
+    expect(getValueForId('editor.complexArray')).toBeUndefined()
+
+    setValueForId('editor.simpleArray', 'a, d')
+
+    expect(atom.config.get('editor.simpleArray')).toEqual ['a', 'd']
+    expect(atom.config.get('editor.complexArray')).toEqual ['a', 'b', {c: true}]
+
+  it "shows the package settings notes for core and editor settings", ->
+    expect(panel.find('#editor-settings-note')).toExist()
+    expect(panel.find('#editor-settings-note').text()).toContain('Check language settings')

--- a/spec/general-panel-spec.coffee
+++ b/spec/general-panel-spec.coffee
@@ -28,11 +28,6 @@ describe "GeneralPanel", ->
     atom.config.set('core.enum', 4)
     atom.config.set('core.int', 22)
     atom.config.set('core.float', 0.1)
-    atom.config.set('editor.boolean', true)
-    atom.config.set('editor.string', 'hey')
-    atom.config.set('editor.object', {boolean: true, int: 3, string: 'test'})
-    atom.config.set('editor.simpleArray', ['a', 'b', 'c'])
-    atom.config.set('editor.complexArray', ['a', 'b', {c: true}])
 
     atom.config.setSchema('', type: 'object')
     atom.config.setSchema('core.enum',
@@ -47,59 +42,28 @@ describe "GeneralPanel", ->
     expect(getValueForId('core.enum')).toBe '4'
     expect(getValueForId('core.int')).toBe '22'
     expect(getValueForId('core.float')).toBe '0.1'
-    expect(getValueForId('editor.boolean')).toBeTruthy()
-    expect(getValueForId('editor.string')).toBe 'hey'
-    expect(getValueForId('editor.object.boolean')).toBeTruthy()
-    expect(getValueForId('editor.object.int')).toBe '3'
-    expect(getValueForId('editor.object.string')).toBe 'test'
 
     atom.config.set('core.enum', 6)
     atom.config.set('core.int', 222)
     atom.config.set('core.float', 0.11)
-    atom.config.set('editor.boolean', false)
-    atom.config.set('editor.string', 'hey again')
-    atom.config.set('editor.object.boolean', false)
-    atom.config.set('editor.object.int', 6)
-    atom.config.set('editor.object.string', 'hi')
 
     expect(getValueForId('core.enum')).toBe '6'
     expect(getValueForId('core.int')).toBe '222'
     expect(getValueForId('core.float')).toBe '0.11'
-    expect(getValueForId('editor.boolean')).toBeFalsy()
-    expect(getValueForId('editor.string')).toBe 'hey again'
-    expect(getValueForId('editor.object.boolean')).toBeFalsy()
-    expect(getValueForId('editor.object.int')).toBe '6'
-    expect(getValueForId('editor.object.string')).toBe 'hi'
 
     setValueForId('core.enum', '2')
     setValueForId('core.int', 90)
     setValueForId('core.float', 89.2)
-    setValueForId('editor.string', "oh hi")
-    setValueForId('editor.boolean', true)
-    setValueForId('editor.object.boolean', true)
-    setValueForId('editor.object.int', 9)
-    setValueForId('editor.object.string', 'yo')
 
     expect(atom.config.get('core.enum')).toBe 2
     expect(atom.config.get('core.int')).toBe 90
     expect(atom.config.get('core.float')).toBe 89.2
-    expect(atom.config.get('editor.boolean')).toBe true
-    expect(atom.config.get('editor.string')).toBe 'oh hi'
-    expect(atom.config.get('editor.object.boolean')).toBe true
-    expect(atom.config.get('editor.object.int')).toBe 9
-    expect(atom.config.get('editor.object.string')).toBe 'yo'
 
     setValueForId('core.int', '')
     setValueForId('core.float', '')
-    setValueForId('editor.string', '')
-    setValueForId('editor.object.int', '')
-    setValueForId('editor.object.string', '')
 
     expect(atom.config.get('core.int')).toBeUndefined()
     expect(atom.config.get('core.float')).toBeUndefined()
-    expect(atom.config.get('editor.string')).toBeUndefined()
-    expect(atom.config.get('editor.object.int')).toBeUndefined()
-    expect(atom.config.get('editor.object.string')).toBeUndefined()
 
   it "does not save the config value until it has been changed to a new value", ->
     observeHandler = jasmine.createSpy("observeHandler")
@@ -121,22 +85,6 @@ describe "GeneralPanel", ->
     expect(atom.config.get('core.int')).toBe 2
     expect(getValueForId('core.int')).toBe '2.'
 
-    setValueForId('editor.simpleArray', "a, b,")
-    expect(atom.config.get('editor.simpleArray')).toEqual ['a', 'b']
-    expect(getValueForId('editor.simpleArray')).toBe 'a, b,'
-
-  it "only adds editors for arrays when all the values in the array are strings", ->
-    expect(getValueForId('editor.simpleArray')).toBe 'a, b, c'
-    expect(getValueForId('editor.complexArray')).toBeUndefined()
-
-    setValueForId('editor.simpleArray', 'a, d')
-
-    expect(atom.config.get('editor.simpleArray')).toEqual ['a', 'd']
-    expect(atom.config.get('editor.complexArray')).toEqual ['a', 'b', {c: true}]
-
   it "shows the package settings notes for core and editor settings", ->
     expect(panel.find('#core-settings-note')).toExist()
-    expect(panel.find('#core-settings-note').text()).toContain('Check individual package settings')
-
-    expect(panel.find('#editor-settings-note')).toExist()
-    expect(panel.find('#editor-settings-note').text()).toContain('Check language settings')
+    expect(panel.find('#core-settings-note').text()).toContain('their package card in')

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -39,7 +39,7 @@ describe "SettingsView", ->
       settingsView.remove()
       jasmine.attachToDOM(newSettingsView.element)
       newSettingsView.initializePanels()
-      expect(newSettingsView.activePanel).toEqual {name: 'Settings', options: {}}
+      expect(newSettingsView.activePanel).toEqual {name: 'Core', options: {}}
 
     it "serializes the active panel name even when the panels were never initialized", ->
       settingsView.showPanel('Themes')
@@ -90,11 +90,18 @@ describe "SettingsView", ->
         settingsView = null
 
       describe "settings-view:open", ->
-        it "opens the settings view", ->
+        it "opens the core settings view", ->
           openWithCommand('settings-view:open')
           runs ->
             expect(atom.workspace.getActivePaneItem().activePanel)
-              .toEqual name: 'Settings', options: {}
+              .toEqual name: 'Core', options: {}
+
+      describe "settings-view:editor", ->
+        it "opens the editor settings view", ->
+          openWithCommand('settings-view:editor')
+          runs ->
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Editor', options: uri: 'atom://config/editor'
 
       describe "settings-view:show-keybindings", ->
         it "opens the settings view to the keybindings page", ->
@@ -164,7 +171,17 @@ describe "SettingsView", ->
         waitsFor (done) -> process.nextTick(done)
         runs ->
           expect(settingsView.activePanel)
-            .toEqual name: 'Settings', options: {}
+            .toEqual name: 'Core', options: {}
+          expect(focusIsWithinActivePanel()).toBe true
+          expectActivePanelToBeKeyboardScrollable()
+
+        waitsForPromise ->
+          atom.workspace.open('atom://config/editor').then (s) -> settingsView = s
+
+        waits 1
+        runs ->
+          expect(settingsView.activePanel)
+            .toEqual name: 'Editor', options: uri: 'atom://config/editor'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
@@ -260,7 +277,7 @@ describe "SettingsView", ->
         waitsFor (done) -> process.nextTick(done)
 
         runs ->
-          expect(settingsView.activePanel).toEqual {name: 'Settings', options: {}}
+          expect(settingsView.activePanel).toEqual {name: 'Core', options: {}}
 
         waitsForPromise ->
           atom.workspace.open('atom://config/install/package:something').then (s) -> settingsView = s
@@ -283,7 +300,8 @@ describe "SettingsView", ->
         runs ->
           settingsView = atom.workspace.getActivePaneItem()
           panels = [
-            settingsView.getOrCreatePanel('Settings')
+            settingsView.getOrCreatePanel('Core')
+            settingsView.getOrCreatePanel('Editor')
             settingsView.getOrCreatePanel('Keybindings')
             settingsView.getOrCreatePanel('Packages')
             settingsView.getOrCreatePanel('Themes')


### PR DESCRIPTION
The Settings tab within Settings was getting very long and is already broken into Core and Editor.

This PR renames the current tab Core and moves Editor out to its own tab, as shown;;

![image](https://cloud.githubusercontent.com/assets/118951/16505031/de8b0324-3ecf-11e6-80de-e5603b6bdd0f.png)
