### PR TITLE
Indicate when a package is updating in the status bar tile

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -280,7 +280,7 @@ class PackageManager
         error.stderr = stderr
         onError(error)
 
-    @emitter.emit('package-updating', {pack})
+    @emitPackageEvent 'updating', pack
     apmProcess = @runCommand(args, exit)
     handleProcessErrors(apmProcess, errorMessage, onError)
 

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -44,7 +44,7 @@ class PackageUpdatesStatusView extends View
       if update.name is pack.name
         @updatingPackages.splice(index, 1)
 
-    for index, update in @failedUpdates
+    for index, update of @failedUpdates
       if update.name is pack.name
         @failedUpdates.splice(index, 1)
 

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -13,26 +13,15 @@ class PackageUpdatesStatusView extends View
     @updatingPackages = []
     @failedUpdates = []
 
-    packageManager.on 'package-updated theme-updated', ({error, pack}) => @onDidUpdatePackage(pack)
     packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
     packageManager.on 'package-updating theme-updating', ({error, pack}) => @onPackageUpdating(pack)
+    packageManager.on 'package-updated theme-updated', ({error, pack}) => @onPackageUpdated(pack)
     packageManager.on 'package-update-failed theme-update-failed', ({error, pack}) => @onPackageUpdateFailed(pack)
 
     @updateTile()
 
     @on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
-
-  onDidUpdatePackage: (pack) ->
-    for index, update of @updates
-      if update.name is pack.name
-        @updates.splice(index, 1)
-
-    for index, update of @updatingPackages
-      if update.name is pack.name
-        @updatingPackages.splice(index, 1)
-
-    @updateTile()
 
   onPackageUpdateAvailable: (pack) ->
     for update in @updates
@@ -44,6 +33,21 @@ class PackageUpdatesStatusView extends View
 
   onPackageUpdating: (pack) ->
     @updatingPackages.push(pack)
+    @updateTile()
+
+  onPackageUpdated: (pack) ->
+    for index, update of @updates
+      if update.name is pack.name
+        @updates.splice(index, 1)
+
+    for index, update of @updatingPackages
+      if update.name is pack.name
+        @updatingPackages.splice(index, 1)
+
+    for index, update in @failedUpdates
+      if update.name is pack.name
+        @failedUpdates.splice(index, 1)
+
     @updateTile()
 
   onPackageUpdateFailed: (pack) ->

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -13,10 +13,10 @@ class PackageUpdatesStatusView extends View
     @updatingPackages = []
     @failedUpdates = []
 
-    packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
-    packageManager.on 'package-updating theme-updating', ({error, pack}) => @onPackageUpdating(pack)
-    packageManager.on 'package-updated theme-updated', ({error, pack}) => @onPackageUpdated(pack)
-    packageManager.on 'package-update-failed theme-update-failed', ({error, pack}) => @onPackageUpdateFailed(pack)
+    packageManager.on 'package-update-available theme-update-available', ({pack, error}) => @onPackageUpdateAvailable(pack)
+    packageManager.on 'package-updating theme-updating', ({pack, error}) => @onPackageUpdating(pack)
+    packageManager.on 'package-updated theme-updated', ({pack, error}) => @onPackageUpdated(pack)
+    packageManager.on 'package-update-failed theme-update-failed', ({pack, error}) => @onPackageUpdateFailed(pack)
 
     @updateTile()
 

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -55,10 +55,6 @@ class PackageUpdatesStatusView extends View
       if update.name is pack.name
         return
 
-    for index, update of @updates
-      if update.name is pack.name
-        @updates.splice(index, 1)
-
     for index, update of @updatingPackages
       if update.name is pack.name
         @updatingPackages.splice(index, 1)
@@ -74,28 +70,19 @@ class PackageUpdatesStatusView extends View
         @destroyed = false
 
       @tooltip?.dispose()
-      labelText = "#{_.pluralize(@updates.length, 'update')}"
+      labelText = "#{_.pluralize(@updates.length, 'update')}" # 5 updates
       tooltipText = "#{_.pluralize(@updates.length, 'package update')} available"
 
       if @updatingPackages.length
-        labelText += " (#{@updatingPackages.length} updating)"
+        labelText = "#{@updatingPackages.length}/#{@updates.length} updating" # 3/5 updating
         tooltipText += ", #{_.pluralize(@updatingPackages.length, 'package')} currently updating"
 
       if @failedUpdates.length
-        labelText += ", #{@failedUpdates.length} failed"
+        labelText += " (#{@failedUpdates.length} failed)" # 1 update (1 failed), or 3/5 updating (1 failed)
         tooltipText += ", #{_.pluralize(@failedUpdates.length, 'failed update')}"
 
       @countLabel.text(labelText)
       @tooltip = atom.tooltips.add(@element, title: tooltipText)
