### PR TITLE
prevent disabled packages from triggering status view updates

### DIFF
--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -53,6 +53,10 @@ export default class PackageUpdatesStatusView {
   }
 
   onPackageUpdateAvailable (pack) {
+    if (atom.packages.isPackageDisabled(pack.name)) {
+      return
+    }
+
     for (const update of this.updates) {
       if (update.name === pack.name) {
         return


### PR DESCRIPTION
### Description of the Change

Check when a package update is available if it is disabled and prevent a status view alert.
Fixes #956 

### Benefits

Remove unnecessary update noise to users.
