### PR TITLE
Updating disabled package doesn't show restart notification

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -207,14 +207,16 @@ export default class PackageCard {
     const updateButtonClickHandler = (event) => {
       event.stopPropagation()
       this.update().then(() => {
-        const buttons = [{
-          text: 'Restart',
-          onDidClick () { return atom.restartApplication() }
-        }]
+        if (!this.isDisabled()) {
+          const buttons = [{
+            text: 'Restart',
+            onDidClick () { return atom.restartApplication() }
+          }]
 
-        atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
-          dismissable: true, buttons
-        })
+          atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
+            dismissable: true, buttons
+          })
+        }
       })
     }
     this.refs.updateButton.addEventListener('click', updateButtonClickHandler)

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -285,6 +285,33 @@ describe "PackageCard", ->
       runs ->
         expect(atom.packages.isPackageDisabled('package-with-config')).toBe true
 
+    it "doesn't prompt to restart if package is disabled", ->
+      pack = atom.packages.getLoadedPackage('package-with-config')
+      pack.latestVersion = '1.1.0'
+      pack.disable()
+      packageUpdated = false
+
+      packageManager.on 'package-updated', -> packageUpdated = true
+      packageManager.runCommand.andCallFake (args, callback) ->
+        callback(0, '', '')
+        onWillThrowError: ->
+
+      originalLoadPackage = atom.packages.loadPackage
+      spyOn(atom.packages, 'loadPackage').andCallFake ->
+        originalLoadPackage.call(atom.packages, path.join(__dirname, 'fixtures', 'package-with-config'))
+
+      card = new PackageCard(pack, new SettingsView(), packageManager)
+      jasmine.attachToDOM(card.element)
+      expect(card.refs.updateButton).toBeVisible()
+
+      card.refs.updateButton.click()
+
+      waits 0 # Wait for PackageCard.update promise to resolve
+
+      runs ->
+        notifications = atom.notifications.getNotifications()
+        expect(notifications.length).toBe 0
+
     it "is uninstalled when the uninstallButton is clicked", ->
       setPackageStatusSpies {installed: true, disabled: false}
 


### PR DESCRIPTION
### Description of the Change
Checks after a package is updated if it is disabled. If it is disabled, it doesn't prompt to restart Atom. Fixes #957

### Benefits
Users won't be annoyed by being asked to restart for a package they don't use.

### Possible Drawbacks
Enabling the package before Atom has restarted would not include the update without the user knowing.

### Applicable Issues
#957
