### PR TITLE
Do not test for update object equality

### DIFF
--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -53,8 +53,10 @@ export default class PackageUpdatesStatusView {
   }
 
   onPackageUpdateAvailable (pack) {
-    if (this.updates.includes(pack)) {
-      return
+    for (const update of this.updates) {
+      if (update.name === pack.name) {
+        return
+      }
     }
 
     this.updates.push(pack)
@@ -100,8 +102,10 @@ export default class PackageUpdatesStatusView {
   }
 
   onPackageUpdateFailed (pack) {
-    if (this.failedUpdates.includes(pack)) {
-      return
+    for (const update of this.failedUpdates) {
+      if (update.name === pack.name) {
+        return
+      }
     }
 
     for (let index = 0; index < this.updatingPackages.length; index++) {

--- a/spec/package-updates-status-view-spec.coffee
+++ b/spec/package-updates-status-view-spec.coffee
@@ -122,6 +122,11 @@ describe "PackageUpdatesStatusView", ->
       packageManager.emitPackageEvent('update-available', outdatedPackage1)
       expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '2 updates'
 
+      # There are more fields in an actual package object,
+      # so make sure only name is tested and not object equality
+      packageManager.emitPackageEvent('update-available', {name: 'out-dated-1', date: Date.now()})
+      expect(document.querySelector('status-bar .package-updates-status-view').textContent).toBe '2 updates'
+
   describe "when the same update fails multiple times", ->
     it "does not keep updating the tile", ->
       packageManager.emitPackageEvent('update-failed', outdatedPackage1)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Reverts an overzealous change from #971.  This should go out in the next Atom 1.20.0-beta hotfix.

/cc @Ben3eeE, @joefitzgerald.