### PR TITLE
Show errors in InstalledPackagesPanel and ThemesPanel

### DIFF
--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -82,7 +82,7 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
 
     @packageManagerSubscriptions = new CompositeDisposable
     @packageManagerSubscriptions.add @packageManager.on 'package-install-failed theme-install-failed package-uninstall-failed theme-uninstall-failed package-update-failed theme-update-failed', ({pack, error}) =>
-      @updateErrors.append(new ErrorView(@packageManager, error))
+      @errors.append(new ErrorView(@packageManager, error))
 
     loadPackagesTimeout = null
     @packageManagerSubscriptions.add @packageManager.on 'package-updated package-installed package-uninstalled package-installed-alternative', =>

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -26,7 +26,7 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
 
           @div outlet: 'errors'
 
-          @div outlet: 'packages', =>
+          @div outlet: 'installedPackages', =>
             @section outlet: 'deprecatedSection', class: 'sub-section deprecated-packages', =>
               @h3 outlet: 'deprecatedPackagesHeader', class: 'sub-section-heading icon icon-package', =>
                 @text 'Deprecated Packages'
@@ -162,7 +162,7 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
 
       .catch (error) =>
         @totalPackages.hide()
-        @packages.hide()
+        @installedPackages.hide()
         @errors.append(new ErrorView(@packageManager, error))
 
   displayPackageUpdates: (packagesWithUpdates) ->

--- a/lib/installed-packages-panel.coffee
+++ b/lib/installed-packages-panel.coffee
@@ -24,43 +24,44 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
           @div class: 'editor-container', =>
             @subview 'filterEditor', new TextEditorView(mini: true, placeholderText: 'Filter packages by name')
 
-          @div outlet: 'updateErrors'
+          @div outlet: 'errors'
 
-          @section outlet: 'deprecatedSection', class: 'sub-section deprecated-packages', =>
-            @h3 outlet: 'deprecatedPackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Deprecated Packages'
-              @span outlet: 'deprecatedCount', class: 'section-heading-count badge badge-flexible', '…'
-            @p 'Atom does not load deprecated packages. These packages may have updates available.'
-            @div outlet: 'deprecatedPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+          @div outlet: 'packages', =>
+            @section outlet: 'deprecatedSection', class: 'sub-section deprecated-packages', =>
+              @h3 outlet: 'deprecatedPackagesHeader', class: 'sub-section-heading icon icon-package', =>
+                @text 'Deprecated Packages'
+                @span outlet: 'deprecatedCount', class: 'section-heading-count badge badge-flexible', '…'
+              @p 'Atom does not load deprecated packages. These packages may have updates available.'
+              @div outlet: 'deprecatedPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
-          @section class: 'sub-section installed-packages', =>
-            @h3 outlet: 'communityPackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Community Packages'
-              @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'communityPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+            @section class: 'sub-section installed-packages', =>
+              @h3 outlet: 'communityPackagesHeader', class: 'sub-section-heading icon icon-package', =>
+                @text 'Community Packages'
+                @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'communityPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
-          @section class: 'sub-section core-packages', =>
-            @h3 outlet: 'corePackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Core Packages'
-              @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'corePackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+            @section class: 'sub-section core-packages', =>
+              @h3 outlet: 'corePackagesHeader', class: 'sub-section-heading icon icon-package', =>
+                @text 'Core Packages'
+                @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'corePackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
-          @section class: 'sub-section dev-packages', =>
-            @h3 outlet: 'devPackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Development Packages'
-              @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'devPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+            @section class: 'sub-section dev-packages', =>
+              @h3 outlet: 'devPackagesHeader', class: 'sub-section-heading icon icon-package', =>
+                @text 'Development Packages'
+                @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'devPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
-          @section class: 'sub-section git-packages', =>
-            @h3 outlet: 'gitPackagesHeader', class: 'sub-section-heading icon icon-package', =>
-              @text 'Git Packages'
-              @span outlet: 'gitCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'gitPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
+            @section class: 'sub-section git-packages', =>
+              @h3 outlet: 'gitPackagesHeader', class: 'sub-section-heading icon icon-package', =>
+                @text 'Git Packages'
+                @span outlet: 'gitCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'gitPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading packages…"
 
   initialize: (@packageManager) ->
     super
