### PR TITLE
Add correct styling to syntax theme settings button

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -93,7 +93,7 @@
     align-items: stretch;
   }
 
-  .btn.active-theme-settings {
+  .themes-picker-item .btn {
     margin-left: 2px;
     &::before {
       margin-right: 0;


### PR DESCRIPTION
I changed the selector to `.themes-picker-item .btn` so that it won't break if another button is added.

Fixes atom/atom#15563

@simurai