### PR TITLE
Add new System tab for Windows shell integration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All of the following commands are under the `atom-workspace` selector.
 |Command|Description|Keybinding (Linux)|Keybinding (OS X)|Keybinding (Windows)|
 |-------|-----------|------------------|-----------------|--------------------|
 |`settings-view:open`|Opens the Settings View|<kbd>ctrl-,</kbd>|<kbd>cmd-,</kbd>|<kbd>ctrl-,</kbd>|
+|`settings-view:system`|Opens the _System_ section of the Settings View (Windows)|
 |`settings-view:show-keybindings`|Opens the _Keybindings_ section of the Settings View|
 |`settings-view:uninstall-packages`|Opens the _Packages_ section of the Settings View|
 |`settings-view:change-themes`|Opens the _Themes_ section of the Settings View|

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,6 +34,7 @@ module.exports =
     atom.commands.add 'atom-workspace',
       'settings-view:open': -> atom.workspace.open(configUri)
       'settings-view:editor': -> atom.workspace.open("#{configUri}/editor")
+      'settings-view:system': -> atom.workspace.open("#{configUri}/system") if process.platform is 'win32'
       'settings-view:show-keybindings': -> atom.workspace.open("#{configUri}/keybindings")
       'settings-view:change-themes': -> atom.workspace.open("#{configUri}/themes")
       'settings-view:install-packages-and-themes': -> atom.workspace.open("#{configUri}/install")

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -35,7 +35,6 @@ module.exports =
       'settings-view:open': -> atom.workspace.open(configUri)
       'settings-view:core': -> atom.workspace.open("#{configUri}/core")
       'settings-view:editor': -> atom.workspace.open("#{configUri}/editor")
-      'settings-view:system': -> atom.workspace.open("#{configUri}/system") if process.platform is 'win32'
       'settings-view:show-keybindings': -> atom.workspace.open("#{configUri}/keybindings")
       'settings-view:change-themes': -> atom.workspace.open("#{configUri}/themes")
       'settings-view:install-packages-and-themes': -> atom.workspace.open("#{configUri}/install")
@@ -44,6 +43,9 @@ module.exports =
       'settings-view:view-installed-packages': -> atom.workspace.open("#{configUri}/packages")
       'settings-view:uninstall-packages': -> atom.workspace.open("#{configUri}/packages")
       'settings-view:check-for-package-updates': -> atom.workspace.open("#{configUri}/updates")
+
+    if process.platform is 'win32' and require('atom').WinShell?
+      atom.commands.add 'atom-workspace', 'settings-view:system': -> atom.workspace.open("#{configUri}/system")
 
   deactivate: ->
     settingsView?.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,6 +33,7 @@ module.exports =
 
     atom.commands.add 'atom-workspace',
       'settings-view:open': -> atom.workspace.open(configUri)
+      'settings-view:core': -> atom.workspace.open("#{configUri}/core")
       'settings-view:editor': -> atom.workspace.open("#{configUri}/editor")
       'settings-view:system': -> atom.workspace.open("#{configUri}/system") if process.platform is 'win32'
       'settings-view:show-keybindings': -> atom.workspace.open("#{configUri}/keybindings")

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -47,10 +47,6 @@ class SettingsView extends ScrollView
       panel.dispose?()
     return
 
-  #TODO Remove both of these post 1.0
-  onDidChangeTitle: -> new Disposable()
-  onDidChangeModified: -> new Disposable()
-
   initializePanels: ->
     return if @panels.size > 0
 
@@ -66,7 +62,7 @@ class SettingsView extends ScrollView
 
     @addCorePanel 'Core', 'settings', -> new GeneralPanel
     @addCorePanel 'Editor', 'file-text', -> new EditorPanel
-    if process.platform is 'win32'
+    if process.platform is 'win32' and require('atom').WinShell?
       SystemPanel = require './system-windows-panel'
       @addCorePanel 'System', 'device-desktop', -> new SystemPanel
     @addCorePanel 'Keybindings', 'keyboard', -> new KeybindingsPanel

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -66,6 +66,9 @@ class SettingsView extends ScrollView
 
     @addCorePanel 'Core', 'settings', -> new GeneralPanel
     @addCorePanel 'Editor', 'file-text', -> new EditorPanel
