### PR TITLE
Remove normalizeIndentOnPaste from scopedSettings

### DIFF
--- a/lib/settings-panel.coffee
+++ b/lib/settings-panel.coffee
@@ -19,7 +19,6 @@ class SettingsPanel extends CollapsibleSectionPanel
         'autoIndentOnPaste'
         'invisibles'
         'nonWordCharacters'
-        'normalizeIndentOnPaste'
         'preferredLineLength'
         'scrollPastEnd'
         'showIndentGuide'


### PR DESCRIPTION
This setting was removed from Atom Core a while ago, and having it here just produces erroneous text fields in all of the language packages.

#### Before (language-python):
![image](https://cloud.githubusercontent.com/assets/3310769/19795070/40d13998-9ca6-11e6-973c-93e874a17e13.png)

#### After (language-python):
![image](https://cloud.githubusercontent.com/assets/3310769/19795085/678b0b22-9ca6-11e6-812f-8c7fa8f09948.png)


This closes #873 