### PR TITLE
Use input-checkbox styles

### DIFF
--- a/lib/package-keymap-view.coffee
+++ b/lib/package-keymap-view.coffee
@@ -11,7 +11,7 @@ class PackageKeymapView extends View
       @div class: 'section-heading icon icon-keyboard', 'Keybindings'
       @div class: 'checkbox', =>
         @label for: 'toggleKeybindings', =>
-          @input id: 'toggleKeybindings', type: 'checkbox', outlet: 'keybindingToggle'
+          @input id: 'toggleKeybindings', class: 'input-checkbox', type: 'checkbox', outlet: 'keybindingToggle'
           @div class: 'setting-title', 'Enable'
         @div class: 'setting-description', 'Disable this if you want to bind your own keystrokes for this package\'s commands in your keymap.'
       @table class: 'package-keymap-table table native-key-bindings text', tabindex: -1, =>

--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -260,7 +260,7 @@ appendCheckbox = (namespace, name, value) ->
 
   @div class: 'checkbox', =>
     @label for: keyPath, =>
-      @input id: keyPath, type: 'checkbox'
+      @input id: keyPath, class: 'input-checkbox', type: 'checkbox'
       @div class: 'setting-title', title
     @div class: 'setting-description', =>
       @raw(description)

--- a/lib/system-windows-panel.coffee
+++ b/lib/system-windows-panel.coffee
@@ -16,7 +16,7 @@ class SystemPanel extends ScrollView
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
                     @label for: 'system.windows.file-handler', =>
-                      @input outlet: 'fileHandlerCheckbox', id: 'system.windows.file-handler', type: 'checkbox'
+                      @input outlet: 'fileHandlerCheckbox', id: 'system.windows.file-handler', class: 'input-checkbox', type: 'checkbox'
                       @div class: 'setting-title', 'Register as file handler'
                       @div class: 'setting-description', =>
                         @raw("Show #{WinShell.appName} in the \"Open with\" application list for easy association with file types.")
@@ -24,7 +24,7 @@ class SystemPanel extends ScrollView
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
                     @label for: 'system.windows.shell-menu-files', =>
-                      @input outlet: 'fileContextMenuCheckbox', id: 'system.windows.shell-menu-files', type: 'checkbox'
+                      @input outlet: 'fileContextMenuCheckbox', id: 'system.windows.shell-menu-files', class: 'input-checkbox', type: 'checkbox'
                       @div class: 'setting-title', 'Show in file context menus'
                       @div class: 'setting-description', =>
                         @raw("Add \"Open with #{WinShell.appName}\" to the File Explorer context menu for files.")
@@ -32,7 +32,7 @@ class SystemPanel extends ScrollView
                 @div class: 'controls', =>
                   @div class: 'checkbox', =>
                     @label for: 'system.windows.shell-menu-folders', =>
-                      @input outlet: 'folderContextMenuCheckbox', id: 'system.windows.shell-menu-folders', type: 'checkbox'
+                      @input outlet: 'folderContextMenuCheckbox', id: 'system.windows.shell-menu-folders', class: 'input-checkbox', type: 'checkbox'
                       @div class: 'setting-title', 'Show in folder context menus'
                       @div class: 'setting-description', =>
                         @raw("Add \"Open with #{WinShell.appName}\" to the File Explorer context menu for folders.")

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -112,71 +112,7 @@
     }
   }
   input[type="checkbox"] {
-    -webkit-appearance: none;
-    display: inline-block;
-    position: relative;
-    font-size: inherit;
     margin: 0 .75em 0 -2.25em;
-    vertical-align: top;
-    width: 1.5em;
-    height: 1.5em;
-    cursor: pointer;
-    outline: 0;
-    border-radius: @component-border-radius;
-    background-color: @text-color-subtle;
-    transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-
-    &:focus {
-      box-shadow: 0 0 0 1px @base-border-color;
-    }
-
-    &:active {
-      background-color: @background-color-success;
-    }
-
-    &::before,
-    &::after {
-      content: "";
-      position: absolute;
-      top: 1.1em;
-      left: .6em;
-      height: .16em;
-      min-height: 2px;
-      border-radius: 1px;
-      background-color: @base-background-color;
-      transform-origin: 0% 0%;
-      opacity: 0;
-      transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
-    }
-    &::before {
-      width: .45em;
-      transform: rotate(225deg) scale(0);
-    }
-    &::after {
-      width: .9em;
-      margin: -1px;
-      transform: rotate(-45deg) scale(0);
-      transition-delay: .05s;
-    }
-
-    &:checked {
-      background-color: @background-color-success;
-      &:active {
-        background-color: @text-color-subtle;
-      }
-      &::before,
-      &::after {
-        opacity: 1;
-      }
-      &::before {
-        transform: rotate(225deg) scale(1);
-        transition-delay: .05s;
-      }
-      &::after {
-        transform: rotate(-45deg) scale(1);
-        transition-delay: 0;
-      }
-    }
   }
 
   .color {


### PR DESCRIPTION
Now that we have the `input-checkbox` styles from `atom-ui`, we can remove the custom styling in settings-view.