@@ -160,9 +161,9 @@ class InstalledPackagesPanel extends CollapsibleSectionPanel
         @matchPackages()
 
       .catch (error) =>
-        console.error error.message, error.stack
-        @loadingMessage.hide()
-        @featuredErrors.append(new ErrorView(@packageManager, error))
+        @totalPackages.hide()
+        @packages.hide()
+        @errors.append(new ErrorView(@packageManager, error))
 
   displayPackageUpdates: (packagesWithUpdates) ->
     for packageType in ['dev', 'core', 'user', 'git', 'deprecated']

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -52,35 +52,36 @@ class ThemesPanel extends CollapsibleSectionPanel
           @div class: 'editor-container', =>
             @subview 'filterEditor', new TextEditorView(mini: true, placeholderText: 'Filter themes by name')
 
-          @div outlet: 'themeErrors'
+          @div outlet: 'errors'
 
-          @section class: 'sub-section installed-packages', =>
-            @h3 outlet: 'communityThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
-              @text 'Community Themes'
-              @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'communityPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
+          @div outlet: 'themes', =>
+            @section class: 'sub-section installed-packages', =>
+              @h3 outlet: 'communityThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
+                @text 'Community Themes'
+                @span outlet: 'communityCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'communityPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
-          @section class: 'sub-section core-packages', =>
-            @h3 outlet: 'coreThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
-              @text 'Core Themes'
-              @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'corePackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
+            @section class: 'sub-section core-packages', =>
+              @h3 outlet: 'coreThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
+                @text 'Core Themes'
+                @span outlet: 'coreCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'corePackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
-          @section class: 'sub-section dev-packages', =>
-            @h3 outlet: 'developmentThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
-              @text 'Development Themes'
-              @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'devPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
+            @section class: 'sub-section dev-packages', =>
+              @h3 outlet: 'developmentThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
+                @text 'Development Themes'
+                @span outlet: 'devCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'devPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
-          @section class: 'sub-section git-packages', =>
-            @h3 outlet: 'gitThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
-              @text 'Git Themes'
-              @span outlet: 'gitCount', class: 'section-heading-count badge badge-flexible', '…'
-            @div outlet: 'gitPackages', class: 'container package-container', =>
-              @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
+            @section class: 'sub-section git-packages', =>
+              @h3 outlet: 'gitThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
+                @text 'Git Themes'
+                @span outlet: 'gitCount', class: 'section-heading-count badge badge-flexible', '…'
+              @div outlet: 'gitPackages', class: 'container package-container', =>
+                @div class: 'alert alert-info loading-area icon icon-hourglass', "Loading themes…"
 
   initialize: (@packageManager) ->
     super
@@ -178,8 +179,9 @@ class ThemesPanel extends CollapsibleSectionPanel
         @updateSectionCounts()
 
       .catch (error) =>
-        @loadingMessage.hide()
-        @themeErrors.append(new ErrorView(@packageManager, error))
+        @totalPackages.hide()
+        @themes.hide()
+        @errors.append(new ErrorView(@packageManager, error))
 
   # Update the active UI and syntax themes and populate the menu
   updateActiveThemes: ->

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -101,7 +101,7 @@ class ThemesPanel extends CollapsibleSectionPanel
 
     @disposables = new CompositeDisposable()
     @disposables.add @packageManager.on 'theme-install-failed theme-uninstall-failed', ({pack, error}) =>
-      @themeErrors.append(new ErrorView(@packageManager, error))
+      @errors.append(new ErrorView(@packageManager, error))
 
     @openUserStysheet.on 'click', ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'application:open-your-stylesheet')

