### PR TITLE
Relative image URLs in package READMEs are now resolved correctly

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -372,16 +372,22 @@ export default class PackageDetailView {
       readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
     }
 
-    let readmeSrcBase
+    let readmeSrc
 
     if (this.pack.path) {
-      readmeSrcBase = this.pack.path
+      // If package is installed, use installed path
+      readmeSrc = this.pack.path
     } else {
+      // If package isn't installed, use url path
       let repoUrl = this.packageManager.getRepositoryUrl(this.pack)
-      readmeSrcBase = repoUrl + '/blob/master/'
+
+      // Check if URL is undefined (i.e. package is unpublished)
+      if (repoUrl) {
+        readmeSrc = repoUrl + `/blob/master/`
+      }
     }
 
-    const readmeView = new PackageReadmeView(readme, readmeSrcBase)
+    const readmeView = new PackageReadmeView(readme, readmeSrc)
     if (this.readmeView) {
       this.readmeView.element.parentElement.replaceChild(readmeView.element, this.readmeView.element)
       this.readmeView.destroy()

--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -372,7 +372,16 @@ export default class PackageDetailView {
       readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
     }
 
-    const readmeView = new PackageReadmeView(readme)
+    let readmeSrcBase
+
+    if (this.pack.path) {
+      readmeSrcBase = this.pack.path
+    } else {
+      let repoUrl = this.packageManager.getRepositoryUrl(this.pack)
+      readmeSrcBase = repoUrl + '/blob/master/'
+    }
+
+    const readmeView = new PackageReadmeView(readme, readmeSrcBase)
     if (this.readmeView) {
       this.readmeView.element.parentElement.replaceChild(readmeView.element, this.readmeView.element)
       this.readmeView.destroy()

--- a/lib/package-readme-view.js
+++ b/lib/package-readme-view.js
@@ -27,7 +27,7 @@ const ATTRIBUTES_TO_REMOVE = [
   'onunload'
 ]
 
-function sanitize (html) {
+function sanitize (html, readmeSrcBase) {
   const temporaryContainer = document.createElement('div')
   temporaryContainer.innerHTML = html
 
@@ -45,13 +45,42 @@ function sanitize (html) {
     checkbox.setAttribute('disabled', true)
   }
 
+  let path = require('path')
+  let urlProtocolRegex = new RegExp("^(?:[a-z]+:)?\/\/", "i")
+
+  for (const image of temporaryContainer.querySelectorAll('img')) {
+    let imageSrc = image.getAttribute('src')
+
+    let changeSrc = true
+
+    // If src contains a protocol then it must be absolute
+    if (urlProtocolRegex.test(imageSrc)) {
+      changeSrc = false
+    }
+
+    // If path is absolute on file system it must be a local file, e.g. emoji
+    if (path.isAbsolute(imageSrc)) {
+      changeSrc = false
+    }
+
+    if (changeSrc) {
+      if (path.isAbsolute(readmeSrcBase)) {
+        // If repoUrl is a local path
+        image.setAttribute('src', path.join(readmeSrcBase, imageSrc))
+      } else {
+        // If repoUrl is a URL
+        image.setAttribute('src', new URL(imageSrc, readmeSrcBase))
+      }
+    }
+  }
+
   return temporaryContainer.innerHTML
 }
 
 // Displays the readme for a package, if it has one
 // TODO Decide to keep this or current button-to-new-tab view
 export default class PackageReadmeView {
-  constructor (readme) {
+  constructor (readme, readmeSrcBase) {
     this.element = document.createElement('section')
     this.element.classList.add('section')
 
@@ -73,7 +102,7 @@ export default class PackageReadmeView {
       if (err) {
         this.packageReadme.innerHTML = '<h3>Error parsing README</h3>'
       } else {
-        this.packageReadme.innerHTML = sanitize(content)
+        this.packageReadme.innerHTML = sanitize(content, readmeSrcBase)
       }
     })
   }

--- a/lib/package-readme-view.js
+++ b/lib/package-readme-view.js
@@ -27,7 +27,7 @@ const ATTRIBUTES_TO_REMOVE = [
   'onunload'
 ]
 
-function sanitize (html, readmeSrcBase) {
+function sanitize (html, readmeSrc) {
   const temporaryContainer = document.createElement('div')
   temporaryContainer.innerHTML = html
 
@@ -46,30 +46,30 @@ function sanitize (html, readmeSrcBase) {
   }
 
   let path = require('path')
-  let urlProtocolRegex = new RegExp("^(?:[a-z]+:)?\/\/", "i")
 
   for (const image of temporaryContainer.querySelectorAll('img')) {
     let imageSrc = image.getAttribute('src')
 
-    let changeSrc = true
+    let changeImageSrc = true
 
     // If src contains a protocol then it must be absolute
-    if (urlProtocolRegex.test(imageSrc)) {
-      changeSrc = false
+    if (/^(?:[a-z]+:)?\/\//i.test(imageSrc)) {
+      changeImageSrc = false
     }
 
     // If path is absolute on file system it must be a local file, e.g. emoji
     if (path.isAbsolute(imageSrc)) {
-      changeSrc = false
+      changeImageSrc = false
     }
 
-    if (changeSrc) {
-      if (path.isAbsolute(readmeSrcBase)) {
-        // If repoUrl is a local path
-        image.setAttribute('src', path.join(readmeSrcBase, imageSrc))
+    // If imageSrc needs changing and readmeSrc isn't undefined (i.e. if package was unpublished)
+    if (changeImageSrc && readmeSrc) {
+      if (path.isAbsolute(readmeSrc)) {
+        // If repoUrl is a local path (i.e. package is installed)
+        image.setAttribute('src', path.join(readmeSrc, imageSrc))
       } else {
-        // If repoUrl is a URL
-        image.setAttribute('src', new URL(imageSrc, readmeSrcBase))
+        // If repoUrl is a URL (i.e. package isn't installed)
+        image.setAttribute('src', new URL(imageSrc, readmeSrc))
       }
     }
   }
@@ -80,7 +80,7 @@ function sanitize (html, readmeSrcBase) {
 // Displays the readme for a package, if it has one
 // TODO Decide to keep this or current button-to-new-tab view
 export default class PackageReadmeView {
-  constructor (readme, readmeSrcBase) {
+  constructor (readme, readmeSrc) {
     this.element = document.createElement('section')
     this.element.classList.add('section')
 
@@ -102,7 +102,7 @@ export default class PackageReadmeView {
       if (err) {
         this.packageReadme.innerHTML = '<h3>Error parsing README</h3>'
       } else {
-        this.packageReadme.innerHTML = sanitize(content, readmeSrcBase)
+        this.packageReadme.innerHTML = sanitize(content, readmeSrc)
       }
     })
   }

--- a/spec/fixtures/package-with-readme/README.md
+++ b/spec/fixtures/package-with-readme/README.md
@@ -2,3 +2,6 @@ I am a Readme!
 
 *   [ ] I'm a not completed task
 *   [x] I'm completed
+
+![AbsoluteImage](https://example.com/static/image.jpg)
+![RelativeImage](static/image.jpg)

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -87,9 +87,12 @@ describe "PackageDetailView", ->
     expect(view.element.querySelectorAll('.package-readme').length).toBe(1)
 
   it "renders the README successfully with sanitized html", ->
+    console.log('-- README SANITIZE --')
     loadPackageFromRemote()
     expect(view.element.querySelectorAll('.package-readme script').length).toBe(0)
     expect(view.element.querySelectorAll('.package-readme input[type="checkbox"][disabled]').length).toBe(2)
+    expect(view.element.querySelector('img[alt="AbsoluteImage"]').getAttribute('src')).toBe('https://example.com/static/image.jpg')
+    expect(view.element.querySelector('img[alt="RelativeImage"]').getAttribute('src')).toBe('https://github.com/example/package-with-readme/blob/master/static/image.jpg')
 
   it "renders the README when the package path is undefined", ->
     atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-readme'))

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -87,7 +87,6 @@ describe "PackageDetailView", ->
     expect(view.element.querySelectorAll('.package-readme').length).toBe(1)
 
   it "renders the README successfully with sanitized html", ->
-    console.log('-- README SANITIZE --')
     loadPackageFromRemote()
     expect(view.element.querySelectorAll('.package-readme script').length).toBe(0)
     expect(view.element.querySelectorAll('.package-readme input[type="checkbox"][disabled]').length).toBe(2)


### PR DESCRIPTION
### Description of the Change

When rendering package READMEs, whilst sanitizing the source image, URLs are now checked to see if they are absolute or relative and if they are relative then they are resolved appropriately. For example for non-installed plugins the base URL would be the GitHub repo however if they are installed it uses the path of the installed plugin.

**Before**:
![relative url before](https://user-images.githubusercontent.com/3003251/30452631-4c299318-998e-11e7-91de-f450c92a8548.png)

**After**:
![relative url after](https://user-images.githubusercontent.com/3003251/30452636-505f0e7c-998e-11e7-9f55-33f6cf10dca5.png)

### Alternate Designs

I considered attempting to match up each image in the Markdown with its counterpart on its Atom.io page or its README on GitHub and using those URLs. I chose this solution in the end as it was much simpler and in the cases I've tested still seems to work.

### Benefits

Packages using relative URLs for images in their README files as recommended by GitHub will now be rendered correctly

### Possible Drawbacks

Any URL scheme not recognized by the code I have written will be assumed to be a relative path so the image URL may be altered incorrectly.

### Applicable Issues

The applicable issue would be [here](https://github.com/atom/settings-view/issues/987)