### PR TITLE
Prevent version pinned packages from showing as needing updates

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -146,8 +146,7 @@ class PackageManager
           error = createJsonParseError(errorMessage, parseError, stdout)
           return callback(error)
 
-        pinnedPackages = atom.config.get('core.versionPinnedPackages') ? []
-        updatablePackages = (pack for pack in packages when not pinnedPackages.includes(pack?.name))
+        updatablePackages = (pack for pack in packages when not @getVersionPinnedPackages().includes(pack?.name))
 
         @apmCache.loadOutdated =
           value: updatablePackages
@@ -164,6 +163,9 @@ class PackageManager
         callback(error)
 
     handleProcessErrors(apmProcess, errorMessage, callback)
+
+  getVersionPinnedPackages: ->
+    atom.config.get('core.versionPinnedPackages') ? []
 
   clearOutdatedCache: ->
     @apmCache.loadOutdated =

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -146,17 +146,17 @@ class PackageManager
           error = createJsonParseError(errorMessage, parseError, stdout)
           return callback(error)
 
-        pinnedPackages = atom.config.get('core.versionPinnedPackages')
-        packages = (pack for pack in packages when not pinnedPackages.includes(pack?.name))
+        pinnedPackages = atom.config.get('core.versionPinnedPackages') ? []
+        updatablePackages = (pack for pack in packages when not pinnedPackages.includes(pack?.name))
 
         @apmCache.loadOutdated =
-          value: packages
+          value: updatablePackages
           expiry: Date.now() + @CACHE_EXPIRY
 
-        for pack in packages
+        for pack in updatablePackages
           @emitPackageEvent 'update-available', pack
 
-        callback(null, packages)
+        callback(null, updatablePackages)
       else
         error = new Error(errorMessage)
         error.stdout = stdout

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -146,6 +146,9 @@ class PackageManager
           error = createJsonParseError(errorMessage, parseError, stdout)
           return callback(error)
 
+        pinnedPackages = atom.config.get('core.versionPinnedPackages')
+        packages = (pack for pack in packages when not pinnedPackages.includes(pack?.name))
+
         @apmCache.loadOutdated =
           value: packages
           expiry: Date.now() + @CACHE_EXPIRY

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -81,6 +81,7 @@ export default class UpdatesPanel {
               </div>
             </div>
 
+            <div ref='versionPinnedPackagesMessage' className='alert alert-warning icon icon-alert'>The following packages are pinned to their current version and are not being checked for updates: <strong>{ this.packageManager.getVersionPinnedPackages().join(', ') }</strong></div>
             <div ref='updateErrors'></div>
             <div ref='checkingMessage' className='alert alert-info icon icon-hourglass'>{`Checking for updates\u2026`}</div>
             <div ref='noUpdatesMessage' className='alert alert-info icon icon-heart'>All of your installed packages are up to date!</div>
@@ -112,6 +113,10 @@ export default class UpdatesPanel {
       this.availableUpdates = []
       this.clearPackageCards()
       this.checkForUpdates()
+    }
+
+    if (this.packageManager.getVersionPinnedPackages().length === 0) {
+      this.refs.versionPinnedPackagesMessage.style.display = 'none'
     }
   }
 

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -33,6 +33,17 @@ describe 'UpdatesPanel', ->
     expect(panel.refs.updatesContainer.children.length).toBe(0)
     expect(panel.refs.noUpdatesMessage.style.display).not.toBe('none')
 
+  describe "version pinned packages message", ->
+    it 'shows a message when there are pinned version packages', ->
+      spyOn(packageManager, 'getVersionPinnedPackages').andReturn(['foo', 'bar', 'baz'])
+      panel.beforeShow(updates: [])
+      expect(panel.refs.versionPinnedPackagesMessage.style.display).not.toBe('none')
+
+    it 'does not show a message when there are no version pinned packages', ->
+      spyOn(packageManager, 'getVersionPinnedPackages').andReturn([])
+      panel.beforeShow(updates: [])
+      expect(panel.refs.versionPinnedPackagesMessage.style.display).toBe('none')
+
   describe "the Update All button", ->
     packA =
       name: 'test-package-a'


### PR DESCRIPTION
### Description of the Change

Prevent package whose names are listed in `core.versionPinnedPackages` from being shown for automatic updating. This is only prevented through the Atom UI. Using `apm` from the command line will not respect the `core.versionPinnedPackages` setting.

### Alternate Designs

* Specify the version number in addition to the package name
    * Decided that simply specifying the package name simplified the code and was probably good enough for the target use case
    * If people want to update to a newer version, they would need to update the package _and_ update their config file
* Prevent the packages from being updated within `apm` as well
    * Figured that people should be able to easily update their pinned version if they wanted but keep the package pinned

### Benefits

People can prevent Atom from recommending to update to a newer version of specific packages when the newer version has bugs or problems.

### Possible Drawbacks

People could get "stuck" on old versions of packages that have critical improvements. (Added alert to the updates panel to help with this.)

### Applicable Issues

* atom/atom#14417