+    if process.platform is 'win32' # TODO: Min-version for Atom install/upgrade scripts?
+      SystemPanel = require './system-windows-panel'
+      @addCorePanel 'System', 'device-desktop', -> new SystemPanel
     @addCorePanel 'Keybindings', 'keyboard', -> new KeybindingsPanel
     @addCorePanel 'Packages', 'package', => new InstalledPackagesPanel(@packageManager)
     @addCorePanel 'Themes', 'paintcan', => new ThemesPanel(@packageManager)

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -66,7 +66,7 @@ class SettingsView extends ScrollView
 
     @addCorePanel 'Core', 'settings', -> new GeneralPanel
     @addCorePanel 'Editor', 'file-text', -> new EditorPanel
-    if process.platform is 'win32' # TODO: Min-version for Atom install/upgrade scripts?
+    if process.platform is 'win32'
       SystemPanel = require './system-windows-panel'
       @addCorePanel 'System', 'device-desktop', -> new SystemPanel
     @addCorePanel 'Keybindings', 'keyboard', -> new KeybindingsPanel

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -19,7 +19,7 @@ class SystemPanel extends ScrollView
                       @input outlet: 'fileHandlerCheckbox', id: 'system.windows.file-handler', type: 'checkbox'
                       @div class: 'setting-title', 'Register as file handler'
                       @div class: 'setting-description', =>
-                        @raw("Show #{WindowsShell.appName} in the \"Open with\" application list for easy association with file types.")
+                        @raw("Show #{WinShell.appName} in the \"Open with\" application list for easy association with file types.")
               @div class: 'control-group', =>
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
@@ -27,7 +27,7 @@ class SystemPanel extends ScrollView
                       @input outlet: 'fileContextMenuCheckbox', id: 'system.windows.shell-menu-files', type: 'checkbox'
                       @div class: 'setting-title', 'Show in file context menus'
                       @div class: 'setting-description', =>
-                        @raw("Add \"Open with #{WindowsShell.appName}\" to the File Explorer context menu for files.")
+                        @raw("Add \"Open with #{WinShell.appName}\" to the File Explorer context menu for files.")
               @div class: 'control-group', =>
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
@@ -35,7 +35,7 @@ class SystemPanel extends ScrollView
                       @input outlet: 'folderContextMenuCheckbox', id: 'system.windows.shell-menu-folders', type: 'checkbox'
                       @div class: 'setting-title', 'Show in folder context menus'
                       @div class: 'setting-description', =>
-                        @raw("Add \"Open with #{WindowsShell.appName}\" to the File Explorer context menu for folders.")
+                        @raw("Add \"Open with #{WinShell.appName}\" to the File Explorer context menu for folders.")
 
   initialize: ->
     super
@@ -43,11 +43,11 @@ class SystemPanel extends ScrollView
     WinShell.fileContextMenu.isRegistered (i) => @fileContextMenuCheckbox.prop('checked', i)
     WinShell.folderContextMenu.isRegistered (i) => @folderContextMenuCheckbox.prop('checked', i)
 
