### PR TITLE
Improve updates panel UX

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -100,9 +100,11 @@ class PackageManager
 
     handleProcessErrors(apmProcess, errorMessage, callback)
 
-  loadOutdated: (callback) ->
+  loadOutdated: (clearCache, callback) ->
+    if clearCache
+      @clearOutdatedCache()
     # Short circuit if we have cached data.
-    if @apmCache.loadOutdated.value and @apmCache.loadOutdated.expiry > Date.now()
+    else if @apmCache.loadOutdated.value and @apmCache.loadOutdated.expiry > Date.now()
       return callback(null, @apmCache.loadOutdated.value)
 
     args = ['outdated', '--json']
@@ -197,9 +199,9 @@ class PackageManager
         else
           resolve(result)
 
-  getOutdated: ->
+  getOutdated: (clearCache = false) ->
     new Promise (resolve, reject) =>
-      @loadOutdated (error, result) ->
+      @loadOutdated clearCache, (error, result) ->
         if error
           reject(error)
         else

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -22,7 +22,7 @@ class UpdatesPanel extends ScrollView
     super
     @updateAllButton.on 'click', => @updateAll()
     @checkButton.on 'click', =>
-      @checkForUpdates()
+      @checkForUpdates(true)
 
     @updateAllButton.hide()
     @checkForUpdates()
@@ -46,14 +46,14 @@ class UpdatesPanel extends ScrollView
       @checkForUpdates()
 
   # Check for updates and display them
-  checkForUpdates: ->
+  checkForUpdates: (clearCache) ->
     @noUpdatesMessage.hide()
     @updateAllButton.prop('disabled', true)
     @checkButton.prop('disabled', true)
 
     @checkingMessage.show()
 
-    @packageManager.getOutdated()
+    @packageManager.getOutdated(clearCache)
       .then (@availableUpdates) =>
         @checkButton.prop('disabled', false)
         @addUpdateViews()

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -1,4 +1,5 @@
 {$, ScrollView} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
 ErrorView = require './error-view'
 PackageCard = require './package-card'
 
@@ -20,18 +21,32 @@ class UpdatesPanel extends ScrollView
 
   initialize: (@packageManager) ->
     super
+
+    @disposables = new CompositeDisposable()
+    @updatingPackages = []
+
     @updateAllButton.on 'click', => @updateAll()
-    @checkButton.on 'click', =>
-      @checkForUpdates(true)
+    @checkButton.on 'click', => @checkForUpdates(true)
 
     @updateAllButton.hide()
     @checkForUpdates()
 
-    @packageManagerSubscription = @packageManager.on 'package-update-failed theme-update-failed', ({pack, error}) =>
-      @updateErrors.append(new ErrorView(@packageManager, error))
+    @disposables.add @packageManager.on 'package-updating theme-updating', ({pack, error}) =>
+      @checkButton.prop('disabled', true)
+      @updatingPackages.push(pack)
+
+    @disposables.add @packageManager.on 'package-updated theme-updated package-update-failed theme-update-failed', ({pack, error}) =>
+      @updateErrors.append(new ErrorView(@packageManager, error)) if error?
+
+      for index, update of @updatingPackages
+        if update.name is pack.name
+          @updatingPackages.splice(index, 1)
+
+      unless @updatingPackages.length
+        @checkButton.prop('disabled', false)
 
   dispose: ->
-    @packageManagerSubscription.dispose()
+    @disposables.dispose()
 
   beforeShow: (opts) ->
     if opts?.back
@@ -74,6 +89,7 @@ class UpdatesPanel extends ScrollView
       @updatesContainer.append(new PackageCard(pack, @packageManager, {back: 'Updates'}))
 
   updateAll: ->
+    @checkButton.prop('disabled', true)
     @updateAllButton.prop('disabled', true)
 
     packageCards = @getPackageCards()
