### PR TITLE
Fix scrolling performance issues in settings-view

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -8,6 +8,7 @@
 .settings-view {
   display: flex;
   overflow: auto;
+  will-change: transform;
 
   .breadcrumb {
     margin-bottom: 0;
@@ -372,6 +373,7 @@
     background-color: lighten(@base-background-color, 2%);
     border-right: 1px solid @base-border-color;
     overflow-x: auto;
+    will-change: transform;
 
     .icon:before {
       text-align: center;
@@ -380,6 +382,7 @@
     .panels-packages{
       flex-grow: 1;
       overflow: auto;
+      will-change: transform;
       height: 0;
 
       li + li {
@@ -465,6 +468,7 @@
       flex: 1;
       min-width: 372px; // magic number: fit the Settings, Uninstall and Disable button
       overflow: auto;
+      will-change: transform;
     }
   }
 


### PR DESCRIPTION
Part of fix for atom/atom#12949.

Forces Chromium to use the compositor to render scroll containers. This greatly decreases CPU usage when scrolling.
