### PR TITLE
In scoped editor settings panels, use unscoped setting value as its default

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -42,7 +42,6 @@ class SettingsPanel extends CollapsibleSectionPanel
     @bindEditors()
     @handleEvents()
 
-
   dispose: ->
     @disposables.dispose()
 
@@ -114,9 +113,12 @@ class SettingsPanel extends CollapsibleSectionPanel
     not value? or defaultValue is value
 
   getDefault: (name) ->
-    params = {excludeSources: [atom.config.getUserConfigPath()]}
-    params.scope = [@options.scopeName] if @options.scopeName?
-    atom.config.get(name, params)
+    if @options.scopeName?
+      atom.config.get(name)
+    else
+      params = {excludeSources: [atom.config.getUserConfigPath()]}
+      params.scope = [@options.scopeName] if @options.scopeName?
+      atom.config.get(name, params)
 
   set: (name, value) ->
     if @options.scopeName
@@ -146,7 +148,10 @@ class SettingsPanel extends CollapsibleSectionPanel
       type = editorView.attr('type')
 
       if defaultValue = @valueToString(@getDefault(name))
-        editor.setPlaceholderText("Default: #{defaultValue}")
+        if @options.scopeName?
+          editor.setPlaceholderText("Unscoped value: #{defaultValue}")
+        else
+          editor.setPlaceholderText("Default: #{defaultValue}")
 
       editorElement.on 'focus', =>
         if @isDefault(name)

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -109,6 +109,21 @@ describe "SettingsPanel", ->
       settingsPanel.set('foo.testZero', 0)
       expect(settingsPanel.isDefault('foo.testZero')).toBe true
 
+    describe 'when displaying scoped settings', ->
+      it 'displays the settings unscoped value of a setting as its default', ->
+        expect(atom.config.get('editor.tabLength')).toBe(2)
+        atom.config.set('editor.tabLength', 8)
+
+        settingsPanel = new SettingsPanel("editor", {includeTitle: false, scopeName: '.source.js'})
+        tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
+        expect(tabLengthEditor.getModel().getText()).toBe('')
+        expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Unscoped value: 8')
+
+        # This is the default value, but it differs from the unscoped value
+        settingsPanel.set('editor.tabLength', 2)
+        expect(tabLengthEditor.getModel().getText()).toBe('2')
+        expect(atom.config.get('editor.tabLength', {scope: ['source.js']})).toBe(2)
+
   describe 'grouped settings', ->
     beforeEach ->
       config =


### PR DESCRIPTION
Fixes https://github.com/atom/settings-view/issues/774