### PR TITLE
Use `atom.packages.resolvePackagePath` instead of `pack.path`

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -78,8 +78,9 @@ export default class PackageDetailView {
 
     const openButtonClickHandler = (event) => {
       event.preventDefault()
-      if (fs.existsSync(this.pack.path)) {
-        atom.open({pathsToOpen: [this.pack.path]})
+      const packagePath = atom.packages.resolvePackagePath(this.pack.name)
+      if (fs.existsSync(packagePath)) {
+        atom.open({pathsToOpen: [packagePath]})
       }
     }
     this.refs.openButton.addEventListener('click', openButtonClickHandler)
@@ -337,9 +338,10 @@ export default class PackageDetailView {
         this.refs.sections.appendChild(this.settingsPanel.element)
         this.refs.sections.appendChild(this.keymapView.element)
 
-        if (this.pack.path) {
-          this.grammarsView = new PackageGrammarsView(this.pack.path)
-          this.snippetsView = new PackageSnippetsView(this.pack.path, this.snippetsProvider)
+        const packagePath = atom.packages.resolvePackagePath(this.pack.name)
+        if (packagePath) {
+          this.grammarsView = new PackageGrammarsView(packagePath)
+          this.snippetsView = new PackageSnippetsView(packagePath, this.snippetsProvider)
           this.refs.sections.appendChild(this.grammarsView.element)
           this.refs.sections.appendChild(this.snippetsView.element)
         }
@@ -418,7 +420,7 @@ export default class PackageDetailView {
     this.licensePath = null
     this.readmePath = null
 
-    const packagePath = this.pack.path != null ? this.pack.path : atom.packages.resolvePackagePath(this.pack.name)
+    const packagePath = atom.packages.resolvePackagePath(this.pack.name)
     for (const child of fs.listSync(packagePath)) {
       switch (path.basename(child, path.extname(child)).toLowerCase()) {
         case 'changelog':

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -9,7 +9,13 @@ SnippetsProvider =
 
 describe "InstalledPackageView", ->
   beforeEach ->
+    atom.packages.packageDirPaths.push(path.join(__dirname, 'fixtures'))
+
     spyOn(PackageManager.prototype, 'loadCompatiblePackageVersion').andCallFake ->
+
+  afterEach ->
+    index = atom.packages.packageDirPaths.indexOf(path.join(__dirname, 'fixtures'))
+    atom.packages.packageDirPaths.splice(index, 1)
 
   it "displays the grammars registered by the package", ->
     settingsPanels = null


### PR DESCRIPTION
Bundled packages will be preloaded during `script/build` and, since Atom cannot provide an absolute path during the snapshot phase, it will assign a relative path (`node_modules/{packageName}`) to preloaded packages. 

With this pull request we will resolve such path at runtime via `atom.packages.resolvePackagePath` in order to load e.g. readmes when opening a package card.