-    @fileHandlerCheckbox.on 'click', (e) -> setRegistration WinShell.fileHandler, e.target.clicked
-    @fileContextMenuCheckbox.on 'click', (e) -> setRegistration WinShell.fileContextMenu, e.target.clicked
-    @folderContextMenuCheckbox.on 'click', (e) ->
-      setRegistration WinShell.folderContextMenu, e.target.clicked
-      setRegistration WinShell.folderBackgroundContextMenu, e.target.clicked
+    @fileHandlerCheckbox.on 'click', (e) => @setRegistration WinShell.fileHandler, e.target.checked
+    @fileContextMenuCheckbox.on 'click', (e) => @setRegistration WinShell.fileContextMenu, e.target.checked
+    @folderContextMenuCheckbox.on 'click', (e) =>
+      @setRegistration WinShell.folderContextMenu, e.target.checked
+      @setRegistration WinShell.folderBackgroundContextMenu, e.target.checked
 
   setRegistration: (option, shouldBeRegistered) ->
     if shouldBeRegistered

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -1,0 +1,102 @@
+{ScrollView} = require 'atom-space-pen-views'
+SettingsPanel = require './settings-panel'
+Registry = require 'winreg'
+Path = require 'path'
+
+exeName = Path.basename(process.execPath)
+appPath = "\"#{process.execPath}\""
+appName = exeName.replace('atom', 'Atom').replace('beta', 'Beta').replace('.exe', '')
+
+fileHandlerRegistry = {
+  key: "\\Software\\Classes\\Applications\\#{exeName}",
+  parts: [{key: 'shell\\open\\command', name: '', value: "#{appPath} \"%1\""}]
+}
+
+contextRegistryParts = [
+    {key: 'command', name: '', value: "#{appPath} \"%1\""},
+    {name: '', value: "Open with #{appName}"},
+    {name: 'Icon', value: "#{appPath}"}
+]
+
+contextFileRegistry = {
+  key: "\\Software\\Classes\\*\\shell\\#{appName}",
+  parts: contextRegistryParts
+}
+
+contextFolderRegistry = {
+  key: "\\Software\\Classes\\Directory\\shell\\#{appName}",
+  parts: contextRegistryParts
+}
+
+contextFolderBackgroundRegistry = {
+  key: "\\Software\\Classes\\Directory\\background\\shell\\#{appName}",
+  parts: JSON.parse(JSON.stringify(contextRegistryParts).replace('%1', '%V'))
+}
+
+module.exports =
+class SystemPanel extends ScrollView
+  @content: ->
+    @div tabindex: 0, class: 'panels-item', =>
+      @form class: 'general-panel section', =>
+        @div class: 'settings-panel', =>
+          @div class: 'section-container', =>
+            @div class: 'block section-heading icon icon-device-desktop', 'System settings'
+            @div class: 'text icon icon-question', 'These settings determine how Atom integrates with your operating system.'
+            @div class: 'section-body', =>
+              @div class: 'control-group', =>
+                @div class: 'controls', =>
+                  @div class: 'checkbox', =>
+                    @label for: 'system.windows.file-handler', =>
+                      @input outlet: 'fileHandlerCheckbox', id: 'system.windows.file-handler', type: 'checkbox'
+                      @div class: 'setting-title', 'Register as file handler'
+                      @div class: 'setting-description', =>
+                        @raw('Show Atom in the "Open with" application list for easy association with file types.')
+              @div class: 'control-group', =>
+                @div class: 'controls', =>
+                  @div class: 'checkbox', =>
+                    @label for: 'system.windows.shell-menu-files', =>
+                      @input outlet: 'contextFileCheckbox', id: 'system.windows.shell-menu-files', type: 'checkbox'
+                      @div class: 'setting-title', 'Show in file context menus'
+                      @div class: 'setting-description', =>
+                        @raw('Add "Open with Atom" to the File Explorer context menu for files.')
+              @div class: 'control-group', =>
+                @div class: 'controls', =>
+                  @div class: 'checkbox', =>
+                    @label for: 'system.windows.shell-menu-folders', =>
+                      @input outlet: 'contextFolderCheckbox', id: 'system.windows.shell-menu-folders', type: 'checkbox'
+                      @div class: 'setting-title', 'Show in folder context menus'
+                      @div class: 'setting-description', =>
+                        @raw('Add "Open with Atom" to the File Explorer context menu for folders.')
+
+  initialize: ->
+    super
+    @checkRegistry(fileHandlerRegistry, (isSet) => @fileHandlerCheckbox.prop('checked', isSet))
+    @checkRegistry(contextFileRegistry, (isSet) => @contextFileCheckbox.prop('checked', isSet))
+    @checkRegistry(contextFolderRegistry, (isSet) => @contextFolderCheckbox.prop('checked', isSet))
+
+    @fileHandlerCheckbox.on 'click', (e) => @updateRegistry(fileHandlerRegistry, e.target.checked, -> )
+    @contextFileCheckbox.on 'click', (e) => @updateRegistry(contextFileRegistry, e.target.checked, -> )
+    @contextFolderCheckbox.on 'click', (e) =>
+      @updateRegistry(contextFolderRegistry, e.target.checked, -> )
+      @updateRegistry(contextFolderBackgroundRegistry, e.target.checked, -> )
+
+  updateRegistry: (area, shouldBeSet, callback) ->
+    if shouldBeSet
+      @setRegistry(area, callback)
+    else
+      @clearRegistry(area, callback)
+
+  checkRegistry: (area, callback) ->
+    new Registry({hive: 'HKCU', key: "#{area.key}\\#{area.parts[0].key}"})
+      .get(area.parts[0].name, (err, val) -> callback(not err? and val.value is area.parts[0].value))
+
+  setRegistry: (area, callback) ->
+    doneCount = area.parts.length
+    area.parts.forEach((part) ->
+      reg = new Registry({hive: 'HKCU', key: if part.key? then "#{area.key}\\#{part.key}" else area.key})
+      reg.create( -> reg.set(part.name, Registry.REG_SZ, part.value, -> callback() if doneCount-- is 0))
+    )
+
+  clearRegistry: (area, callback) ->
+    new Registry({hive: 'HKCU', key: area.key})
+      .destroy(callback)

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -49,6 +49,9 @@ class SystemPanel extends ScrollView
       @setRegistration WinShell.folderContextMenu, e.target.checked
       @setRegistration WinShell.folderBackgroundContextMenu, e.target.checked
 
