### PR TITLE
Drastically improve loading time of updates panel

### DIFF
--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -52,15 +52,14 @@ class UpdatesPanel extends ScrollView
 
     @checkingMessage.show()
 
-    @packageManager.getInstalled().then =>
-      @packageManager.getOutdated()
-        .then (@availableUpdates) =>
-          @checkButton.prop('disabled', false)
-          @addUpdateViews()
-        .catch (error) =>
-          @checkButton.prop('disabled', false)
-          @checkingMessage.hide()
-          @updateErrors.append(new ErrorView(@packageManager, error))
+    @packageManager.getOutdated()
+      .then (@availableUpdates) =>
+        @checkButton.prop('disabled', false)
+        @addUpdateViews()
+      .catch (error) =>
+        @checkButton.prop('disabled', false)
+        @checkingMessage.hide()
+        @updateErrors.append(new ErrorView(@packageManager, error))
 
   addUpdateViews: ->
     if @availableUpdates.length > 0


### PR DESCRIPTION
`getInstalled()` doesn't affect `getOutdated()` and was just slowing the process down if we had cached data from `getOutdated()`.

Here's two GIFs, the first one before the change and the second one after.  Pretty big difference :).  Sorry for the extra non-Atom stuff in the background.  Had to resize the Atom window but forgot to resize licecap.
Before:
![wl-updates-panel-before](https://cloud.githubusercontent.com/assets/2766036/20994921/852d114e-bcc1-11e6-88db-b33f74930d4f.gif)

After:
![wl-updates-panel-after](https://cloud.githubusercontent.com/assets/2766036/20994924/885bcc48-bcc1-11e6-9f63-4596dce114e6.gif)

Fixes #409, closes atom/atom#6945.
Though this doesn't do anything about the case when you click the updates tile a sufficiently long time after Atom loads, causing Atom to check for updates again since the outdated cache expired.  I think that's fine though.

/cc @Caged