### PR TITLE
Order packages and themes case-insensitively

### DIFF
--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -229,7 +229,15 @@ class ThemesPanel extends CollapsibleSectionPanel
   populateThemeMenus: ->
     @uiMenu.empty()
     @syntaxMenu.empty()
-    availableThemes = _.sortBy(atom.themes.getLoadedThemes(), 'name')
+    availableThemes = atom.themes.getLoadedThemes().sort (a, b) ->
+      nameA = a.name.toLowerCase()
+      nameB = b.name.toLowerCase()
+      if nameA < nameB
+        -1
+      else if nameA > nameB
+        1
+      else 0
+
     for {name, metadata} in availableThemes
       switch metadata.theme
         when 'ui'

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -270,7 +270,7 @@ class ThemesPanel extends CollapsibleSectionPanel
 
   # Get a human readable title for the given theme name.
   getThemeTitle: (themeName='') ->
-    title = themeName.replace(/-(ui|syntax)/g, '').replace(/-theme$/g, '')
+    title = themeName.replace(/-(ui|syntax)/gi, '').replace(/-theme$/gi, '')
     _.undasherize(_.uncamelcase(title))
 
   createPackageCard: (pack) =>

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -18,9 +18,11 @@ packageComparatorAscending = (left, right) ->
   leftStatus = atom.packages.isPackageDisabled(left.name)
   rightStatus = atom.packages.isPackageDisabled(right.name)
   if leftStatus is rightStatus
-    if left.name > right.name
+    leftName = left.name.toLowerCase()
+    rightName = right.name.toLowerCase()
+    if leftName > rightName
       -1
-    else if left.name < right.name
+    else if leftName < rightName
       1
     else
       0

--- a/spec/fixtures/Z-package/package.json
+++ b/spec/fixtures/Z-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "Z-Package",
+  "version": "1.0.0",
+  "theme": "syntax"
+}