--- a/lib/themes-panel.coffee
+++ b/lib/themes-panel.coffee
@@ -54,7 +54,7 @@ class ThemesPanel extends CollapsibleSectionPanel
 
           @div outlet: 'errors'
 
-          @div outlet: 'themes', =>
+          @div outlet: 'installedThemes', =>
             @section class: 'sub-section installed-packages', =>
               @h3 outlet: 'communityThemesHeader', class: 'sub-section-heading icon icon-paintcan', =>
                 @text 'Community Themes'
@@ -180,7 +180,7 @@ class ThemesPanel extends CollapsibleSectionPanel
 
       .catch (error) =>
         @totalPackages.hide()
-        @themes.hide()
+        @installedThemes.hide()
         @errors.append(new ErrorView(@packageManager, error))
 
   # Update the active UI and syntax themes and populate the menu

--- a/spec/themes-panel-spec.coffee
+++ b/spec/themes-panel-spec.coffee
@@ -198,3 +198,29 @@ describe "ThemesPanel", ->
       expect(panel.find('.section-heading-count').text()).toMatch /^0(0\/0)+$/
       expect(panel.find('.sub-section .icon-paintcan').length).toBe 4
       expect(panel.find('.sub-section .icon-paintcan.has-items').length).toBe 0
+
+  describe 'when an error occurs loading themes', ->
+    beforeEach ->
+      spyOn(packageManager, 'loadCompatiblePackageVersion').andCallFake ->
+      spyOn(packageManager, 'getInstalled').andReturn Promise.reject({stderr: 'nope'})
+      panel = new ThemesPanel(packageManager)
+
+      waitsFor ->
+        packageManager.getInstalled.callCount is 1 and panel.errors.text().length isnt 0
+
+    it 'displays the error and hides the theme sections', ->
+      expect(panel.errors.text()).toContain 'nope'
+      expect(panel.totalPackages.isHidden()).toBe true
+      expect(panel.installedThemes.isHidden()).toBe true
+      expect(panel.find('.sub-section.installed-packages')).toBeHidden()
+
+  describe 'when an error occurs uninstalling a theme', ->
+    beforeEach ->
+      panel = new ThemesPanel(packageManager)
+      packageManager.emitPackageEvent('install-failed', {theme: true}, {stderr: 'nope'})
+
+      waitsFor ->
+        panel.errors.text().length isnt 0
+
+    it 'displays the error', ->
+      expect(panel.errors.text()).toContain 'nope'

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -168,3 +168,14 @@ describe 'UpdatesPanel', ->
 
         packageManager.emitPackageEvent 'update-failed', {name: 'packA'}
         expect(panel.checkButton.prop('disabled')).toBe false
+
+  describe 'when an error occurs loading updates', ->
+    beforeEach ->
+      rejectOutdated({stderr: 'nope'})
+
+      waitsFor ->
+        packageManager.getOutdated.callCount is 1 and panel.updateErrors.text().length isnt 0
+
+    it 'displays the error and hides the checking message', ->
+      expect(panel.updateErrors.text()).toContain 'nope'
+      expect(panel.checkingMessage.isHidden()).toBe true


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

From the looks of it, InstalledPackagesPanel and ThemesPanel were mostly a result of copy-paste from UpdatesPanel and InstallPanel.  And some of the variables forgot to be renamed...resulting in a hidden uncaught exception when attempting to display the error.  Errorception.
So: add an extra div that wraps around all the sub-package listings (community, core, etc).  When something goes :boom:, hide that div and also the total package count, then display the error.  The error div itself has been renamed from `updateErrors` and `themeErrors` to just `errors`.

### Alternate Designs

This is primarily a bugfix, so no alternate designs were considered.

### Benefits

No more "hmm, the packages listing is taking a _really_ long time to load..." 🤔

### Possible Drawbacks

None

### Applicable Issues

None

Whitespace-insensitive diff: https://github.com/atom/settings-view/pull/916/files?w=1