### PR TITLE
Unify icons between tabs and titles

### DIFF
--- a/lib/editor-panel.coffee
+++ b/lib/editor-panel.coffee
@@ -13,7 +13,7 @@ class EditorPanel extends ScrollView
     @loadingElement.remove()
 
     @subPanels = [
-      new SettingsPanel('editor', note: '''
+      new SettingsPanel('editor', icon: 'file-text', note: '''
         <div class="text icon icon-question" id="editor-settings-note" tabindex="-1">These settings are related to text editing. Some of these can be overriden on a per-language basis. Check language settings by clicking its package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
     ]

--- a/lib/editor-panel.coffee
+++ b/lib/editor-panel.coffee
@@ -13,7 +13,7 @@ class EditorPanel extends ScrollView
     @loadingElement.remove()
 
     @subPanels = [
-      new SettingsPanel('editor', icon: 'file-text', note: '''
+      new SettingsPanel('editor', icon: 'code', note: '''
         <div class="text icon icon-question" id="editor-settings-note" tabindex="-1">These settings are related to text editing. Some of these can be overriden on a per-language basis. Check language settings by clicking its package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
     ]

--- a/lib/general-panel.coffee
+++ b/lib/general-panel.coffee
@@ -13,7 +13,7 @@ class GeneralPanel extends ScrollView
     @loadingElement.remove()
 
     @subPanels = [
-      new SettingsPanel('core', note: '''
+      new SettingsPanel('core', icon: 'settings', note: '''
         <div class="text icon icon-question" id="core-settings-note" tabindex="-1">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages may have their own additional settings found within their package card in the <a class="link packages-open">Packages list</a>.</div>
       ''')
     ]

--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -19,7 +19,7 @@ class InstallPanel extends ScrollView
     @div class: 'panels-item', =>
       @div class: 'section packages', =>
         @div class: 'section-container', =>
-          @h1 outlet: 'installHeading', class: 'section-heading icon icon-cloud-download', 'Install Packages'
+          @h1 outlet: 'installHeading', class: 'section-heading icon icon-plus', 'Install Packages'
 
           @div class: 'text native-key-bindings', tabindex: -1, =>
             @span class: 'icon icon-question'

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -61,7 +61,7 @@ class SettingsView extends ScrollView
       atom.open(pathsToOpen: [atom.getConfigDirPath()])
 
     @addCorePanel 'Core', 'settings', -> new GeneralPanel
-    @addCorePanel 'Editor', 'file-text', -> new EditorPanel
+    @addCorePanel 'Editor', 'code', -> new EditorPanel
     if process.platform is 'win32' and require('atom').WinShell?
       SystemPanel = require './system-windows-panel'
       @addCorePanel 'System', 'device-desktop', -> new SystemPanel

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -5,11 +5,11 @@ SettingsPanel = require './settings-panel'
 module.exports =
 class SystemPanel extends ScrollView
   @content: ->
-    @div tabindex: 0, class: 'panels-item', =>
+    @div class: 'panels-item', =>
       @form class: 'general-panel section', =>
         @div class: 'settings-panel', =>
           @div class: 'section-container', =>
-            @div class: 'block section-heading icon icon-device-desktop', 'System settings'
+            @div class: 'block section-heading icon icon-device-desktop', 'System Settings'
             @div class: 'text icon icon-question', 'These settings determine how Atom integrates with your operating system.'
             @div class: 'section-body', =>
               @div class: 'control-group', =>

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -23,7 +23,7 @@ class ThemesPanel extends CollapsibleSectionPanel
     @div class: 'panels-item', =>
       @div class: 'section packages themes-panel', =>
         @div class: 'section-container', =>
-          @div class: 'section-heading icon icon-device-desktop', 'Choose a Theme'
+          @div class: 'section-heading icon icon-paintcan', 'Choose a Theme'
 
           @div class: 'text native-key-bindings', tabindex: -1, =>
             @span class: 'icon icon-question', 'You can also style Atom by editing '


### PR DESCRIPTION
- Core Settings title now uses icon-settings like sidebar
- System Settings now title-cased
- Install title now uses icon-plus like sidebar
- Theme title now uses icon-paintcan like sidebar