### PR TITLE
Hidden settings

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -344,6 +344,11 @@ function elementForSetting (namespace, name, value) {
     }
   }
 
+  let schema = atom.config.getSchema(`${namespace}.${name}`)
+  if (schema && schema.hidden) {
+    return document.createDocumentFragment()
+  }
+
   const controlGroup = document.createElement('div')
   controlGroup.classList.add('control-group')
 
@@ -351,7 +356,6 @@ function elementForSetting (namespace, name, value) {
   controls.classList.add('controls')
   controlGroup.appendChild(controls)
 
-  let schema = atom.config.getSchema(`${namespace}.${name}`)
   if (schema && schema.enum) {
     controls.appendChild(elementForOptions(namespace, name, value))
   } else if (schema && schema.type === 'color') {

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -183,3 +183,29 @@ describe "SettingsPanel", ->
       expect(controlGroups[1].querySelector('.sub-section .sub-section-heading').classList.contains('has-items')).toBe true
       # Should be already collapsed
       expect(controlGroups[1].querySelector('.sub-section .sub-section-heading').parentElement.classList.contains('collapsed')).toBe true
+
+  describe 'hidden settings', ->
+    beforeEach ->
+      config =
+        type: 'object'
+        properties:
+          visible:
+            name: 'visible'
+            title: 'A visible setting'
+            description: 'This setting should appear in the settings view'
+            type: 'string'
+            default: 'hurf'
+          invisible:
+            name: 'shhh'
+            title: 'Oh no'
+            description: 'This setting should not appear in the settings view'
+            type: 'integer'
+            default: 400
+            hidden: true
+
+      atom.config.setSchema("foo", config)
+      settingsPanel = new SettingsPanel({namespace: "foo", includeTitle: false})
+
+    it 'does not display the hidden setting', ->
+      expect(settingsPanel.element.querySelectorAll('[id="foo.visible"]').length).toEqual 1
+      expect(settingsPanel.element.querySelectorAll('[id="foo.invisible"]').length).toEqual 0


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Support a `hidden` attribute in package configuration schema. If present and set to something truthy, the setting is not rendered in the Settings View, but can only be interacted with manually through `atom.config.set()` or by editing `config.cson`.

### Alternate Designs

I considered blacklisting a package name like `hidden` on atom.io and using `atom.config.set('hidden.someSetting')` as a quicker way to achieve non-user-facing options, but I wasn't fond of that because it creates a single, global namespace for hidden settings, and because it would cause additional confusion for anyone who looked at their raw `config.cson`.

I also considered using a visible "show on load" setting like we have in the welcome package, but we don't have an obvious place to put the checkbox on our panels, and I didn't want to make users hunt for it in the settings view. If we used a visible setting and automatically toggled it off after the first reveal, that would cause even _more_ confusion because we'd be messing with something that they explicitly enabled.

### Benefits

In the GitHub package, we want to show the Git and GitHub dock items on launch to aid discoverability, but only on the first Atom run. We're currently using state serialization, but that has the drawback of being scoped to the current project, so the dock items reappear each time you open a new project.

Hidden settings provide a mechanism for storing Atom-global package state, which we can use to store a latch setting that tracks whether or not we should launch with the panels present or not.

### Possible Drawbacks

It introduces a disparity between the configuration seen in the settings view and the one seen in your config file, so I wouldn't overuse it. If the config file gets corrupted somehow it would be harder for users to diagnose the problem.

/cc @BinaryMuse @kuychaco @nathansobo @lee-dohm 
