### PR TITLE
Fix #821 Settings-view overflows when pane is narrow

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -7,6 +7,7 @@
 
 .settings-view {
   display: flex;
+  overflow: auto;
 
   .breadcrumb {
     margin-bottom: 0;


### PR DESCRIPTION
Sets `overflow: auto` for settings-view to prevent overflow.

see #821 