### PR TITLE
fix keybindings checkbox description

### DIFF
--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -76,7 +76,7 @@ export default class PackageKeymapView {
             <div className='setting-title'>Enable</div>
           </label>
           <div className='setting-description'>
-            {"Disable this if you want to bind your own keystrokes for this package's commands in your keymap."}
+            Disable this if you want to bind your own keystrokes for this package's commands in your keymap.
           </div>
         </div>
         <table className='package-keymap-table table native-key-bindings text' tabIndex='-1'>


### PR DESCRIPTION
fixes the slash in front of the apostrophe in the keybindings checkbox description

![image](https://user-images.githubusercontent.com/97994/29379870-6e9256cc-8289-11e7-8cf8-f7297d0cd23c.png)

reverts https://github.com/atom/settings-view/commit/9cc8f973d0dba91609a7eb3623e154c96259ae87