### PR TITLE
Use correct grammar to highlight code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Custom keybindings can be added by referencing the above commands.  To learn mor
 ## Customize
 The Settings View package uses the `ui-variables` to match a theme's color scheme. You can still customize the UI in your `styles.less` file. For example:
 
-```css
+```less
 // Change the color of the titles
 .settings-view .section .section-heading {
   color: white;


### PR DESCRIPTION
[This jumped out at me](https://github.com/atom/settings-view#customize), so I had to fix it:

<img src="https://cloud.githubusercontent.com/assets/2346707/23365047/8b4c5fce-fd55-11e6-8f19-b502824610c9.png" width="420" alt="Figure 1" />
