### PR TITLE
Height incorrectly set to 100%

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -542,7 +542,6 @@
   }
 
   .packages {
-    height: 100%;
     display: flex;
     flex-flow: column;
 


### PR DESCRIPTION
Fix height of "Choose a Theme" and "Install Packages" panels when running Atom with recent versions of Electron (currently 1.3.3). See https://github.com/tensor5/arch-atom/issues/38.

![screenshot from 2016-08-21 10-25-06](https://cloud.githubusercontent.com/assets/1545895/17834781/f1c6a6d0-678a-11e6-8807-9215b525754e.png)

![screenshot from 2016-08-21 10-25-19](https://cloud.githubusercontent.com/assets/1545895/17834791/0adb10a2-678b-11e6-8c42-8c443ee3b72d.png)

![screenshot from 2016-08-21 10-25-23](https://cloud.githubusercontent.com/assets/1545895/17834794/11282f76-678b-11e6-9ff5-c77df2cf2cbc.png)

![screenshot from 2016-08-21 10-25-32](https://cloud.githubusercontent.com/assets/1545895/17834795/1e827fe6-678b-11e6-8553-a3d1a93d9e02.png)
