### PR TITLE
Use a single package manager when deserializing

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -73,6 +73,7 @@ module.exports =
 
   createSettingsView: (params) ->
     SettingsView ?= require './settings-view'
+    packageManager ?= new PackageManager()
     params.packageManager = packageManager
     params.snippetsProvider = SnippetsProvider
     settingsView = new SettingsView(params)

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -35,7 +35,6 @@ class SettingsView extends ScrollView
   initialize: ({@uri, @packageManager, @snippetsProvider, activePanel}={}) ->
     super
 
-    @packageManager ?= new PackageManager()
     @deferredPanel = activePanel
     process.nextTick => @initializePanels()
 

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -81,6 +81,7 @@ class SettingsView extends ScrollView
     version: 2
     activePanel: @activePanel ? @deferredPanel
     uri: @uri
+    packageManager: @packageManager
 
   getPackages: ->
     return @packages if @packages?

--- a/lib/settings-view.coffee
+++ b/lib/settings-view.coffee
@@ -81,7 +81,6 @@ class SettingsView extends ScrollView
     version: 2
     activePanel: @activePanel ? @deferredPanel
     uri: @uri
-    packageManager: @packageManager
 
   getPackages: ->
     return @packages if @packages?

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 {$, $$} = require 'atom-space-pen-views'
+main = require '../lib/main'
 PackageManager = require '../lib/package-manager'
 SettingsView = require '../lib/settings-view'
 SnippetsProvider =
@@ -10,7 +11,7 @@ describe "SettingsView", ->
   packageManager = new PackageManager()
 
   beforeEach ->
-    settingsView = new SettingsView({packageManager: packageManager, snippetsProvider: SnippetsProvider})
+    settingsView = main.createSettingsView({packageManager: packageManager, snippetsProvider: SnippetsProvider})
     spyOn(settingsView, "initializePanels").andCallThrough()
     window.advanceClock(10000)
     waitsFor ->
@@ -19,7 +20,7 @@ describe "SettingsView", ->
   describe "serialization", ->
     it "remembers which panel was visible", ->
       settingsView.showPanel('Themes')
-      newSettingsView = new SettingsView(settingsView.serialize())
+      newSettingsView = main.createSettingsView(settingsView.serialize())
       settingsView.remove()
       jasmine.attachToDOM(newSettingsView.element)
       newSettingsView.initializePanels()
@@ -28,7 +29,7 @@ describe "SettingsView", ->
     it "shows the previously active panel if it is added after deserialization", ->
       settingsView.addCorePanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
       settingsView.showPanel('Panel 1')
-      newSettingsView = new SettingsView(settingsView.serialize())
+      newSettingsView = main.createSettingsView(settingsView.serialize())
       newSettingsView.addPanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
       newSettingsView.initializePanels()
       jasmine.attachToDOM(newSettingsView.element)
@@ -37,7 +38,7 @@ describe "SettingsView", ->
     it "shows the Settings panel if the last saved active panel name no longer exists", ->
       settingsView.addCorePanel('Panel 1', 'panel1', -> $$ -> @div id: 'panel-1')
       settingsView.showPanel('Panel 1')
-      newSettingsView = new SettingsView(settingsView.serialize())
+      newSettingsView = main.createSettingsView(settingsView.serialize())
       settingsView.remove()
       jasmine.attachToDOM(newSettingsView.element)
       newSettingsView.initializePanels()
@@ -45,8 +46,8 @@ describe "SettingsView", ->
 
     it "serializes the active panel name even when the panels were never initialized", ->
       settingsView.showPanel('Themes')
-      settingsView2 = new SettingsView(settingsView.serialize())
-      settingsView3 = new SettingsView(settingsView2.serialize())
+      settingsView2 = main.createSettingsView(settingsView.serialize())
+      settingsView3 = main.createSettingsView(settingsView2.serialize())
       jasmine.attachToDOM(settingsView3.element)
       settingsView3.initializePanels()
       expect(settingsView3.activePanel).toEqual {name: 'Themes', options: {}}

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -1,14 +1,16 @@
 path = require 'path'
 {$, $$} = require 'atom-space-pen-views'
+PackageManager = require '../lib/package-manager'
 SettingsView = require '../lib/settings-view'
 SnippetsProvider =
   getSnippets: -> {}
 
 describe "SettingsView", ->
   settingsView = null
+  packageManager = new PackageManager()
 
   beforeEach ->
-    settingsView = new SettingsView({snippetsProvider: SnippetsProvider})
+    settingsView = new SettingsView({packageManager: packageManager, snippetsProvider: SnippetsProvider})
     spyOn(settingsView, "initializePanels").andCallThrough()
     window.advanceClock(10000)
     waitsFor ->

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -5,14 +5,12 @@ CSON = require 'season'
 
 PackageManager = require '../lib/package-manager'
 ThemesPanel = require '../lib/themes-panel'
-SettingsView = require '../lib/settings-view'
 
 describe "ThemesPanel", ->
   [panel, packageManager, reloadedHandler] = []
   settingsView = null
 
   beforeEach ->
-    settingsView = new SettingsView
     atom.packages.loadPackage('atom-light-ui')
     atom.packages.loadPackage('atom-dark-ui')
     atom.packages.loadPackage('atom-light-syntax')
@@ -32,7 +30,6 @@ describe "ThemesPanel", ->
       spyOn(packageManager, 'getFeatured').andCallFake (callback) ->
         Promise.resolve([themeMetadata])
       panel = new ThemesPanel(packageManager)
-      settingsView.addPanel('Themes', null, -> panel)
 
       # Make updates synchronous
       spyOn(panel, 'scheduleUpdateThemeConfig').andCallFake -> @updateThemeConfig()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Recent changes to the status bar tile necessitated that a single PackageManager instance was used throughout the codebase so that events would be caught correctly.  Unfortunately, there was one instance that I forgot to change: when deserializing, two PackageManagers get created (one in `main`, one in `settings-view`), leading to the status bar not receiving any events.  This PR fixes that.

### Alternate Designs

None.

### Benefits

The status bar and other parts of the code will work correctly when the Settings View is deserialized.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #902

Note: I am not sure how to add a spec for this, or if it is necessary.