@@ -95,8 +111,10 @@ class UpdatesPanel extends ScrollView
           atom.notifications.addSuccess(message, {dismissable: true, buttons})
 
         if successfulUpdatesCount is totalUpdatesCount
+          @checkButton.prop('disabled', false)
           @updateAllButton.hide()
         else # Some updates failed
+          @checkButton.prop('disabled', false)
           @updateAllButton.prop('disabled', false)
 
     onUpdateResolved = ->

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -24,6 +24,7 @@ class UpdatesPanel extends ScrollView
     @checkButton.on 'click', =>
       @checkForUpdates()
 
+    @updateAllButton.hide()
     @checkForUpdates()
 
     @packageManagerSubscription = @packageManager.on 'package-update-failed theme-update-failed', ({pack, error}) =>
@@ -47,7 +48,7 @@ class UpdatesPanel extends ScrollView
   # Check for updates and display them
   checkForUpdates: ->
     @noUpdatesMessage.hide()
-    @updateAllButton.hide()
+    @updateAllButton.prop('disabled', true)
     @checkButton.prop('disabled', true)
 
     @checkingMessage.show()
@@ -93,7 +94,9 @@ class UpdatesPanel extends ScrollView
           }]
           atom.notifications.addSuccess(message, {dismissable: true, buttons})
 
-        if successfulUpdatesCount < totalUpdatesCount # Some updates failed
+        if successfulUpdatesCount is totalUpdatesCount
+          @updateAllButton.hide()
+        else # Some updates failed
           @updateAllButton.prop('disabled', false)
 
     onUpdateResolved = ->

--- a/lib/updates-panel.coffee
+++ b/lib/updates-panel.coffee
@@ -127,7 +127,11 @@ class UpdatesPanel extends ScrollView
       notifyIfDone()
 
     for packageCard in packageCards
-      packageCard.update().then(onUpdateResolved, onUpdateRejected)
+      if packageCard.pack not in @updatingPackages
+        packageCard.update().then(onUpdateResolved, onUpdateRejected)
+      else
+        remainingPackagesCount--
+        totalUpdatesCount--
 
   getPackageCards: ->
     @updatesContainer.find('.package-card').toArray()

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -247,10 +247,10 @@ describe "package manager", ->
         callback(0, '["boop"]', '')
         onWillThrowError: ->
 
-      packageManager.loadOutdated ->
+      packageManager.loadOutdated false, ->
       expect(packageManager.apmCache.loadOutdated.value).toMatch(['boop'])
 
-      packageManager.loadOutdated ->
+      packageManager.loadOutdated false, ->
       expect(packageManager.runCommand.calls.length).toBe(1)
 
 
@@ -259,10 +259,10 @@ describe "package manager", ->
         callback(0, '["boop"]', '')
         onWillThrowError: ->
 
-      packageManager.loadOutdated ->
+      packageManager.loadOutdated false, ->
       now = Date.now()
       spyOn(Date, 'now').andReturn((-> now + packageManager.CACHE_EXPIRY + 1)())
-      packageManager.loadOutdated ->
+      packageManager.loadOutdated false, ->
 
       expect(packageManager.runCommand.calls.length).toBe(2)
 
@@ -281,16 +281,16 @@ describe "package manager", ->
     spyOn(atom.packages, 'unloadPackage').andReturn(true)
     spyOn(atom.packages, 'loadPackage').andReturn(true)
 
-    packageManager.loadOutdated ->
+    packageManager.loadOutdated false, ->
     expect(packageManager.runCommand.calls.length).toBe(0)
 
     packageManager.update {}, {}, -> # +1 runCommand call to update the package
-    packageManager.loadOutdated -> # +1 runCommand call to load outdated because the cache should be wiped
+    packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
     expect(packageManager.runCommand.calls.length).toBe(2)
 
     packageManager.install {}, -> # +1 runCommand call to install the package
-    packageManager.loadOutdated -> # +1 runCommand call to load outdated because the cache should be wiped
+    packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
     expect(packageManager.runCommand.calls.length).toBe(4)
 
