### PR TITLE
Hide unnamed grammars in package-detail view

### DIFF
--- a/lib/package-grammars-view.coffee
+++ b/lib/package-grammars-view.coffee
@@ -46,11 +46,11 @@ class PackageGrammarsView extends View
     @grammarSettings.empty()
 
     for grammar in @getPackageGrammars()
-      {scopeName} = grammar
-      continue unless scopeName
+      {scopeName, name} = grammar
+      continue unless scopeName and name
       scopeName = ".#{scopeName}" unless scopeName.startsWith('.')
 
-      title = "#{grammar.name} Grammar"
+      title = "#{name} Grammar"
       panel = new SettingsPanel(null, {title, scopeName, icon: 'puzzle'})
       @addGrammarHeading(grammar, panel)
       @grammarSettings.append(panel)

--- a/spec/fixtures/language-test/grammars/c.json
+++ b/spec/fixtures/language-test/grammars/c.json
@@ -1,0 +1,3 @@
+{
+  "scopeName": "source.c"
+}

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -31,6 +31,8 @@ describe "PackageDetailView", ->
       expect(settingsPanels.eq(1).find('.grammar-scope').text()).toBe 'Scope: source.b'
       expect(settingsPanels.eq(1).find('.grammar-filetypes').text()).toBe 'File Types: '
 
+      expect(settingsPanels.eq(2).length).toEqual(0)
+
   it "displays the snippets registered by the package", ->
     snippetsTable = null
 

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -52,7 +52,7 @@ describe "PackageDetailView", ->
       snippetsTable = view.find('.package-snippets-table tbody')
 
     waitsFor ->
-      snippetsTable.children().length is 2
+      snippetsTable.children().length >= 2
     , 'Snippets table children to contain 2 items', 5000
 
     runs ->


### PR DESCRIPTION
It isn't uncommon for language packages to include a few "helper" grammars for internal use. Most of the time, this is to provide embeddable highlighting for one or more "real" grammars. These shouldn't be visible to the end user... and certainly not with a title of `undefined Grammar`:

<img src="https://cloud.githubusercontent.com/assets/2346707/19624344/edebc2e6-993c-11e6-9f17-cd490d96f5d7.png" width="536" alt="Figure 1" />

**Complements:** atom/grammar-selector#34