### PR TITLE
Wipe failed status from status bar when an update is retried

### DIFF
--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -89,6 +89,13 @@ export default class PackageUpdatesStatusView {
       }
     }
 
+    for (let index = 0; index < this.failedUpdates.length; index++) {
+      const update = this.failedUpdates[index]
+      if (update.name === pack.name) {
+        this.failedUpdates.splice(index, 1)
+      }
+    }
+
     this.updateTile()
   }
 

--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -53,10 +53,8 @@ export default class PackageUpdatesStatusView {
   }
 
   onPackageUpdateAvailable (pack) {
-    for (const update of this.updates) {
-      if (update.name === pack.name) {
-        return
-      }
+    if (this.updates.includes(pack)) {
+      return
     }
 
     this.updates.push(pack)
@@ -64,6 +62,14 @@ export default class PackageUpdatesStatusView {
   }
 
   onPackageUpdating (pack) {
+    // Wipe failed status when an update is retried
+    for (let index = 0; index < this.failedUpdates.length; index++) {
+      const update = this.failedUpdates[index]
+      if (update.name === pack.name) {
+        this.failedUpdates.splice(index, 1)
+      }
+    }
+
     this.updatingPackages.push(pack)
     this.updateTile()
   }
@@ -83,21 +89,12 @@ export default class PackageUpdatesStatusView {
       }
     }
 
-    for (let index = 0; index < this.failedUpdates.length; index++) {
-      const update = this.failedUpdates[index]
-      if (update.name === pack.name) {
-        this.failedUpdates.splice(index, 1)
-      }
-    }
-
     this.updateTile()
   }
 
   onPackageUpdateFailed (pack) {
-    for (const update of this.failedUpdates) {
-      if (update.name === pack.name) {
-        return
-      }
+    if (this.failedUpdates.includes(pack)) {
+      return
     }
 
     for (let index = 0; index < this.updatingPackages.length; index++) {

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -70,6 +70,16 @@ describe "PackageUpdatesStatusView", ->
 
   describe "when a package fails to update", ->
     it "updates the tile", ->
+      packageManager.emitPackageEvent('updating', outdatedPackage1)
+      packageManager.emitPackageEvent('update-failed', outdatedPackage1)
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '2 updates (1 failed)'
+
+  describe "when a package that previously failed to update starts updating again", ->
+    it "updates the tile", ->
+      packageManager.emitPackageEvent('updating', outdatedPackage1)
+      packageManager.emitPackageEvent('update-failed', outdatedPackage1)
+      packageManager.emitPackageEvent('updating', outdatedPackage1)
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '1/2 updating'
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)
       expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '2 updates (1 failed)'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Redo of #970 because it wasn't picking up my second commit.  Accidentally found this bug yesterday when an update failed two times.  Instead of removing the failed status when the package successfully updates, instead remove it when the package begins updating.  This fixes an issue where if the same update failed multiple times, `onPackageUpdateFailed` would return early and not remove the failed update from the updating list, resulting in the status bar eternally thinking that the package was still updating.

### Alternate Designs

Change some logic around in `onPackageUpdateFailed` to handle an update failing multiple times, rather than simply removing the failed package from the list when it starts updating again.  This is what I started with, but didn't like it because it made `onPackageUpdateFailed` different from all the other event handlers.

### Benefits

When an update fails multiple times, the status bar should now properly display `1 update (1 failed)` rather than `1/1 updating (1 failed)`.

### Possible Drawbacks

None.

### Applicable Issues

None.