-    packageManager.loadOutdated -> # +0 runCommand call, should be cached
+    packageManager.loadOutdated false, -> # +0 runCommand call, should be cached
     expect(packageManager.runCommand.calls.length).toBe(4)

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -273,7 +273,7 @@ describe "PackageManager", ->
       packageManager.loadOutdated false, -> # +0 runCommand call, should be cached
       expect(packageManager.runCommand.calls.length).toBe(4)
 
-    fit "expires results if it is called with clearCache set to true", ->
+    it "expires results if it is called with clearCache set to true", ->
       packageManager.apmCache.loadOutdated =
         value: ['hi']
         expiry: Date.now() + 999999999

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -232,7 +232,6 @@ describe "PackageManager", ->
       packageManager.loadOutdated false, ->
       expect(packageManager.runCommand.calls.length).toBe(1)
 
-
     it "expires results after a timeout", ->
       spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
         callback(0, '["boop"]', '')
@@ -245,31 +244,44 @@ describe "PackageManager", ->
 
       expect(packageManager.runCommand.calls.length).toBe(2)
 
-  it "expires results after a package updated/installed", ->
-    packageManager.apmCache.loadOutdated =
-      value: ['hi']
-      expiry: Date.now() + 999999999
+    it "expires results after a package updated/installed", ->
+      packageManager.apmCache.loadOutdated =
+        value: ['hi']
+        expiry: Date.now() + 999999999
 
-    spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
-      callback(0, '["boop"]', '')
-      onWillThrowError: ->
+      spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
+        callback(0, '["boop"]', '')
+        onWillThrowError: ->
 
-    # Just prevent this stuff from calling through, it doesn't matter for this test
-    spyOn(atom.packages, 'deactivatePackage').andReturn(true)
-    spyOn(atom.packages, 'activatePackage').andReturn(true)
-    spyOn(atom.packages, 'unloadPackage').andReturn(true)
-    spyOn(atom.packages, 'loadPackage').andReturn(true)
+      # Just prevent this stuff from calling through, it doesn't matter for this test
+      spyOn(atom.packages, 'deactivatePackage').andReturn(true)
+      spyOn(atom.packages, 'activatePackage').andReturn(true)
+      spyOn(atom.packages, 'unloadPackage').andReturn(true)
+      spyOn(atom.packages, 'loadPackage').andReturn(true)
 
-    packageManager.loadOutdated false, ->
-    expect(packageManager.runCommand.calls.length).toBe(0)
+      packageManager.loadOutdated false, ->
+      expect(packageManager.runCommand.calls.length).toBe(0)
 
-    packageManager.update {}, {}, -> # +1 runCommand call to update the package
-    packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
-    expect(packageManager.runCommand.calls.length).toBe(2)
+      packageManager.update {}, {}, -> # +1 runCommand call to update the package
+      packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
+      expect(packageManager.runCommand.calls.length).toBe(2)
 
-    packageManager.install {}, -> # +1 runCommand call to install the package
-    packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
-    expect(packageManager.runCommand.calls.length).toBe(4)
+      packageManager.install {}, -> # +1 runCommand call to install the package
+      packageManager.loadOutdated false, -> # +1 runCommand call to load outdated because the cache should be wiped
+      expect(packageManager.runCommand.calls.length).toBe(4)
 
