### PR TITLE
Add pane for URI protocol registration settings

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -341,6 +341,7 @@ function elementForSetting (namespace, name, value) {
     if (name === 'themes') { return document.createDocumentFragment() } // Handled in the Themes panel
     if (name === 'disabledPackages') { return document.createDocumentFragment() } // Handled in the Packages panel
     if (name === 'customFileTypes') { return document.createDocumentFragment() }
+    if (name === 'uriHandlerRegistration') { return document.createDocumentFragment() } // Handled in the URI Handler panel
   }
 
   if (namespace === 'editor') {

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -14,6 +14,7 @@ import InstallPanel from './install-panel'
 import ThemesPanel from './themes-panel'
 import InstalledPackagesPanel from './installed-packages-panel'
 import UpdatesPanel from './updates-panel'
+import UriHandlerPanel from './uri-handler-panel'
 import PackageManager from './package-manager'
 
 export default class SettingsView {
@@ -110,6 +111,7 @@ export default class SettingsView {
 
     this.addCorePanel('Core', 'settings', () => new GeneralPanel())
     this.addCorePanel('Editor', 'code', () => new EditorPanel())
+    this.addCorePanel('URI Handling', 'link', () => new UriHandlerPanel())
     if ((process.platform === 'win32') && (require('atom').WinShell != null)) {
       const SystemPanel = require('./system-windows-panel')
       this.addCorePanel('System', 'device-desktop', () => new SystemPanel())

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -111,7 +111,10 @@ export default class SettingsView {
 
     this.addCorePanel('Core', 'settings', () => new GeneralPanel())
     this.addCorePanel('Editor', 'code', () => new EditorPanel())
-    this.addCorePanel('URI Handling', 'link', () => new UriHandlerPanel())
+    if (atom.config.getSchema('core.uriHandlerRegistration').type !== 'any') {
+      // "feature flag" based on core support for URI handling
+      this.addCorePanel('URI Handling', 'link', () => new UriHandlerPanel())
+    }
     if ((process.platform === 'win32') && (require('atom').WinShell != null)) {
       const SystemPanel = require('./system-windows-panel')
       this.addCorePanel('System', 'device-desktop', () => new SystemPanel())

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -105,7 +105,7 @@ export default class UriHandlerPanel {
     if (this.isDefaultProtocolClient) {
       return 'Atom is already the default handler for atom:// URIs.'
     } else if (isSupported()) {
-      return 'Become the default handler for atom:// URIs.'
+      return 'Register Atom as the default handler for atom:// URIs.'
     } else {
       return 'Registration as the default handler for atom:// URIs is only supported on Windows and macOS.'
     }

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -1,0 +1,159 @@
+/** @babel */
+/** @jsx etch.dom */
+
+import {CompositeDisposable} from 'atom'
+import etch from 'etch'
+
+function isSupported () {
+  return ['win32', 'darwin'].includes(process.platform)
+}
+
+function isDefaultProtocolClient () {
+  return require('electron').remote.app.isDefaultProtocolClient('atom', process.execPath, ['--url-handler'])
+}
+
+function setAsDefaultProtocolClient () {
+  // This Electron API is only available on Windows and macOS. There might be some
+  // hacks to make it work on Linux; see https://github.com/electron/electron/issues/6440
+  return isSupported() && require('electron').remote.app.setAsDefaultProtocolClient('atom', process.execPath, ['--url-handler'])
+}
+
+export default class UriHandlerPanel {
+  constructor () {
+    this.handleChange = this.handleChange.bind(this)
+    this.handleBecomeProtocolClient = this.handleBecomeProtocolClient.bind(this)
+    this.isDefaultProtocolClient = isDefaultProtocolClient()
+    etch.initialize(this)
+
+    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(atom.commands.add(this.element, {
+      'core:move-up': () => { this.scrollUp() },
+      'core:move-down': () => { this.scrollDown() },
+      'core:page-up': () => { this.pageUp() },
+      'core:page-down': () => { this.pageDown() },
+      'core:move-to-top': () => { this.scrollToTop() },
+      'core:move-to-bottom': () => { this.scrollToBottom() }
+    }))
+  }
+
+  destroy () {
+    this.subscriptions.dispose()
+    return etch.destroy(this)
+  }
+
+  update () {}
+
+  render () {
+    const schema = atom.config.getSchema('core.uriHandlerRegistration')
+
+    return (
+      <div className='panels-item' tabIndex='0'>
+        <form className='general-panel section'>
+          <div className='settings-panel'>
+            <div className='section-container'>
+              <div className='block section-heading icon icon-device-desktop'>URI Handling</div>
+              <div className='text icon icon-question'>These settings determine how Atom handles atom:// URIs.</div>
+              <div className='section-body'>
+                <div className='control-group'>
+                  <div className='controls'>
+                    <label className='control-label'>
+                      <div className='setting-title'>URI Handler Registration</div>
+                      <div className='setting-description'>
+                        {this.renderRegistrationDescription()}
+                      </div>
+                    </label>
+                    <button
+                      className='btn btn-primary'
+                      disabled={!isSupported() || this.isDefaultProtocolClient}
+                      style={{fontSize: '1.25em', display: 'block'}}
+                      onClick={this.handleBecomeProtocolClient}
+                    >
+                      Register as atom:// protocol handler
+                    </button>
+                  </div>
+                </div>
+
+                <div className='control-group'>
+                  <div className='controls'>
+                    <label className='control-label'>
+                      <div className='setting-title'>Default Registration</div>
+                      <div className='setting-description'>
+                        {schema.description}
+                      </div>
+                    </label>
+                    <select
+                      id='core.uriHandlerRegistration'
+                      className='form-control'
+                      onChange={this.handleChange}
+                      value={atom.config.get('core.uriHandlerRegistration')}
+                    >
+                      {schema.enum.map(({description, value}) => (
+                        <option value={value}>{description}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    )
+  }
+
+  renderRegistrationDescription () {
+    if (this.isDefaultProtocolClient) {
+      return 'Atom is already the default handler for atom:// URIs.'
+    } else if (isSupported()) {
+      return 'Become the default handler for atom:// URIs.'
+    } else {
+      return 'Registration as the default handler for atom:// URIs is only supported on Windows and macOS.'
+    }
+  }
+
+  handleChange (evt) {
+    atom.config.set('core.uriHandlerRegistration', evt.target.value)
+  }
+
+  handleBecomeProtocolClient (evt) {
+    evt.preventDefault()
+    if (setAsDefaultProtocolClient()) {
+      this.isDefaultProtocolClient = isDefaultProtocolClient()
+      etch.update(this)
+    } else {
+      atom.notifications.addError('Could not become default protocol client')
+    }
+  }
+
+  focus () {
+    this.element.focus()
+  }
+
+  show () {
+    this.element.style.display = ''
+  }
+
+  scrollUp () {
+    this.element.scrollTop -= document.body.offsetHeight / 20
+  }
+
+  scrollDown () {
+    this.element.scrollTop += document.body.offsetHeight / 20
+  }
+
+  pageUp () {
+    this.element.scrollTop -= this.element.offsetHeight
+  }
+
+  pageDown () {
+    this.element.scrollTop += this.element.offsetHeight
+  }
+
+  scrollToTop () {
+    this.element.scrollTop = 0
+  }
+
+  scrollToBottom () {
+    this.element.scrollTop = this.element.scrollHeight
+  }
+}

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -23,17 +23,24 @@ export default class UriHandlerPanel {
     this.handleChange = this.handleChange.bind(this)
     this.handleBecomeProtocolClient = this.handleBecomeProtocolClient.bind(this)
     this.isDefaultProtocolClient = isDefaultProtocolClient()
+    this.urlHistory = []
     etch.initialize(this)
 
     this.subscriptions = new CompositeDisposable()
-    this.subscriptions.add(atom.commands.add(this.element, {
-      'core:move-up': () => { this.scrollUp() },
-      'core:move-down': () => { this.scrollDown() },
-      'core:page-up': () => { this.pageUp() },
-      'core:page-down': () => { this.pageDown() },
-      'core:move-to-top': () => { this.scrollToTop() },
-      'core:move-to-bottom': () => { this.scrollToBottom() }
-    }))
+    this.subscriptions.add(
+      atom.commands.add(this.element, {
+        'core:move-up': () => { this.scrollUp() },
+        'core:move-down': () => { this.scrollDown() },
+        'core:page-up': () => { this.pageUp() },
+        'core:page-down': () => { this.pageDown() },
+        'core:move-to-top': () => { this.scrollToTop() },
+        'core:move-to-bottom': () => { this.scrollToBottom() }
+      }),
+      atom.urlHandlerRegistry.onHistoryChange(() => {
+        this.urlHistory = atom.urlHandlerRegistry.getRecentlyHandledUrls()
+        etch.update(this)
+      })
+    )
   }
 
   destroy () {
@@ -93,12 +100,45 @@ export default class UriHandlerPanel {
                     </select>
                   </div>
                 </div>
+
+                <div className='control-group'>
+                  <div className='controls'>
+                    <label className='controls-label'>
+                      <div className='setting-title'>Recently Handled URIs</div>
+                    </label>
+                    <table className='uri-history'>
+                      <tr><th>URI</th><th>Package</th></tr>
+                      {this.urlHistory.map(this.renderHistoryRow.bind(this))}
+                    </table>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </form>
       </div>
     )
+  }
+
+  renderHistoryRow (item, idx) {
+    return (
+      <tr
+        key={item.id}
+        className=''
+      >
+        <td>{item.url}</td>
+        <td>
+          {item.handled
+            ? <a href={`atom://config/packages/${item.host}`} onClick={this.handlePackageLinkClicked}>{item.host}</a>
+            : '<em>not handled</em>'
+          }</td>
+      </tr>
+    )
+  }
+
+  handlePackageLinkClicked (evt) {
+    evt.preventDefault()
+    atom.workspace.open(evt.target.getAttribute('href'))
   }
 
   renderRegistrationDescription () {

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -9,13 +9,13 @@ function isSupported () {
 }
 
 function isDefaultProtocolClient () {
-  return require('electron').remote.app.isDefaultProtocolClient('atom', process.execPath, ['--url-handler'])
+  return require('electron').remote.app.isDefaultProtocolClient('atom', process.execPath, ['--uri-handler'])
 }
 
 function setAsDefaultProtocolClient () {
   // This Electron API is only available on Windows and macOS. There might be some
   // hacks to make it work on Linux; see https://github.com/electron/electron/issues/6440
-  return isSupported() && require('electron').remote.app.setAsDefaultProtocolClient('atom', process.execPath, ['--url-handler'])
+  return isSupported() && require('electron').remote.app.setAsDefaultProtocolClient('atom', process.execPath, ['--uri-handler'])
 }
 
 export default class UriHandlerPanel {
@@ -23,7 +23,7 @@ export default class UriHandlerPanel {
     this.handleChange = this.handleChange.bind(this)
     this.handleBecomeProtocolClient = this.handleBecomeProtocolClient.bind(this)
     this.isDefaultProtocolClient = isDefaultProtocolClient()
-    this.urlHistory = []
+    this.uriHistory = []
     etch.initialize(this)
 
     this.subscriptions = new CompositeDisposable()
@@ -36,8 +36,8 @@ export default class UriHandlerPanel {
         'core:move-to-top': () => { this.scrollToTop() },
         'core:move-to-bottom': () => { this.scrollToBottom() }
       }),
-      atom.urlHandlerRegistry.onHistoryChange(() => {
-        this.urlHistory = atom.urlHandlerRegistry.getRecentlyHandledUrls()
+      atom.uriHandlerRegistry.onHistoryChange(() => {
+        this.uriHistory = atom.uriHandlerRegistry.getRecentlyHandledURIs()
         etch.update(this)
       })
     )
@@ -75,7 +75,7 @@ export default class UriHandlerPanel {
                       style={{fontSize: '1.25em', display: 'block'}}
                       onClick={this.handleBecomeProtocolClient}
                     >
-                      Register as atom:// protocol handler
+                      Register as default atom:// protocol handler
                     </button>
                   </div>
                 </div>
@@ -108,7 +108,7 @@ export default class UriHandlerPanel {
                     </label>
                     <table className='uri-history'>
                       <tr><th>URI</th><th>Package</th></tr>
-                      {this.urlHistory.map(this.renderHistoryRow.bind(this))}
+                      {this.uriHistory.map(this.renderHistoryRow.bind(this))}
                     </table>
                   </div>
                 </div>
@@ -126,7 +126,7 @@ export default class UriHandlerPanel {
         key={item.id}
         className=''
       >
-        <td>{item.url}</td>
+        <td>{item.uri}</td>
         <td>
           {item.handled
             ? <a href={`atom://config/packages/${item.host}`} onClick={this.handlePackageLinkClicked}>{item.host}</a>

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -104,7 +104,7 @@ export default class UriHandlerPanel {
                 <div className='control-group'>
                   <div className='controls'>
                     <label className='controls-label'>
-                      <div className='setting-title'>Recently Handled URIs</div>
+                      <div className='setting-title'>Recent URIs</div>
                     </label>
                     <table className='uri-history'>
                       <tr><th>URI</th><th>Package</th></tr>
@@ -130,7 +130,7 @@ export default class UriHandlerPanel {
         <td>
           {item.handled
             ? <a href={`atom://config/packages/${item.host}`} onClick={this.handlePackageLinkClicked}>{item.host}</a>
-            : '<em>not handled</em>'
+            : <em>not handled</em>
           }</td>
       </tr>
     )

--- a/lib/uri-handler-panel.js
+++ b/lib/uri-handler-panel.js
@@ -107,7 +107,10 @@ export default class UriHandlerPanel {
                       <div className='setting-title'>Recent URIs</div>
                     </label>
                     <table className='uri-history'>
-                      <tr><th>URI</th><th>Package</th></tr>
+                      <tr>
+                        <th>URI</th>
+                        <th>Handled By</th>
+                      </tr>
                       {this.uriHistory.map(this.renderHistoryRow.bind(this))}
                     </table>
                   </div>
@@ -129,11 +132,19 @@ export default class UriHandlerPanel {
         <td>{item.uri}</td>
         <td>
           {item.handled
-            ? <a href={`atom://config/packages/${item.host}`} onClick={this.handlePackageLinkClicked}>{item.host}</a>
+            ? this.renderItem(item)
             : <em>not handled</em>
           }</td>
       </tr>
     )
+  }
+
+  renderItem (item) {
+    if (item.host === 'core') {
+      return <em>core</em>
+    } else {
+      return <a href={`atom://config/packages/${item.host}`} onClick={this.handlePackageLinkClicked}>{item.host}</a>
+    }
   }
 
   handlePackageLinkClicked (evt) {

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -623,6 +623,10 @@
   .uri-history {
     width: 100%;
 
+    th {
+      white-space: nowrap;
+    }
+
     td, th {
       padding: 0 @component-padding @component-padding/2 0;
     }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -619,6 +619,14 @@
       border-style: solid;
     }
   }
+
+  .uri-history {
+    width: 100%;
+
+    td, th {
+      padding: 0 @component-padding @component-padding/2 0;
+    }
+  }
 }
 
 @media all and (max-width: 800px) {


### PR DESCRIPTION
This adds settings and logs related to URI handler registration, etc. to the settings view. It will include:

* A button to make Atom the default atom:// URI handler if it's not already
* A tri-state setting for what to do when Atom starts and isn't the default protocol handler
  * Always ask
  * Always automatically register
  * Never register
* A list of recent URIs handled and which package handled them (with a button to disable said package)

Depends on https://github.com/atom/atom/pull/11399