### PR TITLE
Prompt to restart Atom after updating packages rather than trying to "hot reload" them

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -167,12 +167,15 @@ class PackageCard extends View
     @updateButton.on 'click', (event) =>
       event.stopPropagation()
       @update().then =>
-        atom.notifications.addSuccess("Restart Atom to complete the update of `#{@pack.name}`.", {
-          dismissable: true,
-          buttons: [{
+        buttons = []
+        # TODO: Remove conditional after 1.12.0 is released as stable
+        if atom.restartApplication?
+          buttons.push({
             text: 'Restart',
             onDidClick: -> atom.restartApplication()
-          }]
+          })
+        atom.notifications.addSuccess("Restart Atom to complete the update of `#{@pack.name}`.", {
+          dismissable: true, buttons: buttons
         })
 
     @packageName.on 'click', (event) =>

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -477,7 +477,7 @@ class PackageCard extends View
     pack = @installablePack ? @pack
     version = if @newVersion then "v#{@newVersion}" else "##{@newSha.substr(0, 8)}"
 
-    new Promise (resolve) =>
+    new Promise (resolve, reject) =>
       @packageManager.update pack, @newVersion, (error) =>
         if error?
           atom.assert false, "Package update failed", (assertionError) =>
@@ -490,7 +490,9 @@ class PackageCard extends View
               errorStderr: error.stderr
             }
           console.error("Updating #{@type} #{pack.name} to #{version} failed:\n", error, error.stderr ? '')
-        resolve(error)
+          reject(error)
+        else
+          resolve()
 
   uninstall: ->
     @packageManager.uninstall @pack, (error) =>

--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -166,7 +166,14 @@ class PackageCard extends View
 
     @updateButton.on 'click', (event) =>
       event.stopPropagation()
-      @update()
+      @update().then =>
+        atom.notifications.addSuccess("Restart Atom to complete the update of `#{@pack.name}`.", {
+          dismissable: true,
+          buttons: [{
+            text: 'Restart',
+            onDidClick: -> atom.restartApplication()
+          }]
+        })
 
     @packageName.on 'click', (event) =>
       event.stopPropagation()
@@ -469,18 +476,21 @@ class PackageCard extends View
     return unless @newVersion or @newSha
     pack = @installablePack ? @pack
     version = if @newVersion then "v#{@newVersion}" else "##{@newSha.substr(0, 8)}"
-    @packageManager.update pack, @newVersion, (error) =>
-      if error?
-        atom.assert false, "Package update failed", (assertionError) =>
-          assertionError.metadata = {
-            type: @type,
-            name: pack.name,
-            version: version,
-            errorMessage: error.message,
-            errorStack: error.stack,
-            errorStderr: error.stderr
-          }
-        console.error("Updating #{@type} #{pack.name} to #{version} failed:\n", error, error.stderr ? '')
+
+    new Promise (resolve) =>
+      @packageManager.update pack, @newVersion, (error) =>
+        if error?
+          atom.assert false, "Package update failed", (assertionError) =>
+            assertionError.metadata = {
+              type: @type,
+              name: pack.name,
+              version: version,
+              errorMessage: error.message,
+              errorStack: error.stack,
+              errorStderr: error.stderr
+            }
+          console.error("Updating #{@type} #{pack.name} to #{version} failed:\n", error, error.stderr ? '')
+        resolve(error)
 
   uninstall: ->
     @packageManager.uninstall @pack, (error) =>

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -252,14 +252,6 @@ class PackageManager
   update: (pack, newVersion, callback) ->
     {name, theme, apmInstallSource} = pack
 
-    if theme
-      activateOnSuccess = atom.packages.isPackageActive(name)
-    else
-      activateOnSuccess = not atom.packages.isPackageDisabled(name)
-    activateOnFailure = atom.packages.isPackageActive(name)
-    atom.packages.deactivatePackage(name) if atom.packages.isPackageActive(name)
-    atom.packages.unloadPackage(name) if atom.packages.isPackageLoaded(name)
-
     errorMessage = if newVersion
       "Updating to \u201C#{name}@#{newVersion}\u201D failed."
     else
@@ -277,17 +269,9 @@ class PackageManager
     exit = (code, stdout, stderr) =>
       if code is 0
         @clearOutdatedCache()
-
-        loadedPackage = atom.packages.loadPackage(name)
-
-        Promise.resolve(loadedPackage).then =>
-          if activateOnSuccess
-            atom.packages.activatePackage(name)
-
-          callback?()
-          @emitPackageEvent 'updated', pack
+        callback?()
+        @emitPackageEvent 'updated', pack
       else
-        atom.packages.activatePackage(name) if activateOnFailure
         error = new Error(errorMessage)
         error.stdout = stdout
         error.stderr = stderr

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -85,13 +85,15 @@ class UpdatesPanel extends ScrollView
         pluralizedPackages = 'package'
         pluralizedPackages += 's' if successfulUpdatesCount > 1
         message = "Restart Atom to complete the update of #{successfulUpdatesCount} #{pluralizedPackages}."
-        atom.notifications.addSuccess(message, {
-          dismissable: true,
-          buttons: [{
+
+        buttons = []
+        # TODO: Remove conditional after 1.12.0 is released as stable
+        if atom.restartApplication?
+          buttons.push({
             text: 'Restart',
             onDidClick: -> atom.restartApplication()
-          }]
-        })
+          })
+        atom.notifications.addSuccess(message, {dismissable: true, buttons})
 
     onUpdateResolved = ->
       remainingPackagesCount--

--- a/spec/installed-packages-panel-spec.coffee
+++ b/spec/installed-packages-panel-spec.coffee
@@ -146,18 +146,6 @@ describe 'InstalledPackagesPanel', ->
       waits 1
       runs ->
         expect(PackageCard::displayAvailableUpdate).toHaveBeenCalledWith('1.1.0')
-        @packageManager.update({name: 'user-package'})
-        updateCallback(0, '', '')
-
-      waits 1
-      runs ->
-        advanceClock InstalledPackagesPanel.loadPackagesDelay
-
-      waits 1
-      runs ->
-        expect(@panel.deprecatedSection).not.toBeVisible()
-        expect(@panel.deprecatedCount.text().trim()).toBe '0'
-        expect(@panel.deprecatedPackages.find('.package-card:not(.hidden)').length).toBe 0
 
   describe 'expanding and collapsing sub-sections', ->
     beforeEach ->

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -463,9 +463,12 @@ describe "PackageCard", ->
 
             notifications = atom.notifications.getNotifications()
             expect(notifications.length).toBe 1
-            spyOn(atom, 'restartApplication')
-            notifications[0].options.buttons[0].onDidClick()
-            expect(atom.restartApplication).toHaveBeenCalled()
+
+            # TODO: Remove conditional after 1.12.0 is released as stable
+            if atom.restartApplication?
+              spyOn(atom, 'restartApplication')
+              notifications[0].options.buttons[0].onDidClick()
+              expect(atom.restartApplication).toHaveBeenCalled()
 
     describe "when hasAlternative is true and alternative is core", ->
       beforeEach ->

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -415,7 +415,7 @@ describe "PackageCard", ->
           expect(card.enablementButton).toBeVisible()
           expect(card.enablementButton.text()).toBe 'Disable'
 
-        it "updates the package when the update button is clicked", ->
+        it "updates the package and shows a restart notification when the update button is clicked", ->
           expect(atom.packages.getLoadedPackage('package-with-config')).toBeTruthy()
 
           [updateCallback] = []
@@ -450,8 +450,7 @@ describe "PackageCard", ->
 
           updateCallback(0, '', '')
 
-          waitsFor ->
-            atom.packages.isPackageActive('package-with-config')
+          waits 0 # Wait for PackageCard.update promise to resolve
 
           runs ->
             expect(card.updateButton[0].disabled).toBe false
@@ -460,11 +459,13 @@ describe "PackageCard", ->
             expect(card.installButtonGroup).not.toBeVisible()
             expect(card.packageActionButtonGroup).toBeVisible()
             expect(card.installAlternativeButtonGroup).not.toBeVisible()
+            expect(card.versionValue.text()).toBe '1.0.0' # Does not update until restart
 
-            expect(card).not.toHaveClass 'deprecated'
-            expect(card.packageMessage).not.toHaveClass 'text-warning'
-            expect(card.packageMessage.text()).toBe ''
-            expect(card.versionValue.text()).toBe '1.1.0'
+            notifications = atom.notifications.getNotifications()
+            expect(notifications.length).toBe 1
+            spyOn(atom, 'restartApplication')
+            notifications[0].options.buttons[0].onDidClick()
+            expect(atom.restartApplication).toHaveBeenCalled()
 
     describe "when hasAlternative is true and alternative is core", ->
       beforeEach ->

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -70,6 +70,8 @@ describe 'UpdatesPanel', ->
         notifications = atom.notifications.getNotifications()
         expect(notifications.length).toBe 1
 
-        spyOn(atom, 'restartApplication')
-        notifications[0].options.buttons[0].onDidClick()
-        expect(atom.restartApplication).toHaveBeenCalled()
+        # TODO: Remove conditional after 1.12.0 is released as stable
+        if atom.restartApplication?
+          spyOn(atom, 'restartApplication')
+          notifications[0].options.buttons[0].onDidClick()
+          expect(atom.restartApplication).toHaveBeenCalled()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -67,4 +67,9 @@ describe 'UpdatesPanel', ->
 
       waits 0
       runs ->
-        expect(atom.notifications.getNotifications().length).toBe 1
+        notifications = atom.notifications.getNotifications()
+        expect(notifications.length).toBe 1
+
+        spyOn(atom, 'restartApplication')
+        notifications[0].options.buttons[0].onDidClick()
+        expect(atom.restartApplication).toHaveBeenCalled()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -2,8 +2,10 @@ UpdatesPanel = require '../lib/updates-panel'
 PackageManager = require '../lib/package-manager'
 
 describe 'UpdatesPanel', ->
+  panel = null
+
   beforeEach ->
-    @panel = new UpdatesPanel(new PackageManager)
+    panel = new UpdatesPanel(new PackageManager)
 
   it "Shows updates when updates are available", ->
     pack =
@@ -13,10 +15,56 @@ describe 'UpdatesPanel', ->
       version: '1.0.0'
 
     # skip packman stubbing
-    @panel.beforeShow(updates: [pack])
-    expect(@panel.updatesContainer.children().length).toBe(1)
+    panel.beforeShow(updates: [pack])
+    expect(panel.updatesContainer.children().length).toBe(1)
 
   it "Shows a message when updates are not available", ->
-    @panel.beforeShow(updates: [])
-    expect(@panel.updatesContainer.children().length).toBe(0)
-    expect(@panel.noUpdatesMessage.css('display')).not.toBe('none')
+    panel.beforeShow(updates: [])
+    expect(panel.updatesContainer.children().length).toBe(0)
+    expect(panel.noUpdatesMessage.css('display')).not.toBe('none')
+
+  describe "when the 'Update All' button is clicked", ->
+    it "attempts to update all packages and prompts to restart if at least one package updated successfully", ->
+      packA =
+        name: 'test-package-a'
+        description: 'some description'
+        latestVersion: '99.0.0'
+        version: '1.0.0'
+      packB =
+        name: 'test-package-b'
+        description: 'some description'
+        latestVersion: '99.0.0'
+        version: '1.0.0'
+      packC =
+        name: 'test-package-c'
+        description: 'some description'
+        latestVersion: '99.0.0'
+        version: '1.0.0'
+
+      # skip packman stubbing
+      panel.beforeShow(updates: [packA, packB, packC])
+
+      [cardA, cardB, cardC] = panel.getPackageCards()
+
+      [resolveA, rejectB, resolveC] = []
+
+      spyOn(cardA, 'update').andReturn(new Promise((resolve) -> resolveA = resolve))
+      spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> rejectB = reject))
+      spyOn(cardC, 'update').andReturn(new Promise((resolve) -> resolveC = resolve))
+
+      expect(atom.notifications.getNotifications().length).toBe 0
+
+      panel.updateAll()
+
+      resolveA()
+      rejectB('Error updating package')
+
+      waits 0
+      runs ->
+        expect(atom.notifications.getNotifications().length).toBe 0
+
+        resolveC()
+
+      waits 0
+      runs ->
+        expect(atom.notifications.getNotifications().length).toBe 1


### PR DESCRIPTION
Previously, we attempted to unload and reload packages after they were updated. This has never really worked and has produced a lot of confusion. The reason it doesn't work is that Node's `require` system caches values for every path, so only new files in the package would be successfully required. We could potentially do some fancy stuff to track dependencies and delete them all from the cache on reload, but I understand that it's basically impossible to unload and reload native addons in Node, which would mean even that would be a partial solution. So instead we'll just prompt the user to restart.

Depends on https://github.com/atom/atom/pull/12733 to display a "restart" button, but is  backward compatible by just making the user restart manually in older versions.

Closes https://github.com/atom/atom/issues/12650

@lee-dohm @50Wliu Are there any other issues this might also close?