-    else if @failedUpdates.length
-      if @destroyed
-        # Priority of -99 should put us just to the left of the Squirrel icon, which displays when Atom has updates available
-        @tile = @statusBar.addRightTile(item: this, priority: -99)
-        @destroyed = false
-
-      @tooltip?.dispose()
-      @countLabel.text("#{@failedUpdates.length} failed")
-      @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@failedUpdates.length, 'failed update')}")
     else
       @tooltip?.dispose()
       @tile.destroy()

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -10,17 +10,13 @@ class PackageUpdatesStatusView extends View
 
   initialize: (@statusBar, packageManager, @updates) ->
     @destroyed = true
+    @updatingPackages = []
 
     packageManager.on 'package-updated theme-updated', ({error, pack}) => @onDidUpdatePackage(pack)
     packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
+    packageManager.on 'package-updating theme-updating', ({error, pack}) => @onPackageUpdating(pack)
 
-    if @updates.length
-      @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
-      @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
-
-      # Priority of -99 should put us just to the left of the Squirrel icon, which displays when Atom has updates available
-      @tile = @statusBar.addRightTile(item: this, priority: -99)
-      @destroyed = false
+    @updateTile()
 
     @on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
@@ -30,27 +26,42 @@ class PackageUpdatesStatusView extends View
       if update.name is pack.name
         @updates.splice(index, 1)
 
-    @tooltip.dispose()
+    for index, update of @updatingPackages
+      if update.name is pack.name
+        @updatingPackages.splice(index, 1)
 
-    unless @updates.length
-      @tile.destroy()
-      @destroyed = true
-      return
-
-    @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
-    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
+    @updateTile()
 
   onPackageUpdateAvailable: (pack) ->
-    if @destroyed
-      @tile = @statusBar.addRightTile(item: this, priority: 0)
-      @destroyed = false
-
     for update in @updates
       if update.name is pack.name
         return
 
     @updates.push(pack)
-    @tooltip.dispose()
+    @updateTile()
 
-    @countLabel.text("#{_.pluralize(@updates.length, 'update')}")
-    @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@updates.length, 'package update')} available")
+  onPackageUpdating: (pack) ->
+    @updatingPackages.push(pack)
+    @updateTile()
+
+  updateTile: ->
+    if @updates.length
+      if @destroyed
+        # Priority of -99 should put us just to the left of the Squirrel icon, which displays when Atom has updates available
+        @tile = @statusBar.addRightTile(item: this, priority: -99)
+        @destroyed = false
+
+      @tooltip?.dispose()
+      labelText = "#{_.pluralize(@updates.length, 'update')}"
+      tooltipText = "#{_.pluralize(@updates.length, 'package update')} available"
+
+      if @updatingPackages.length
+        labelText += " (#{@updatingPackages.length} updating)"
+        tooltipText += ", #{_.pluralize(@updatingPackages.length, 'package')} currently updating"
+
+      @countLabel.text(labelText)
+      @tooltip = atom.tooltips.add(@element, title: tooltipText)
+    else
+      @tooltip?.dispose()
+      @tile.destroy()
+      @destroyed = true

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -51,8 +51,16 @@ class PackageUpdatesStatusView extends View
       if update.name is pack.name
         return
 
+    for index, update of @updates
+      if update.name is pack.name
+        @updates.splice(index, 1)
+
+    for index, update of @updatingPackages
+      if update.name is pack.name
+        @updatingPackages.splice(index, 1)
+
     @failedUpdates.push(pack)
-    # @updateTile()
+    @updateTile()
 
   updateTile: ->
     if @updates.length
@@ -69,8 +77,21 @@ class PackageUpdatesStatusView extends View
         labelText += " (#{@updatingPackages.length} updating)"
         tooltipText += ", #{_.pluralize(@updatingPackages.length, 'package')} currently updating"
 
+      if @failedUpdates.length
+        labelText += ", #{@failedUpdates.length} failed"
+        tooltipText += ", #{_.pluralize(@failedUpdates.length, 'failed update')}"
+
       @countLabel.text(labelText)
       @tooltip = atom.tooltips.add(@element, title: tooltipText)
+    else if @failedUpdates.length
+      if @destroyed
+        # Priority of -99 should put us just to the left of the Squirrel icon, which displays when Atom has updates available
+        @tile = @statusBar.addRightTile(item: this, priority: -99)
+        @destroyed = false
+
+      @tooltip?.dispose()
+      @countLabel.text("#{@failedUpdates.length} failed")
+      @tooltip = atom.tooltips.add(@element, title: "#{_.pluralize(@failedUpdates.length, 'failed update')}")
     else
       @tooltip?.dispose()
       @tile.destroy()

--- a/lib/package-updates-status-view.coffee
+++ b/lib/package-updates-status-view.coffee
@@ -11,10 +11,12 @@ class PackageUpdatesStatusView extends View
   initialize: (@statusBar, packageManager, @updates) ->
     @destroyed = true
     @updatingPackages = []