-    packageManager.loadOutdated false, -> # +0 runCommand call, should be cached
-    expect(packageManager.runCommand.calls.length).toBe(4)
+      packageManager.loadOutdated false, -> # +0 runCommand call, should be cached
+      expect(packageManager.runCommand.calls.length).toBe(4)
+
+    fit "expires results if it is called with clearCache set to true", ->
+      packageManager.apmCache.loadOutdated =
+        value: ['hi']
+        expiry: Date.now() + 999999999
+
+      spyOn(packageManager, 'runCommand').andCallFake (args, callback) ->
+        callback(0, '["boop"]', '')
+        onWillThrowError: ->
+
+      packageManager.loadOutdated true, ->
+      expect(packageManager.runCommand.calls.length).toBe(1)
+      expect(packageManager.apmCache.loadOutdated.value).toEqual ['boop']

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -59,8 +59,9 @@ describe 'UpdatesPanel', ->
       spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> [resolveB, rejectB] = [resolve, reject]))
       spyOn(cardC, 'update').andReturn(new Promise((resolve, reject) -> [resolveC, rejectC] = [resolve, reject]))
 
-    it "attempts to update all packages and prompts to restart if at least one package updates successfully", ->
+    it 'attempts to update all packages and prompts to restart if at least one package updates successfully', ->
       expect(atom.notifications.getNotifications().length).toBe 0
+      expect(panel.updateAllButton).toBeVisible()
 
       panel.updateAll()
 

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -107,6 +107,13 @@ describe 'UpdatesPanel', ->
         expect(panel.updateAllButton.prop('disabled')).toBe false
         expect(panel.updateAllButton).toBeVisible()
 
+    it 'does not attempt to update packages that are already updating', ->
+      cardA.update()
+      packageManager.emitPackageEvent 'updating', packA
+      panel.updateAll()
+
+      expect(cardA.update.calls.length).toBe 1
+
   describe 'the Check for Updates button', ->
     pack =
       name: 'test-package'

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -3,9 +3,10 @@ PackageManager = require '../lib/package-manager'
 
 describe 'UpdatesPanel', ->
   panel = null
+  packageManager = new PackageManager
 
   beforeEach ->
-    panel = new UpdatesPanel(new PackageManager)
+    panel = new UpdatesPanel(packageManager)
 
   it "shows updates when updates are available", ->
     pack =
@@ -98,3 +99,32 @@ describe 'UpdatesPanel', ->
       waits 0
       runs ->
         expect(panel.updateAllButton.prop('disabled')).toBe false
+
+  describe 'when the Check for Updates button is clicked', ->
+    [resolveOutdated, rejectOutdated] = []
+
+    beforeEach ->
+      spyOn(packageManager, 'getOutdated').andReturn(new Promise((resolve, reject) -> [resolveOutdated, rejectOutdated] = [resolve, reject]))
+
+    it 'disables the Check for Updates button and checks for updates', ->
+      # Updates panel checks for updates on initialization so resolve the promise
+      resolveOutdated()
+
+      waits 0
+      runs ->
+        expect(panel.checkButton.prop('disabled')).toBe false
+
+      panel.checkForUpdates()
+      expect(panel.checkButton.prop('disabled')).toBe true
+
+      resolveOutdated()
+
+      waits 0
+      runs ->
+        expect(panel.checkButton.prop('disabled')).toBe false
+
+    it 'clears the outdated cache and explicitly checks for updates', ->
+      # This spec just tests that we're passing the clearCache bool through, not the actual implementation
+      # For that, look at the PackageManager specs
+      panel.checkButton.click()
+      expect(packageManager.getOutdated).toHaveBeenCalledWith true


### PR DESCRIPTION
Some general improvements to the updates panel.
* Don't hide the Update All button when checking for updates: instead, disable it and only hide it after we've checked for updates and none are available.
* When explicitly clicking on the "Check for Updates" button, clear the outdated packages cache and actually recheck for updates.
* Disable checking for updates when packages are updating.  This is to prevent the state getting completely messed up.  More details in the commit description of 1011f43621ca1615734866ecb9a481c7f4ac9a20.
* When the Update All button is clicked, only packages that are not already being updated are updated.  This may fix #879?  Not sure, couldn't reproduce it but I didn't really try to.

Note: there seems to be an issue where the metadata returned by `atom.packages.getLoadedPackage(name)` after a successful update still points to the old package's metadata.  This results in the version on the package card not updating correctly.

TODO:
* [x] Specs