### PR TITLE
Wait for `open()` to complete before considering command done

### DIFF
--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -118,14 +118,22 @@ describe "SettingsView", ->
       expect(settingsView.refs.panels.querySelector('#panel-2')).toBeVisible()
 
   describe "when the package is activated", ->
+    lastOpenResult = null
+
     openWithCommand = (command) ->
       atom.commands.dispatch(atom.views.getView(atom.workspace), command)
       waitsFor ->
         atom.workspace.getActivePaneItem()?
       waitsFor (done) ->
         process.nextTick(done)
+      waitsForPromise -> lastOpenResult
 
     beforeEach ->
+      originalOpen = atom.workspace.open.bind(atom.workspace)
+      spyOn(atom.workspace, 'open').andCallFake(
+        (args...) => lastOpenResult = originalOpen(args...)
+      )
+
       jasmine.attachToDOM(atom.views.getView(atom.workspace))
       waitsForPromise ->
         atom.packages.activatePackage('settings-view')

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -118,22 +118,14 @@ describe "SettingsView", ->
       expect(settingsView.refs.panels.querySelector('#panel-2')).toBeVisible()
 
   describe "when the package is activated", ->
-    lastOpenResult = null
-
     openWithCommand = (command) ->
-      atom.commands.dispatch(atom.views.getView(atom.workspace), command)
-      waitsFor ->
-        atom.workspace.getActivePaneItem()?
       waitsFor (done) ->
-        process.nextTick(done)
-      waitsForPromise -> lastOpenResult
+        openSubscription = atom.workspace.onDidOpen ->
+          openSubscription.dispose()
+          done()
+        atom.commands.dispatch(atom.views.getView(atom.workspace), command)
 
     beforeEach ->
-      originalOpen = atom.workspace.open.bind(atom.workspace)
-      spyOn(atom.workspace, 'open').andCallFake(
-        (args...) => lastOpenResult = originalOpen(args...)
-      )
-
       jasmine.attachToDOM(atom.views.getView(atom.workspace))
       waitsForPromise ->
         atom.packages.activatePackage('settings-view')


### PR DESCRIPTION
This has been relying on the pane to be created synchronously when
dispatching the command (and calling `open()`), which would only happen
in certain conditions. After atom/atom#13977, `open()` is more reliably
async so we need to take that into account.