### PR TITLE
Wait for snippets to load before checking snippets

### DIFF
--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -37,25 +37,29 @@ describe "InstalledPackageView", ->
 
   it "displays the snippets registered by the package", ->
     snippetsTable = null
+    snippetsModule = null
 
     waitsForPromise ->
       atom.packages.activatePackage('snippets').then (p) ->
-        return unless p.mainModule.provideSnippets().getUnparsedSnippets?
+        snippetsModule = p.mainModule
+        return unless snippetsModule.provideSnippets().getUnparsedSnippets?
 
         SnippetsProvider =
-          getSnippets: -> p.mainModule.provideSnippets().getUnparsedSnippets()
+          getSnippets: -> snippetsModule.provideSnippets().getUnparsedSnippets()
 
     waitsForPromise ->
       atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+    waitsFor 'snippets to load', (done) ->
+      snippetsModule.onDidLoadSnippets(done)
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')
       view = new PackageDetailView(pack, new SettingsView(), new PackageManager(), SnippetsProvider)
       snippetsTable = view.element.querySelector('.package-snippets-table tbody')
 
-    waitsFor ->
+    waitsFor 'snippets table children to contain 2 items', ->
       snippetsTable.children.length >= 2
-    , 'Snippets table children to contain 2 items', 5000
 
     runs ->
       expect(snippetsTable.querySelector('tr:nth-child(1) td:nth-child(1)').textContent).toBe 'b'


### PR DESCRIPTION
Wait for all the snippets to load before asserting that snippets show up in the Settings View.  The callback I'm using is already in use in `package-snippets-view.js`.

Before: 50 pass/50 fail
After: 100 pass

Fixes #973