### PR TITLE
Display keybindings even when disabled

### DIFF
--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -114,7 +114,7 @@ export default class PackageKeymapView {
       // Backwards compatibility for Atom <= 1.19
       for (const keyBinding of atom.keymaps.getKeyBindings()) {
         const {command} = keyBinding
-        if (command && command.indexOf && command.indexOf(`${this.namespace}:` === 0)) {
+        if (command && command.indexOf && command.indexOf(`${this.namespace}:`) === 0) {
           keyBindings.push(keyBinding)
         }
       }

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -114,7 +114,7 @@ export default class PackageKeymapView {
       // Backwards compatibility for Atom <= 1.19
       for (const keyBinding of atom.keymaps.getKeyBindings()) {
         const {command} = keyBinding
-        if (command && command.indexOf && command.indexOf(`${this.namespace}` === 0)) {
+        if (command && command.indexOf && command.indexOf(`${this.namespace}:` === 0)) {
           keyBindings.push(keyBinding)
         }
       }

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -106,8 +106,18 @@ export default class PackageKeymapView {
     }
 
     const keyBindings = []
-    for (const [keymapPath, keymap] of atom.packages.getLoadedPackage(this.namespace).keymaps) {
-      keyBindings.push(...atom.keymaps.build(this.namespace, keymap, 0, false))
+    if (atom.keymaps.build) {
+      for (const [keymapPath, keymap] of atom.packages.getLoadedPackage(this.namespace).keymaps) {
+        keyBindings.push(...atom.keymaps.build(this.namespace, keymap, 0, false))
+      }
+    } else {
+      // Backwards compatibility for Atom <= 1.19
+      for (const keyBinding of atom.keymaps.getKeyBindings()) {
+        const {command} = keyBinding
+        if (command && command.indexOf && command.indexOf(`${this.namespace}` === 0)) {
+          keyBindings.push(keyBinding)
+        }
+      }
     }
 
     for (const keyBinding of keyBindings) {

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -97,8 +97,10 @@ export default class PackageKeymapView {
   updateKeyBindingView () {
     this.refs.keybindingItems.innerHTML = ''
 
-    const keymaps = atom.packages.getLoadedPackage(this.namespace).keymaps
-    const keyBindings = atom.keymaps.build(this.namespace, keymaps, 0, false)
+    const keyBindings = []
+    for (const [keymapPath, keymap] of atom.packages.getLoadedPackage(this.namespace).keymaps) {
+      keyBindings.push(...atom.keymaps.build(this.namespace, keymap, 0, false))
+    }
 
     for (const keyBinding of keyBindings) {
       const {command, keystrokes, selector, source} = keyBinding

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -75,7 +75,9 @@ export default class PackageKeymapView {
             <input id='toggleKeybindings' className='input-checkbox' type='checkbox' ref='keybindingToggle'></input>
             <div className='setting-title'>Enable</div>
           </label>
-          <div className='setting-description'>Disable this if you want to bind your own keystrokes for this package\'s commands in your keymap.</div>
+          <div className='setting-description'>
+            {"Disable this if you want to bind your own keystrokes for this package's commands in your keymap."}
+          </div>
         </div>
         <table className='package-keymap-table table native-key-bindings text' tabIndex='-1'>
           <thead>

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -102,7 +102,7 @@ export default class PackageKeymapView {
 
     for (const keyBinding of keyBindings) {
       const {command, keystrokes, selector, source} = keyBinding
-      if (!command || !command.indexOf || command.indexOf(`${this.namespace}:`) !== 0) {
+      if (!command) {
         continue
       }
 

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -97,7 +97,10 @@ export default class PackageKeymapView {
   updateKeyBindingView () {
     this.refs.keybindingItems.innerHTML = ''
 
-    for (const keyBinding of atom.keymaps.getKeyBindings()) {
+    const keymaps = atom.packages.getLoadedPackage(this.namespace).keymaps
+    const keyBindings = atom.keymaps.build(this.namespace, keymaps, 0, false)
+
+    for (const keyBinding of keyBindings) {
       const {command, keystrokes, selector, source} = keyBinding
       if (!command || !command.indexOf || command.indexOf(`${this.namespace}:`) !== 0) {
         continue

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -97,6 +97,14 @@ export default class PackageKeymapView {
   updateKeyBindingView () {
     this.refs.keybindingItems.innerHTML = ''
 
+    const packagesWithKeymapsDisabled = atom.config.get('core.packagesWithKeymapsDisabled') || []
+    const keybindingsDisabled = packagesWithKeymapsDisabled.includes(this.namespace)
+    if (keybindingsDisabled) {
+      this.refs.keybindingItems.classList.add('text-subtle')
+    } else {
+      this.refs.keybindingItems.classList.remove('text-subtle')
+    }
+
     const keyBindings = []
     for (const [keymapPath, keymap] of atom.packages.getLoadedPackage(this.namespace).keymaps) {
       keyBindings.push(...atom.keymaps.build(this.namespace, keymap, 0, false))

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -92,15 +92,17 @@ describe "InstalledPackageView", ->
         expect(card.refs.keybindingToggle.checked).toBe false
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe true
 
-        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody.text-subtle tr')
-        expect(keybindingRows.length).toBe 1
+        if atom.keymaps.build?
+          keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody.text-subtle tr')
+          expect(keybindingRows.length).toBe 1
 
         card.refs.keybindingToggle.click()
         expect(card.refs.keybindingToggle.checked).toBe true
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe false
 
-        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody tr')
-        expect(keybindingRows.length).toBe 1
+        if atom.keymaps.build?
+          keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody tr')
+          expect(keybindingRows.length).toBe 1
 
   describe "when a keybinding is copied", ->
     [pack, card] = []

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -92,7 +92,7 @@ describe "InstalledPackageView", ->
         expect(card.refs.keybindingToggle.checked).toBe false
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe true
 
-        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody tr')
+        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody.text-subtle tr')
         expect(keybindingRows.length).toBe 1
 
         card.refs.keybindingToggle.click()

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -92,15 +92,15 @@ describe "InstalledPackageView", ->
         expect(card.refs.keybindingToggle.checked).toBe false
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe true
 
-        keybindingRows = view.element.querySelector('.package-keymap-table tbody tr')
-        expect(keybindingsRows.length).toBe 1
+        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody tr')
+        expect(keybindingRows.length).toBe 1
 
         card.refs.keybindingToggle.click()
         expect(card.refs.keybindingToggle.checked).toBe true
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe false
 
-        keybindingRows = view.element.querySelector('.package-keymap-table tbody tr')
-        expect(keybindingsRows.length).toBe 1
+        keybindingRows = card.element.querySelectorAll('.package-keymap-table tbody tr')
+        expect(keybindingRows.length).toBe 1
 
   describe "when a keybinding is copied", ->
     [pack, card] = []

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -92,9 +92,15 @@ describe "InstalledPackageView", ->
         expect(card.refs.keybindingToggle.checked).toBe false
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe true
 
+        keybindingRows = view.element.querySelector('.package-keymap-table tbody tr')
+        expect(keybindingsRows.length).toBe 1
+
         card.refs.keybindingToggle.click()
         expect(card.refs.keybindingToggle.checked).toBe true
         expect(_.include(atom.config.get('core.packagesWithKeymapsDisabled') ? [], 'language-test')).toBe false
+
+        keybindingRows = view.element.querySelector('.package-keymap-table tbody tr')
+        expect(keybindingsRows.length).toBe 1
 
   describe "when a keybinding is copied", ->
     [pack, card] = []


### PR DESCRIPTION
Collect the keybindings created by each package from the package itself rather than filtering them from the `atom.keymaps` global. `atom.keymaps` does not include bindings from disabled packages or from packages with disabled keybindings, but the package's `.keymaps` property does.

As a side effect, we'll no longer be relying on the convention of beginning command names with the package name to identify which commands are associated with a package. Weird Things will happen if you deviate from this with the present scheme!

Fixes #946. Depends on atom/atom-keymap#218 for `atom.keymaps.build()`.