### PR TITLE
Prioritize close matches in install search results

### DIFF
--- a/lib/install-panel.coffee
+++ b/lib/install-panel.coffee
@@ -125,7 +125,7 @@ class InstallPanel extends ScrollView
       null
 
   performSearch: ->
-    if query = @searchEditorView.getText().trim()
+    if query = @searchEditorView.getText().trim().toLowerCase()
       @performSearchForQuery(query)
 
   performSearchForQuery: (query) ->
@@ -170,6 +170,8 @@ class InstallPanel extends ScrollView
       .then (packages=[]) =>
         @highlightExactMatch(@resultsContainer, query, packages)
       .then (packages=[]) =>
+        @addCloseMatches(@resultsContainer, query, packages)
+      .then (packages=[]) =>
         @addPackageViews(@resultsContainer, packages)
       .catch (error) =>
         @searchMessage.hide()
@@ -189,8 +191,18 @@ class InstallPanel extends ScrollView
 
     packages
 
+  addCloseMatches: (container, query, packages) ->
+    matches = _.filter(packages, (pkg) -> pkg.name.indexOf(query) >= 0)
+
+    for pack in matches
+      packageCard = @getPackageCardView(pack)
+      @addPackageCardView(container, packageCard)
+      packages.splice(packages.indexOf(pack), 1)
+
+    packages
+
   addPackageViews: (container, packages) ->
-    for pack, index in packages
+    for pack in packages
       packageCard = @getPackageCardView(pack)
       @addPackageCardView(container, packageCard)
 


### PR DESCRIPTION
Current behavior:
![search](https://cloud.githubusercontent.com/assets/1017132/18514766/88293994-7a9b-11e6-828d-4b9b41c96f72.png)

This pull request moves packages which names contain the search query to the top, below the exact hit. 
![search2](https://cloud.githubusercontent.com/assets/1017132/18515256/626ab294-7a9d-11e6-831e-c91f188c5a32.png)

I personally think that this will surface more relevant packages in a partial search but it might bury some popular packages, for instance when searching `file-icons` then `file-type-icons` will rank lower, but it will surface more packages that contain the search term. A better long term solution would be to use a scoring system that would view each word individually.

Feedback would be appreciated.