### PR TITLE
Implement custom renderer for config options

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -89,7 +89,7 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
     const body = document.createElement('div')
     body.classList.add('section-body')
     for (const name of sortedSettings) {
-      body.appendChild(elementForSetting(namespace, name, settings[name]))
+      body.appendChild(elementForSetting(namespace, name, settings[name], this.disposables))
     }
     container.appendChild(body)
 
@@ -330,7 +330,7 @@ function sortSettings (namespace, settings) {
     .value()
 }
 
-function elementForSetting (namespace, name, value) {
+function elementForSetting (namespace, name, value, disposables) {
   if (namespace === 'core') {
     if (name === 'themes') { return document.createDocumentFragment() } // Handled in the Themes panel
     if (name === 'disabledPackages') { return document.createDocumentFragment() } // Handled in the Packages panel
@@ -352,7 +352,9 @@ function elementForSetting (namespace, name, value) {
   controlGroup.appendChild(controls)
 
   let schema = atom.config.getSchema(`${namespace}.${name}`)
-  if (schema && schema.enum) {
+  if (schema && schema.renderer) {
+    controls.appendChild(elementForCustomRenderer(namespace, name, schema.renderer, disposables))
+  } else if (schema && schema.enum) {
     controls.appendChild(elementForOptions(namespace, name, value))
   } else if (schema && schema.type === 'color') {
     controls.appendChild(elementForColor(namespace, name, value))
@@ -378,6 +380,13 @@ function getSettingTitle (keyPath, name) {
   const schema = atom.config.getSchema(keyPath)
   const title = schema != null ? schema.title : null
   return title || _.uncamelcase(name).split('.').map(_.capitalize).join(' ')
+}
+
+function elementForCustomRenderer (namespace, name, Renderer, disposables) {
+  let keyPath = `${namespace}.${name}`
+  const customView = new Renderer(keyPath)
+  disposables.add({ dispose() { customView.destroy() } })
+  return customView.getElement()
 }
 
 function elementForOptions (namespace, name, value) {


### PR DESCRIPTION
### Description of the Change

Implements custom configuration interfaces as requested in issue #90.

Currently if a package developer wishes to implement a custom configuration interface, they must:
- create a command and add it to _package.json_,
- implement a command handler,
- implement a URI handler for the config pane to open in a new tab, and
- document this "alternate" configuration flow for end-users.

This PR permits package developers to bypass this process and display a custom configuration view directly in their package's settings panel.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

- The view class needs to be passed from the package via some key on the `config` object; I arbitrarily chose `renderer` since it seemed descriptive. Suggestions for alternatives are welcome.
- The `CompositeDisposable` instance is passed to `elementForSetting` via a new argument. I'm not a huge fan of this, but the only alternatives I saw were to either  bind `elementForSetting` to the `SettingsPanel` instance (which would have been harder to read and more tightly-coupled (e.g. `elementForSetting.call(this/*, existingArgs */)`), or to move `elementForSetting` into the `SettingsPanel` class as a method (which, as a refactoring, carries inherent risk).
- The custom renderer could have been passed as a field on the `options` argument to the `SettingsPanel` constructor. This would have required changes in unrelated files such as _package-detail-view.js_; it also would have prevented developers from using the stock config UI elements in cases where only one field needs a custom renderer. (Consider a hypothetical `Slider` view; if a developer wanted a given config field to use a slider with the alternate method proposed in this bullet point, they'd be forced to reimplement the config views required for all other config fields for their package.)
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Package developers will be able to implement their own configuration interface. This unlocks a wide range of possibilities:
- Displaying UI elements (such as a slider, date-picker, etc.) not currently supported by the settings panel.
- Displaying custom elements for editing array or object values.
- Dynamic showing or hiding of irrelevant config options. For instance, if the `Vegetables` option is disabled, the presence of a `Favorite Vegetable` field is irrelevant.
- Visually confirming authentication with a service without leaving the configuration page. For example, if a package requires a GitHub API key, the package could use a custom renderer and display a yellow warning icon if the key has not been supplied, a green check mark if it can successfully make service requests, or a red error icon if the API key has been rejected.
- Atom developers are pretty imaginative, so I expect I'm not even starting to touch the surface.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
- As with any new feature, this PR increases the complexity of the codebase. Specifically, it adds a new parameter, `disposables`, to the `elementForSetting` function. Unlike the `namespace`, `name`, and `value` parameters, the `disposables` parameter is somewhat unrelated to the core functionality provided and is only used for the `elementForCustomRenderer` call.
- An end-user might come across a bug in a custom renderer and file it with `atom/atom` or `atom/settings-view` instead of the package implementing the custom renderer; because of the seamless integration with the settings panel, an average user might think that the custom UI is part of the core IDE itself.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
- #90
<!-- Enter any applicable Issues here -->