+    @failedUpdates = []
 
     packageManager.on 'package-updated theme-updated', ({error, pack}) => @onDidUpdatePackage(pack)
     packageManager.on 'package-update-available theme-update-available', ({error, pack}) => @onPackageUpdateAvailable(pack)
     packageManager.on 'package-updating theme-updating', ({error, pack}) => @onPackageUpdating(pack)
+    packageManager.on 'package-update-failed theme-update-failed', ({error, pack}) => @onPackageUpdateFailed(pack)
 
     @updateTile()
 
@@ -43,6 +45,14 @@ class PackageUpdatesStatusView extends View
   onPackageUpdating: (pack) ->
     @updatingPackages.push(pack)
     @updateTile()
+
+  onPackageUpdateFailed: (pack) ->
+    for update in @failedUpdates
+      if update.name is pack.name
+        return
+
+    @failedUpdates.push(pack)
+    # @updateTile()
 
   updateTile: ->
     if @updates.length

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 process = require 'process'
 PackageManager = require '../lib/package-manager'
 
-describe "package manager", ->
+describe "PackageManager", ->
   [packageManager] = []
 
   beforeEach ->

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -62,6 +62,13 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('updated', outdatedPackage1)
       expect($('status-bar .package-updates-status-view').text()).toBe '1 update'
 
+  describe "when multiple packages are updating and one finishes", ->
+    it "updates the tile", ->
+      packageManager.emitPackageEvent('updating', outdatedPackage1)
+      packageManager.emitPackageEvent('updating', outdatedPackage2)
+      packageManager.emitPackageEvent('updated', outdatedPackage1)
+      expect($('status-bar .package-updates-status-view').text()).toBe '1 update (1 updating)'
+
   describe "when a package fails to update", ->
     it "updates the tile", ->
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -49,7 +49,7 @@ describe "PackageUpdatesStatusView", ->
   describe "when a package is updating", ->
     it "updates the tile", ->
       packageManager.emitPackageEvent('updating', outdatedPackage1)
-      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates (1 updating)'
+      expect($('status-bar .package-updates-status-view').text()).toBe '1/2 updating'
 
   describe "when a package finishes updating", ->
     it "updates the tile", ->
@@ -67,12 +67,12 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('updating', outdatedPackage1)
       packageManager.emitPackageEvent('updating', outdatedPackage2)
       packageManager.emitPackageEvent('updated', outdatedPackage1)
-      expect($('status-bar .package-updates-status-view').text()).toBe '1 update (1 updating)'
+      expect($('status-bar .package-updates-status-view').text()).toBe '1/1 updating'
 
   describe "when a package fails to update", ->
     it "updates the tile", ->
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
-      expect($('status-bar .package-updates-status-view').text()).toBe '1 update, 1 failed'
+      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates (1 failed)'
 
   describe "when a package update that previously failed succeeds on a subsequent try", ->
     it "updates the tile", ->
@@ -85,19 +85,13 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('update-available', installedPackage)
       packageManager.emitPackageEvent('updating', outdatedPackage1)
       packageManager.emitPackageEvent('update-failed', outdatedPackage2)
-      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates (1 updating), 1 failed'
+      expect($('status-bar .package-updates-status-view').text()).toBe '1/3 updating (1 failed)'
 
   describe "when there are no more updates", ->
     it "destroys the tile", ->
       packageManager.emitPackageEvent('updated', outdatedPackage1)
       packageManager.emitPackageEvent('updated', outdatedPackage2)
       expect($('status-bar .package-updates-status-view')).not.toExist()
-
-  describe "when there are no more updates but an update failed", ->
-    it "updates the tile", ->
-      packageManager.emitPackageEvent('updated', outdatedPackage1)
-      packageManager.emitPackageEvent('update-failed', outdatedPackage2)
-      expect($('status-bar .package-updates-status-view').text()).toBe '1 failed'
 
   describe "when a new update becomes available and the tile is destroyed", ->
     it "recreates the tile", ->
@@ -124,4 +118,4 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
-      expect($('status-bar .package-updates-status-view').text()).toBe '1 update, 1 failed'
+      expect($('status-bar .package-updates-status-view').text()).toBe '2 updates (1 failed)'


### PR DESCRIPTION
Closes #883

Some things to note:
* The tile changes have been extracted into a helper `updateTile` method which I think helps streamline and deduplicate things (see below).
* This PR fixes a bug in my previous PR where I accidentally set the priority of the tile to 0 when reinitializing it instead of -99.  The new helper method takes care of this.
* This PR also fixes a different bug in my previous PR where we were trying to call `tooltip.dispose()` on a non-existent tooltip if the Check for Updates button was pressed.  Whoops!
* I fixed a bug in PackageManager where the `package-updating` event was being generically emitted through Emitter rather than through the dedicated `emitPackageEvent` helper method.  This means that `theme-updating` will now start to be emitted for themes.

TODO:
* [x] Finish what to display for failed updates
* [ ] Get some feedback on the label text
* [x] Specs