+  dispose: ->
+    return
+
   setRegistration: (option, shouldBeRegistered) ->
     if shouldBeRegistered
       option.register ->

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -1,37 +1,6 @@
 {ScrollView} = require 'atom-space-pen-views'
+{WinShell} = require 'atom'
 SettingsPanel = require './settings-panel'
-Registry = require 'winreg'
-Path = require 'path'
-
-exeName = Path.basename(process.execPath)
-appPath = "\"#{process.execPath}\""
-appName = exeName.replace('atom', 'Atom').replace('beta', 'Beta').replace('.exe', '')
-
-fileHandlerRegistry = {
-  key: "\\Software\\Classes\\Applications\\#{exeName}",
-  parts: [{key: 'shell\\open\\command', name: '', value: "#{appPath} \"%1\""}]
-}
-
-contextRegistryParts = [
-    {key: 'command', name: '', value: "#{appPath} \"%1\""},
-    {name: '', value: "Open with #{appName}"},
-    {name: 'Icon', value: "#{appPath}"}
-]
-
-contextFileRegistry = {
-  key: "\\Software\\Classes\\*\\shell\\#{appName}",
-  parts: contextRegistryParts
-}
-
-contextFolderRegistry = {
-  key: "\\Software\\Classes\\Directory\\shell\\#{appName}",
-  parts: contextRegistryParts
-}
-
-contextFolderBackgroundRegistry = {
-  key: "\\Software\\Classes\\Directory\\background\\shell\\#{appName}",
-  parts: JSON.parse(JSON.stringify(contextRegistryParts).replace('%1', '%V'))
-}
 
 module.exports =
 class SystemPanel extends ScrollView
@@ -50,53 +19,38 @@ class SystemPanel extends ScrollView
                       @input outlet: 'fileHandlerCheckbox', id: 'system.windows.file-handler', type: 'checkbox'
                       @div class: 'setting-title', 'Register as file handler'
                       @div class: 'setting-description', =>
-                        @raw('Show Atom in the "Open with" application list for easy association with file types.')
+                        @raw("Show #{WindowsShell.appName} in the \"Open with\" application list for easy association with file types.")
               @div class: 'control-group', =>
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
                     @label for: 'system.windows.shell-menu-files', =>
