### PR TITLE
React to uninstalls in the status bar tile

### DIFF
--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -25,7 +25,7 @@ export default class PackageUpdatesStatusView {
 
     this.disposables.add(packageManager.on('package-update-available theme-update-available', ({pack, error}) => { this.onPackageUpdateAvailable(pack) }))
     this.disposables.add(packageManager.on('package-updating theme-updating', ({pack, error}) => { this.onPackageUpdating(pack) }))
-    this.disposables.add(packageManager.on('package-updated theme-updated', ({pack, error}) => { this.onPackageUpdated(pack) }))
+    this.disposables.add(packageManager.on('package-updated theme-updated package-uninstalled theme-uninstalled', ({pack, error}) => { this.onPackageUpdated(pack) }))
     this.disposables.add(packageManager.on('package-update-failed theme-update-failed', ({pack, error}) => { this.onPackageUpdateFailed(pack) }))
 
     const clickHandler = () => {

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -118,3 +118,20 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
       expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '2 updates (1 failed)'
+
+  describe "when a package that can be updated is uninstalled", ->
+    it "updates the tile", ->
+      packageManager.emitPackageEvent('uninstalled', outdatedPackage1)
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '1 update'
+
+  describe "when a package that is updating is uninstalled", ->
+    it "updates the tile", ->
+      packageManager.emitPackageEvent('updating', outdatedPackage1)
+      packageManager.emitPackageEvent('uninstalled', outdatedPackage1)
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '1 update'
+
+  describe "when a package that failed to update is uninstalled", ->
+    it "updates the tile", ->
+      packageManager.emitPackageEvent('update-failed', outdatedPackage1)
+      packageManager.emitPackageEvent('uninstalled', outdatedPackage1)
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '1 update'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Update the status bar tile when packages with updates are uninstalled.

### Alternate Designs

None.

### Benefits

Removes another case of the tile being inconsistent.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #964