### PR TITLE
Fix calculation of scoped setting defaults

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -165,15 +165,23 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
   }
 
   getDefault (name) {
+    let params = {excludeSources: [atom.config.getUserConfigPath()]}
     if (this.options.scopeName != null) {
-      return atom.config.get(name)
-    } else {
-      let params = {excludeSources: [atom.config.getUserConfigPath()]}
-      if (this.options.scopeName != null) {
-        params.scope = [this.options.scopeName]
-      }
-      return atom.config.get(name, params)
+      params.scope = [this.options.scopeName]
     }
+
+    let defaultValue = atom.config.get(name, params)
+    if(this.options.scopeName != null) {
+      // If the unscoped default is the same as the scoped default, check the actual config.cson
+      // to make sure that there isn't a non-default value that is overriding the scoped value
+      // For example: the default editor.tabLength is 2, but if someone sets it to 4
+      // the above check still returns 2 and not 4 for a scoped editor.tabLength,
+      // because it bypasses config.cson.
+      if(atom.config.get(name, {excludeSources: [atom.config.getUserConfigPath()]}) === defaultValue) {
+        defaultValue = atom.config.get(name)
+      }
+    }
+    return defaultValue
   }
 
   set (name, value) {
@@ -210,11 +218,7 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       let type = editorElement.getAttribute('type')
 
       if (defaultValue = this.valueToString(this.getDefault(name))) {
-        if (this.options.scopeName != null) {
-          editor.setPlaceholderText(`Unscoped value: ${defaultValue}`)
-        } else {
-          editor.setPlaceholderText(`Default: ${defaultValue}`)
-        }
+        editor.setPlaceholderText(`Default: ${defaultValue}`)
       }
 
       const subscriptions = new CompositeDisposable()

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -171,13 +171,13 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
     }
 
     let defaultValue = atom.config.get(name, params)
-    if(this.options.scopeName != null) {
+    if (this.options.scopeName != null) {
       // If the unscoped default is the same as the scoped default, check the actual config.cson
       // to make sure that there isn't a non-default value that is overriding the scoped value
       // For example: the default editor.tabLength is 2, but if someone sets it to 4
       // the above check still returns 2 and not 4 for a scoped editor.tabLength,
       // because it bypasses config.cson.
-      if(atom.config.get(name, {excludeSources: [atom.config.getUserConfigPath()]}) === defaultValue) {
+      if (atom.config.get(name, {excludeSources: [atom.config.getUserConfigPath()]}) === defaultValue) {
         defaultValue = atom.config.get(name)
       }
     }

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -133,7 +133,7 @@ describe "SettingsPanel", ->
         expect(tabLengthEditor.getModel().getText()).toBe('')
         expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Default: 8')
 
-        # This is the scoped default, but it differs from the current unscoped value
+        # This is the unscoped default, but it differs from the current unscoped value
         settingsPanel.set('editor.tabLength', 2)
         expect(tabLengthEditor.getModel().getText()).toBe('2')
         expect(atom.config.get('editor.tabLength', {scope: ['source.js']})).toBe(2)

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -110,16 +110,22 @@ describe "SettingsPanel", ->
       expect(settingsPanel.isDefault('foo.testZero')).toBe true
 
     describe 'scoped settings', ->
-      xit 'displays the scoped default', ->
+      beforeEach ->
+        schema =
+          scopes:
+            '.source.python':
+              default: 4
+
+        atom.config.setScopedDefaultsFromSchema('editor.tabLength', schema)
         expect(atom.config.get('editor.tabLength')).toBe(2)
 
+      it 'displays the scoped default', ->
         settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.python'})
         tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
         expect(tabLengthEditor.getModel().getText()).toBe('')
         expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Default: 4')
 
       it 'allows the scoped setting to be changed to its normal default if the unscoped value is different', ->
-        expect(atom.config.get('editor.tabLength')).toBe(2)
         atom.config.set('editor.tabLength', 8)
 
         settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.js'})
@@ -132,9 +138,7 @@ describe "SettingsPanel", ->
         expect(tabLengthEditor.getModel().getText()).toBe('2')
         expect(atom.config.get('editor.tabLength', {scope: ['source.js']})).toBe(2)
 
-      xit 'allows the scoped setting to be changed to the unscoped default if it is different', ->
-        expect(atom.config.get('editor.tabLength')).toBe(2)
-
+      it 'allows the scoped setting to be changed to the unscoped default if it is different', ->
         settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.python'})
         tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
         expect(tabLengthEditor.getModel().getText()).toBe('')

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -109,20 +109,41 @@ describe "SettingsPanel", ->
       settingsPanel.set('foo.testZero', 0)
       expect(settingsPanel.isDefault('foo.testZero')).toBe true
 
-    describe 'when displaying scoped settings', ->
-      it 'displays the settings unscoped value of a setting as its default', ->
+    describe 'scoped settings', ->
+      xit 'displays the scoped default', ->
+        expect(atom.config.get('editor.tabLength')).toBe(2)
+
+        settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.python'})
+        tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
+        expect(tabLengthEditor.getModel().getText()).toBe('')
+        expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Default: 4')
+
+      it 'allows the scoped setting to be changed to its normal default if the unscoped value is different', ->
         expect(atom.config.get('editor.tabLength')).toBe(2)
         atom.config.set('editor.tabLength', 8)
 
         settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.js'})
         tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
         expect(tabLengthEditor.getModel().getText()).toBe('')
-        expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Unscoped value: 8')
+        expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Default: 8')
 
-        # This is the default value, but it differs from the unscoped value
+        # This is the scoped default, but it differs from the current unscoped value
         settingsPanel.set('editor.tabLength', 2)
         expect(tabLengthEditor.getModel().getText()).toBe('2')
         expect(atom.config.get('editor.tabLength', {scope: ['source.js']})).toBe(2)
+
+      xit 'allows the scoped setting to be changed to the unscoped default if it is different', ->
+        expect(atom.config.get('editor.tabLength')).toBe(2)
+
+        settingsPanel = new SettingsPanel({namespace: "editor", includeTitle: false, scopeName: '.source.python'})
+        tabLengthEditor = settingsPanel.element.querySelector('[id="editor.tabLength"]')
+        expect(tabLengthEditor.getModel().getText()).toBe('')
+        expect(tabLengthEditor.getModel().getPlaceholderText()).toBe('Default: 4')
+
+        # This is the unscoped default, but it differs from the scoped default
+        settingsPanel.set('editor.tabLength', 2)
+        expect(tabLengthEditor.getModel().getText()).toBe('2')
+        expect(atom.config.get('editor.tabLength', {scope: ['source.python']})).toBe(2)
 
   describe 'grouped settings', ->
     beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Prior to this PR, the scoped setting default was ignored and the unscoped default was used instead.  That was done in #841 to fix #774 (not being able to change scoped settings if the unscoped value was also changed).  However, that caused a different bug where if the scoped default was different than the unscoped default, it was impossible to change the scoped value to the unscoped default.  This PR aims to fix both issues.  First, we search for the scoped default (without looking at the `config.cson`).  Then we check the unscoped default.  If the unscoped and scoped defaults are the same, we then further look at the `config.cson` to determine the currently-set unscoped value, which effectively acts as the scoped default.

### Alternate Designs

None.

### Benefits

Editing scoped settings should work as expected now.

### Possible Drawbacks

Hopefully none.

### Applicable Issues

Fixes #939
Refs #774