### PR TITLE
Show core package READMEs even when disabled

### DIFF
--- a/lib/package-detail-view.coffee
+++ b/lib/package-detail-view.coffee
@@ -232,7 +232,8 @@ class PackageDetailView extends ScrollView
     @licensePath = null
     @readmePath = null
 
-    for child in fs.listSync(@pack.path)
+    packagePath = @pack.path ? atom.packages.resolvePackagePath(@pack.name)
+    for child in fs.listSync(packagePath)
       switch path.basename(child, path.extname(child)).toLowerCase()
         when 'changelog', 'history' then @changelogPath = child
         when 'license', 'licence' then @licensePath = child

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -90,6 +90,16 @@ describe "PackageDetailView", ->
     expect(view.find('.package-readme script').length).toBe(0)
     expect(view.find('.package-readme :checkbox[disabled]').length).toBe(2)
 
+  it "renders the README when the package path is undefined", ->
+    atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-readme'))
+    pack = atom.packages.getLoadedPackage('package-with-readme')
+    delete pack.path
+    view = new PackageDetailView(pack, packageManager, SnippetsProvider)
+
+    expect(view.packageCard).toBeDefined()
+    expect(view.packageCard.packageName.text()).toBe('package-with-readme')
+    expect(view.find('.package-readme').length).toBe(1)
+
   it "should show 'Install' as the first breadcrumb by default", ->
     loadPackageFromRemote()
     expect(view.breadcrumb.text()).toBe('Install')


### PR DESCRIPTION
For some reason disabled core packages don't have `@pack.path`.

Fixes #730