-                      @input outlet: 'contextFileCheckbox', id: 'system.windows.shell-menu-files', type: 'checkbox'
+                      @input outlet: 'fileContextMenuCheckbox', id: 'system.windows.shell-menu-files', type: 'checkbox'
                       @div class: 'setting-title', 'Show in file context menus'
                       @div class: 'setting-description', =>
-                        @raw('Add "Open with Atom" to the File Explorer context menu for files.')
+                        @raw("Add \"Open with #{WindowsShell.appName}\" to the File Explorer context menu for files.")
               @div class: 'control-group', =>
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
                     @label for: 'system.windows.shell-menu-folders', =>
-                      @input outlet: 'contextFolderCheckbox', id: 'system.windows.shell-menu-folders', type: 'checkbox'
+                      @input outlet: 'folderContextMenuCheckbox', id: 'system.windows.shell-menu-folders', type: 'checkbox'
                       @div class: 'setting-title', 'Show in folder context menus'
                       @div class: 'setting-description', =>
-                        @raw('Add "Open with Atom" to the File Explorer context menu for folders.')
+                        @raw("Add \"Open with #{WindowsShell.appName}\" to the File Explorer context menu for folders.")
 
   initialize: ->
     super
-    @checkRegistry(fileHandlerRegistry, (isSet) => @fileHandlerCheckbox.prop('checked', isSet))
-    @checkRegistry(contextFileRegistry, (isSet) => @contextFileCheckbox.prop('checked', isSet))
-    @checkRegistry(contextFolderRegistry, (isSet) => @contextFolderCheckbox.prop('checked', isSet))
+    WinShell.fileHandler.isRegistered (i) => @fileHandlerCheckbox.prop('checked', i)
+    WinShell.fileContextMenu.isRegistered (i) => @fileContextMenuCheckbox.prop('checked', i)
+    WinShell.folderContextMenu.isRegistered (i) => @folderContextMenuCheckbox.prop('checked', i)
 
-    @fileHandlerCheckbox.on 'click', (e) => @updateRegistry(fileHandlerRegistry, e.target.checked, -> )
-    @contextFileCheckbox.on 'click', (e) => @updateRegistry(contextFileRegistry, e.target.checked, -> )
-    @contextFolderCheckbox.on 'click', (e) =>
-      @updateRegistry(contextFolderRegistry, e.target.checked, -> )
-      @updateRegistry(contextFolderBackgroundRegistry, e.target.checked, -> )
+    @fileHandlerCheckbox.on 'click', (e) -> setRegistration WinShell.fileHandler, e.target.clicked
+    @fileContextMenuCheckbox.on 'click', (e) -> setRegistration WinShell.fileContextMenu, e.target.clicked
+    @folderContextMenuCheckbox.on 'click', (e) ->
+      setRegistration WinShell.folderContextMenu, e.target.clicked
+      setRegistration WinShell.folderBackgroundContextMenu, e.target.clicked
 
-  updateRegistry: (area, shouldBeSet, callback) ->
-    if shouldBeSet
-      @setRegistry(area, callback)
+  setRegistration: (option, shouldBeRegistered) ->
+    if shouldBeRegistered
+      option.register ->
     else
-      @clearRegistry(area, callback)
-
-  checkRegistry: (area, callback) ->
-    new Registry({hive: 'HKCU', key: "#{area.key}\\#{area.parts[0].key}"})
-      .get(area.parts[0].name, (err, val) -> callback(not err? and val.value is area.parts[0].value))
-
-  setRegistry: (area, callback) ->
-    doneCount = area.parts.length
-    area.parts.forEach((part) ->
-      reg = new Registry({hive: 'HKCU', key: if part.key? then "#{area.key}\\#{part.key}" else area.key})
-      reg.create( -> reg.set(part.name, Registry.REG_SZ, part.value, -> callback() if doneCount-- is 0))
-    )
-
-  clearRegistry: (area, callback) ->
-    new Registry({hive: 'HKCU', key: area.key})
-      .destroy(callback)
+      option.deregister ->

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "fuzzaldrin": "^2.1",
     "glob": "4.3.1",
     "hosted-git-info": "^2.1.4",
