### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -227,14 +227,14 @@
       border-top: none;
     }
 
-    atom-text-editor[mini], atom-text-editor[mini]::shadow {
+    atom-text-editor[mini] {
       opacity: .75;
       .selection .region {
         background-color: contrast(@input-background-color, lighten(@input-background-color, 8%), darken(@input-background-color, 8%) );
       }
     }
 
-    atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+    atom-text-editor[mini].is-focused {
       opacity: 1;
       .selection .region {
       background-color: contrast(@input-background-color, lighten(@input-background-color, 12%), darken(@input-background-color, 12%) );


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai