### PR TITLE
Escape backslashes when copying keybindings

### DIFF
--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -150,15 +150,16 @@ export default class KeybindingsPanel {
     copyIcon.onclick = function () {
       let content
       const keymapExtension = path.extname(atom.keymaps.getUserKeymapPath())
+      escapedKeystrokes = keystrokes.replace(/\\/g, '\\\\') // Escape backslashes
       if (keymapExtension === '.cson') {
         content = `\
 '${selector}':
-  '${keystrokes}': '${command}'\
+  '${escapedKeystrokes}': '${command}'\
 `
       } else {
         content = `\
 "${selector}": {
-  "${keystrokes}": "${command}"
+  "${escapedKeystrokes}": "${command}"
 }\
 `
       }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Escape backslashes before copying a keybinding to the keyboard.

### Alternate Designs

None.

### Benefits

Backslashes will be escaped properly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #363