### PR TITLE
Added `--production` flag to apm install

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -309,7 +309,7 @@ class PackageManager
     nameWithVersion = if version? then "#{name}@#{version}" else name
 
     @unload(name)
-    args = ['install', nameWithVersion, '--json']
+    args = ['install', nameWithVersion, '--production', '--json']
 
     errorMessage = "Installing \u201C#{nameWithVersion}\u201D failed."
     onError = (error) =>

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -82,12 +82,12 @@ describe "package manager", ->
     it "installs the latest version when a package version is not specified", ->
       packageManager.install {name: 'something'}, ->
       expect(packageManager.runCommand).toHaveBeenCalled()
-      expect(runArgs).toEqual ['install', 'something', '--json']
+      expect(runArgs).toEqual ['install', 'something', '--production', '--json']
 
     it "installs the package@version when a version is specified", ->
       packageManager.install {name: 'something', version: '0.2.3'}, ->
       expect(packageManager.runCommand).toHaveBeenCalled()
-      expect(runArgs).toEqual ['install', 'something@0.2.3', '--json']
+      expect(runArgs).toEqual ['install', 'something@0.2.3', '--production', '--json']
 
     it "installs the package and adds the package to the available package names", ->
       packageManager.cacheAvailablePackageNames(user: [{name: 'a-package'}])
@@ -102,19 +102,19 @@ describe "package manager", ->
         url = "https://github.com/user/repo.git"
         packageManager.install {name: url}
         expect(packageManager.runCommand).toHaveBeenCalled()
-        expect(runArgs).toEqual ['install', 'https://github.com/user/repo.git', '--json']
+        expect(runArgs).toEqual ['install', 'https://github.com/user/repo.git', '--production', '--json']
 
       it 'installs git@ urls', ->
         url = "git@github.com:user/repo.git"
         packageManager.install {name: url}
         expect(packageManager.runCommand).toHaveBeenCalled()
-        expect(runArgs).toEqual ['install', 'git@github.com:user/repo.git', '--json']
+        expect(runArgs).toEqual ['install', 'git@github.com:user/repo.git', '--production', '--json']
 
       it 'installs user/repo url shortcuts', ->
         url = "user/repo"
         packageManager.install {name: url}
         expect(packageManager.runCommand).toHaveBeenCalled()
-        expect(runArgs).toEqual ['install', 'user/repo', '--json']
+        expect(runArgs).toEqual ['install', 'user/repo', '--production', '--json']
 
       it 'installs and activates git pacakges with names different from the repo name', ->
         spyOn(atom.packages, 'activatePackage')
@@ -197,7 +197,7 @@ describe "package manager", ->
       packageManager.installAlternative({name: 'language-test'}, 'a-new-package', installedCallback)
       expect(packageManager.runCommand).toHaveBeenCalled()
       expect(packageManager.runCommand.calls[0].args[0]).toEqual(['uninstall', '--hard', 'language-test'])
-      expect(packageManager.runCommand.calls[1].args[0]).toEqual(['install', 'a-new-package', '--json'])
+      expect(packageManager.runCommand.calls[1].args[0]).toEqual(['install', 'a-new-package', '--production', '--json'])
       expect(atom.packages.isPackageLoaded('language-test')).toBe true
 
       expect(installedEvent).not.toHaveBeenCalled()


### PR DESCRIPTION
:racehorse:  The `--production` flag makes installing new packages faster and prevents a bug when packages have tons of dev-dependencies

Nylas N1 uses the same install script as Atom and on N1, installing packages wth a large number of dev-dependencies fails to install. There should be no need to install dev-dependencies for a redistributed package, so this should help speed up the install process and avoid errors such as seen in Nylas N1: https://github.com/nylas/N1/issues/2723#issuecomment-240983812

The same change was merged to the master branch of Nylas and released last weekend: https://github.com/nylas/N1/pull/2741