--- a/spec/fixtures/installed.json
+++ b/spec/fixtures/installed.json
@@ -17,6 +17,10 @@
     {
       "name": "user-package",
       "version": "1.0.0"
+    },
+    {
+      "name": "Z-package",
+      "version": "1.0.0"
     }
   ],
   "dev": [

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -21,7 +21,7 @@ describe 'InstalledPackagesPanel', ->
         @packageManager.getInstalled.callCount is 1 and @panel.communityCount.text().indexOf('…') < 0
 
       runs ->
-        expect(@panel.communityCount.text().trim()).toBe '1/1'
+        expect(@panel.communityCount.text().trim()).toBe '1/2'
         expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 1
 
         expect(@panel.coreCount.text().trim()).toBe '0/1'
@@ -46,8 +46,8 @@ describe 'InstalledPackagesPanel', ->
         @packageManager.getInstalled.callCount is 1 and @panel.communityCount.text().indexOf('…') < 0
 
     it 'shows packages', ->
-      expect(@panel.communityCount.text().trim()).toBe '1'
-      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 1
+      expect(@panel.communityCount.text().trim()).toBe '2'
+      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
       expect(@panel.coreCount.text().trim()).toBe '1'
       expect(@panel.corePackages.find('.package-card:not(.hidden)').length).toBe 1
@@ -61,7 +61,7 @@ describe 'InstalledPackagesPanel', ->
     it 'filters packages by name', ->
       @panel.filterEditor.getModel().setText('user-')
       window.advanceClock(@panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
-      expect(@panel.communityCount.text().trim()).toBe '1/1'
+      expect(@panel.communityCount.text().trim()).toBe '1/2'
       expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 1
 
       expect(@panel.coreCount.text().trim()).toBe '0/1'
@@ -73,6 +73,11 @@ describe 'InstalledPackagesPanel', ->
       expect(@panel.deprecatedCount.text().trim()).toBe '0/0'
       expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 0
 
+    it 'sorts packages case-insensitively', ->
+      @panel.filterEditor.getModel().setText('')
+      window.advanceClock(@panel.filterEditor.getModel().getBuffer().stoppedChangingDelay)
+      expect(@panel.communityPackages.find('.package-card:not(.hidden) .package-name')[0].textContent).not.toBe "Z-package"
+
     it 'adds newly installed packages to the list', ->
       [installCallback] = []
       spyOn(@packageManager, 'runCommand').andCallFake (args, callback) ->
@@ -81,8 +86,8 @@ describe 'InstalledPackagesPanel', ->
       spyOn(atom.packages, 'activatePackage').andCallFake (name) =>
         @installed.user.push {name}
 
-      expect(@panel.communityCount.text().trim()).toBe '1'
-      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 1
+      expect(@panel.communityCount.text().trim()).toBe '2'
+      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
       @packageManager.install({name: 'another-user-package'})
       installCallback(0, '', '')
@@ -90,8 +95,8 @@ describe 'InstalledPackagesPanel', ->
       advanceClock InstalledPackagesPanel.loadPackagesDelay
       waits 1
       runs ->
-        expect(@panel.communityCount.text().trim()).toBe '2'
-        expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
+        expect(@panel.communityCount.text().trim()).toBe '3'
+        expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 3
 
     it 'removes uninstalled packages from the list', ->
       [uninstallCallback] = []
@@ -101,8 +106,8 @@ describe 'InstalledPackagesPanel', ->
       spyOn(@packageManager, 'unload').andCallFake (name) =>
         @installed.user = []
 
-      expect(@panel.communityCount.text().trim()).toBe '1'
-      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 1
+      expect(@panel.communityCount.text().trim()).toBe '2'
+      expect(@panel.communityPackages.find('.package-card:not(.hidden)').length).toBe 2
 
       @packageManager.uninstall({name: 'user-package'})
       uninstallCallback(0, '', '')
@@ -137,8 +142,8 @@ describe 'InstalledPackagesPanel', ->
       waits 1
       runs ->
         expect(@panel.deprecatedSection).toBeVisible()
-        expect(@panel.deprecatedCount.text().trim()).toBe '1'
-        expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 1
+        expect(@panel.deprecatedCount.text().trim()).toBe '2'
+        expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 2
 
         spyOn(PackageCard::, 'displayAvailableUpdate')
         resolve([{name: 'user-package', latestVersion: '1.1.0'}])

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -116,7 +116,7 @@ describe "package manager", ->
         expect(packageManager.runCommand).toHaveBeenCalled()
         expect(runArgs).toEqual ['install', 'user/repo', '--json']
 
-      it 'installs and activates git pacakges with names different from the repo name', ->
+      it 'installs and activates git packages with names different from the repo name', ->
         spyOn(atom.packages, 'activatePackage')
         packageManager.install(name: 'git-repo-name')
         json =
@@ -226,14 +226,14 @@ describe "package manager", ->
         expect(installedCallback.mostRecentCall.args[1]).toEqual eventArg
 
   describe "::packageHasSettings", ->
-    it "returns true when the pacakge has config", ->
+    it "returns true when the package has config", ->
       atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-config'))
       expect(packageManager.packageHasSettings('package-with-config')).toBe true
 
-    it "returns false when the pacakge does not have config and doesn't define language grammars", ->
+    it "returns false when the package does not have config and doesn't define language grammars", ->
       expect(packageManager.packageHasSettings('random-package')).toBe false
 
-    it "returns true when the pacakge does not have config, but does define language grammars", ->
+    it "returns true when the package does not have config, but does define language grammars", ->
       packageName = 'language-test'
 
       waitsForPromise ->


### PR DESCRIPTION
Minor detail. Packages that begin with a capital letter appear at the top of the packages and themes list, which looks pretty jarring (more so when everything's already formatted in title-case).

I'm aware NPM (and by convention, APM) force users to use lowercase package names, but this won't stop a developer from linking an unpublished package into their workspace (even if it was just to [test something briefly](https://github.com/Alhadis/Breakshow)).