### PR TITLE
Fix update button order

### DIFF
--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -71,13 +71,13 @@ export default class UpdatesPanel {
               <h1 className='section-heading icon icon-cloud-download'>Available Updates</h1>
               <div className='section-heading updates-btn-group'>
                 <button
-                  ref='updateAllButton'
-                  className='pull-right update-all-button btn btn-primary'
-                  onclick={() => { this.updateAll() }}>Update All</button>
-                <button
                   ref='checkButton'
-                  className='pull-right update-all-button btn btn'
+                  className='update-all-button btn'
                   onclick={() => { this.checkForUpdates(true) }}>Check for Updates</button>
+                <button
+                  ref='updateAllButton'
+                  className='update-all-button btn btn-primary'
+                  onclick={() => { this.updateAll() }}>Update All</button>
               </div>
             </div>
 


### PR DESCRIPTION
Somewhere down the line the order of these two buttons in the DOM were switched.  This led to the Check for Updates button receiving the margin-left property and not the Update All button (since the CSS selector was `.update-all-button:last-child`).  Switch them back around and remove some unneeded classes like `.pull-right` (the two are on the right to begin with) and an extra `.btn`.

| Before | After |
| ------- | ------ |
| ![update-button-margin-before](https://user-images.githubusercontent.com/2766036/29009468-907fbe68-7af1-11e7-8e26-325b3820f723.png) | ![update-button-margin-after](https://user-images.githubusercontent.com/2766036/29009457-7c731f0a-7af1-11e7-82c6-76c4b17a95d5.png) |

Sidenote: the `.update-all-button` class is very wrong on the "Check for Updates" button, but too late to change that one I guess :/.