### PR TITLE
Don't hide the update button if updates fail

### DIFF
--- a/lib/package-card.coffee
+++ b/lib/package-card.coffee
@@ -423,12 +423,17 @@ class PackageCard extends View
       @installButton.removeClass('is-installing')
       @updateInterfaceState()
 
-    @subscribeToPackageEvent 'package-updated theme-updated package-update-failed theme-update-failed', =>
+    @subscribeToPackageEvent 'package-updated theme-updated', =>
       metadata = atom.packages.getLoadedPackage(@pack.name)?.metadata
       @pack.version = version if version = metadata?.version
       @pack.apmInstallSource = apmInstallSource if apmInstallSource = metadata?.apmInstallSource
       @newVersion = null
       @newSha = null
+      @updateButton.prop('disabled', false)
+      @updateButton.removeClass('is-installing')
+      @updateInterfaceState()
+
+    @subscribeToPackageEvent 'package-update-failed theme-update-failed', =>
       @updateButton.prop('disabled', false)
       @updateButton.removeClass('is-installing')
       @updateInterfaceState()

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -78,18 +78,23 @@ class UpdatesPanel extends ScrollView
     packageCards = @getPackageCards()
     successfulUpdatesCount = 0
     remainingPackagesCount = packageCards.length
+    totalUpdatesCount = packageCards.length # This value doesn't change unlike remainingPackagesCount
 
-    notifyIfDone = ->
-      if remainingPackagesCount is 0 and successfulUpdatesCount > 0
-        pluralizedPackages = 'package'
-        pluralizedPackages += 's' if successfulUpdatesCount > 1
-        message = "Restart Atom to complete the update of #{successfulUpdatesCount} #{pluralizedPackages}."
+    notifyIfDone = =>
+      if remainingPackagesCount is 0
+        if successfulUpdatesCount > 0
+          pluralizedPackages = 'package'
+          pluralizedPackages += 's' if successfulUpdatesCount > 1
+          message = "Restart Atom to complete the update of #{successfulUpdatesCount} #{pluralizedPackages}."
 
-        buttons = [{
-          text: 'Restart',
-          onDidClick: -> atom.restartApplication()
-        }]
-        atom.notifications.addSuccess(message, {dismissable: true, buttons})
+          buttons = [{
+            text: 'Restart',
+            onDidClick: -> atom.restartApplication()
+          }]
+          atom.notifications.addSuccess(message, {dismissable: true, buttons})
+
+        if successfulUpdatesCount < totalUpdatesCount # Some updates failed
+          @updateAllButton.prop('disabled', false)
 
     onUpdateResolved = ->
       remainingPackagesCount--

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -7,7 +7,7 @@ describe 'UpdatesPanel', ->
   beforeEach ->
     panel = new UpdatesPanel(new PackageManager)
 
-  it "Shows updates when updates are available", ->
+  it "shows updates when updates are available", ->
     pack =
       name: 'test-package'
       description: 'some description'
@@ -18,40 +18,42 @@ describe 'UpdatesPanel', ->
     panel.beforeShow(updates: [pack])
     expect(panel.updatesContainer.children().length).toBe(1)
 
-  it "Shows a message when updates are not available", ->
+  it "shows a message when updates are not available", ->
     panel.beforeShow(updates: [])
     expect(panel.updatesContainer.children().length).toBe(0)
     expect(panel.noUpdatesMessage.css('display')).not.toBe('none')
 
   describe "when the 'Update All' button is clicked", ->
-    it "attempts to update all packages and prompts to restart if at least one package updated successfully", ->
-      packA =
-        name: 'test-package-a'
-        description: 'some description'
-        latestVersion: '99.0.0'
-        version: '1.0.0'
-      packB =
-        name: 'test-package-b'
-        description: 'some description'
-        latestVersion: '99.0.0'
-        version: '1.0.0'
-      packC =
-        name: 'test-package-c'
-        description: 'some description'
-        latestVersion: '99.0.0'
-        version: '1.0.0'
+    packA =
+      name: 'test-package-a'
+      description: 'some description'
+      latestVersion: '99.0.0'
+      version: '1.0.0'
+    packB =
+      name: 'test-package-b'
+      description: 'some description'
+      latestVersion: '99.0.0'
+      version: '1.0.0'
+    packC =
+      name: 'test-package-c'
+      description: 'some description'
+      latestVersion: '99.0.0'
+      version: '1.0.0'
 
+    [cardA, cardB, cardC] = []
+    [resolveA, resolveB, resolveC, rejectA, rejectB, rejectC] = []
+
+    beforeEach ->
       # skip packman stubbing
       panel.beforeShow(updates: [packA, packB, packC])
 
       [cardA, cardB, cardC] = panel.getPackageCards()
 
-      [resolveA, rejectB, resolveC] = []
+      spyOn(cardA, 'update').andReturn(new Promise((resolve, reject) -> [resolveA, rejectA] = [resolve, reject]))
+      spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> [resolveB, rejectB] = [resolve, reject]))
+      spyOn(cardC, 'update').andReturn(new Promise((resolve, reject) -> [resolveC, rejectC] = [resolve, reject]))
 
-      spyOn(cardA, 'update').andReturn(new Promise((resolve) -> resolveA = resolve))
-      spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> rejectB = reject))
-      spyOn(cardC, 'update').andReturn(new Promise((resolve) -> resolveC = resolve))
-
+    it "attempts to update all packages and prompts to restart if at least one package updates successfully", ->
       expect(atom.notifications.getNotifications().length).toBe 0
 
       panel.updateAll()
@@ -73,3 +75,26 @@ describe 'UpdatesPanel', ->
         spyOn(atom, 'restartApplication')
         notifications[0].options.buttons[0].onDidClick()
         expect(atom.restartApplication).toHaveBeenCalled()
+
+    it 'disables the Update All button if all updates succeed', ->
+      expect(panel.updateAllButton.prop('disabled')).toBe false
+      panel.updateAll()
+
+      resolveA()
+      resolveB()
+      resolveC()
+
+      waits 0
+      runs ->
+        expect(panel.updateAllButton.prop('disabled')).toBe true
+
+    it 'keeps the Update All button enabled if not all updates succeed', ->
+      panel.updateAll()
+
+      resolveA()
+      rejectB('Error updating package')
+      resolveC()
+
+      waits 0
+      runs ->
+        expect(panel.updateAllButton.prop('disabled')).toBe false


### PR DESCRIPTION
If an update fails, then there's obviously still a new version/sha available.  Keep the update button there so that users can retry.  Fixes #886.

* [x] Specs