### PR TITLE
Move deprecated notifications out of consumeStatusBar

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,7 +2,7 @@ SettingsView = null
 settingsView = null
 
 PackageManager = require './package-manager'
-packageManager = new PackageManager()
+packageManager = null
 
 SnippetsProvider =
   getSnippets: -> atom.config.scopedSettingsStore.propertySets
@@ -50,6 +50,11 @@ module.exports =
     if process.platform is 'win32' and require('atom').WinShell?
       atom.commands.add 'atom-workspace', 'settings-view:system': -> atom.workspace.open("#{configUri}/system")
 
+    unless localStorage.getItem('hasSeenDeprecatedNotification')
+      packageManager ?= new PackageManager()
+      packageManager.getInstalled().then (packages) =>
+        @showDeprecatedNotification(packages) if packages.user.length
+
   deactivate: ->
     settingsView?.dispose()
     settingsView?.remove()
@@ -57,16 +62,10 @@ module.exports =
     packageManager = null
 
   consumeStatusBar: (statusBar) ->
-    packageManager ?= new PackageManager() # TODO: Why is this needed when the package manager is initialized at the top of the file?
-    Promise.all([packageManager.getOutdated(), packageManager.getInstalled()]).then (values) =>
-      updates = values[0]
-      allPackages = values[1]
-
+    packageManager ?= new PackageManager()
+    packageManager.getOutdated().then (updates) ->
       PackageUpdatesStatusView = require './package-updates-status-view'
       new PackageUpdatesStatusView(statusBar, packageManager, updates)
-
-      if allPackages.length > 0 and not localStorage.getItem('hasSeenDeprecatedNotification')
-        @showDeprecatedNotification(allPackages)
 
   consumeSnippets: (snippets) ->
     if typeof snippets.getUnparsedSnippets is "function"
@@ -79,7 +78,6 @@ module.exports =
     settingsView = new SettingsView(params)
 
   showDeprecatedNotification: (packages) ->
-    return unless packages.user?
     deprecatedPackages = packages.user.filter ({name, version}) ->
       atom.packages.isDeprecatedPackage(name, version)
     return unless deprecatedPackages.length

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -53,7 +53,7 @@ module.exports =
     unless localStorage.getItem('hasSeenDeprecatedNotification')
       packageManager ?= new PackageManager()
       packageManager.getInstalled().then (packages) =>
-        @showDeprecatedNotification(packages) if packages.user.length
+        @showDeprecatedNotification(packages) if packages.user?.length
 
   deactivate: ->
     settingsView?.dispose()


### PR DESCRIPTION
They're not related at all.

As a result, this should speed up the time it takes to initialize the status bar tile, as we no longer have to go through `getInstalled()` (which is slow).

Furthermore, to prevent a slowdown in activation time, I moved the localStorage check to _before_ we call `getInstalled()`.  This way we won't have to do work for nothing.