### PR TITLE
Disable update notification for disabled packages [WiP]

### DIFF
--- a/lib/package-updates-status-view.js
+++ b/lib/package-updates-status-view.js
@@ -27,6 +27,7 @@ export default class PackageUpdatesStatusView {
     this.disposables.add(packageManager.on('package-updating theme-updating', ({pack, error}) => { this.onPackageUpdating(pack) }))
     this.disposables.add(packageManager.on('package-updated theme-updated package-uninstalled theme-uninstalled', ({pack, error}) => { this.onPackageUpdated(pack) }))
     this.disposables.add(packageManager.on('package-update-failed theme-update-failed', ({pack, error}) => { this.onPackageUpdateFailed(pack) }))
+    this.disposables.add(atom.config.onDidChange('core.disabledPackages', () => { this.updateTile() }))
 
     const clickHandler = () => {
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'settings-view:check-for-package-updates')
@@ -120,6 +121,16 @@ export default class PackageUpdatesStatusView {
   }
 
   updateTile () {
+    const disabledPackages = []
+    if (this.updates.length){
+      for (let index = 0; index < this.updates.length; index++) {
+        const update = this.updates[index]
+        if (atom.packages.isPackageDisabled(update.name)) {
+          disabledPackages.push(update)
+          this.updates.splice(index, 1)
+        }
+      }
+    }
     if (this.updates.length) {
       if (this.tooltip) {
         this.tooltip.dispose()
@@ -151,6 +162,9 @@ export default class PackageUpdatesStatusView {
       this.tile.destroy()
       this.tile = null
       this.destroyed = true
+    }
+    for(index=0; index < disabledPackages.length; index++) {
+      this.updates.push(disabledPackages[index])
     }
   }
 }


### PR DESCRIPTION
### Description of the Change
The purpose of this pull request is to fix the bug where a notification is given that updates are available even though the package is disabled.

This is done by looking at all the packages in the list `updates`in the `package-updates-status-view.js`and then temporarily remove all disabled packages from the list when calculating the number of packages that have available updates. 

A event is also introduced which is triggered by enabling or disabling a package. The purpose of this is so that the user is immediately informed if the package has an available update or it let's Atom know that the user is not interested to know if updates are available for the selected package.

### Alternate Designs
An alternative is the remove all the disabled packages from the list `updates` completely and then add them when the package is enabled. This however would lead to that the packages won't show up in the `available-updates` view.

### Benefits
Now all disabled packages will not trigger the update status message that appears in the lower right corner. The status message will also be updated when enabling or disabling a package.

### Possible Drawbacks

The function `updateTile`becomes a bit more complex and also have some impact on performance depending on how many packages that are in the `updates` list.
### Applicable Issues

Fixes #956