-    "marked": "^0.3.3",
+    "marked": "^0.3.5",
     "request": "^2.40",
     "roaster": "^1.1.2",
     "season": "^5.0.2",
     "semver": "^4.3.2",
-    "underscore-plus": "^1.0.6"
+    "underscore-plus": "^1.0.6",
+    "winreg": "^1.2.1"
   },
   "repository": "https://github.com/atom/settings-view",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "roaster": "^1.1.2",
     "season": "^5.0.2",
     "semver": "^4.3.2",
-    "underscore-plus": "^1.0.6",
-    "winreg": "^1.2.1"
+    "underscore-plus": "^1.0.6"
   },
   "repository": "https://github.com/atom/settings-view",
   "engines": {

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -237,14 +237,16 @@ describe "SettingsView", ->
         waitsForPromise ->
           atom.workspace.open('atom://config/install').then (s) -> settingsView = s
 
+        hasSystemPanel = false
         waits 1
         runs ->
           expect(settingsView.activePanel)
             .toEqual name: 'Install', options: uri: 'atom://config/install'
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
+          hasSystemPanel = settingsView.panelsByName['System']?
 
-        if process.platform is 'win32'
+        if hasSystemPanel
           waitsForPromise ->
             atom.workspace.open('atom://config/system').then (s) -> settingsView = s
 

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -235,6 +235,17 @@ describe "SettingsView", ->
           expect(focusIsWithinActivePanel()).toBe true
           expectActivePanelToBeKeyboardScrollable()
 
+        if process.platform is 'win32'
+          waitsForPromise ->
+            atom.workspace.open('atom://config/system').then (s) -> settingsView = s
+
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'System', options: uri: 'atom://config/system'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
       it "opens the package settings view with atom://config/packages/<package-name>", ->
         waitsForPromise ->
           atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'package-with-readme'))
@@ -302,6 +313,7 @@ describe "SettingsView", ->
           panels = [
             settingsView.getOrCreatePanel('Core')
             settingsView.getOrCreatePanel('Editor')
+            settingsView.getOrCreatePanel('System') if process.platform is 'win32'
             settingsView.getOrCreatePanel('Keybindings')
             settingsView.getOrCreatePanel('Packages')
             settingsView.getOrCreatePanel('Themes')

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -90,11 +90,20 @@ describe "SettingsView", ->
         settingsView = null
 
       describe "settings-view:open", ->
-        it "opens the core settings view", ->
+        it "opens the settings view", ->
           openWithCommand('settings-view:open')
           runs ->
             expect(atom.workspace.getActivePaneItem().activePanel)
               .toEqual name: 'Core', options: {}
+
+      describe "settings-view:core", ->
+        it "opens the core settings view", ->
+          openWithCommand('settings-view:editor')
+          runs ->
+            openWithCommand('settings-view:core')
+          runs ->
+            expect(atom.workspace.getActivePaneItem().activePanel)
+              .toEqual name: 'Core', options: uri: 'atom://config/core'
 
       describe "settings-view:editor", ->
         it "opens the editor settings view", ->

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -324,13 +324,15 @@ describe "SettingsView", ->
           panels = [
             settingsView.getOrCreatePanel('Core')
             settingsView.getOrCreatePanel('Editor')
-            settingsView.getOrCreatePanel('System') if process.platform is 'win32'
             settingsView.getOrCreatePanel('Keybindings')
             settingsView.getOrCreatePanel('Packages')
             settingsView.getOrCreatePanel('Themes')
             settingsView.getOrCreatePanel('Updates')
             settingsView.getOrCreatePanel('Install')
           ]
+          systemPanel = settingsView.getOrCreatePanel('System')
+          if systemPanel?
+            panels.push systemPanel
           for panel in panels
             spyOn(panel, 'dispose')
 


### PR DESCRIPTION
Adds a new System tab on Windows that allows configuration of the OS shell integration options for things like the file handler, file context menu and folder context menu.