### PR TITLE
Disable automatic check for updates when "Automatically Update" is disable

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -13,7 +13,7 @@ class PackageManager
     @packagePromises = []
     @apmCache =
       loadOutdated:
-        value: null
+        value: []
         expiry: 0
 
     @emitter = new Emitter
@@ -132,6 +132,10 @@ class PackageManager
     # Short circuit if we have cached data.
     else if @apmCache.loadOutdated.value and @apmCache.loadOutdated.expiry > Date.now()
       return callback(null, @apmCache.loadOutdated.value)
+    # Return cached or empty package lists, if automatic updates are disabled,
+    # even if cache has expired, as long as no cache rebuilding is being forced.
+    else if (not atom.config.get('core.automaticallyUpdate'))
+      return callback(null, @apmCache.loadOutdated.value)
 
     args = ['outdated', '--json']
     version = atom.getVersion()
@@ -169,7 +173,7 @@ class PackageManager
 
   clearOutdatedCache: ->
     @apmCache.loadOutdated =
-      value: null
+      value: []
       expiry: 0
 
   loadPackage: (packageName, callback) ->

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -140,7 +140,7 @@ export default class UpdatesPanel {
     try {
       this.availableUpdates = await this.packageManager.getOutdated(clearCache)
       this.refs.checkButton.disabled = false
-      this.addUpdateViews()
+      this.addUpdateViews(clearCache)
     } catch (error) {
       this.refs.checkButton.disabled = false
       this.refs.checkingMessage.style.display = 'none'
@@ -148,14 +148,14 @@ export default class UpdatesPanel {
     }
   }
 
-  addUpdateViews () {
+  addUpdateViews (forcedUpdate) {
     if (this.availableUpdates.length > 0) {
       this.refs.updateAllButton.style.display = ''
       this.refs.updateAllButton.disabled = false
     }
     this.refs.checkingMessage.style.display = 'none'
     this.clearPackageCards()
-    if (this.availableUpdates.length === 0) {
+    if (this.availableUpdates.length === 0 && (forcedUpdate || atom.config.get('core.automaticallyUpdate'))) {
       this.refs.noUpdatesMessage.style.display = ''
     }
 

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -82,6 +82,10 @@ export default class UpdatesPanel {
             </div>
 
             <div ref='versionPinnedPackagesMessage' className='alert alert-warning icon icon-alert'>The following packages are pinned to their current version and are not being checked for updates: <strong>{ this.packageManager.getVersionPinnedPackages().join(', ') }</strong></div>
+            <div ref='automaticallyUpdateDisabledMessage' className='alert alert-warning icon icon-alert'>
+              Automatically checking for updates is disabled. To enable, check the <em>Automatically Update</em> option
+              in <a class='link' onclick={() => { atom.workspace.open('atom://config/core') }}>Core settings</a>.
+            </div>
             <div ref='updateErrors'></div>
             <div ref='checkingMessage' className='alert alert-info icon icon-hourglass'>{`Checking for updates\u2026`}</div>
             <div ref='noUpdatesMessage' className='alert alert-info icon icon-heart'>All of your installed packages are up to date!</div>
@@ -117,6 +121,12 @@ export default class UpdatesPanel {
 
     if (this.packageManager.getVersionPinnedPackages().length === 0) {
       this.refs.versionPinnedPackagesMessage.style.display = 'none'
+    }
+
+    if (atom.config.get('core.automaticallyUpdate')) {
+      this.refs.automaticallyUpdateDisabledMessage.style.display = 'none'
+    } else {
+       this.refs.automaticallyUpdateDisabledMessage.style.display = ''
     }
   }
 


### PR DESCRIPTION
### Description of the Change
This change disables the periodic checking for updates when `core.automaticallyUpdate` is unset. A warning is displayed to the user, that no automatic checks for updates are performed. Additionally the message `"All of your installed packages are up to date!"` is only shown directly after manually triggering the check.

### Alternate Designs
Another approach would have been to express the _no-check-for-updates-yet-perfomed_ state explicitly in the `PackageManager` class and communicated to the UI. As a consequence, the usage of the `PackageManager` would need to be reworked.

I think, the proposed solution is minimally invasive.

### Benefits
Up until now, Atom checks at every startup and in ten minutes intervals the availability for updates for all installed packages. People with limited mobile plans have complained about these automatic checks. (See https://discuss.atom.io/t/open-how-to-prevent-atom-to-update-packages-at-each-reload/45638/5 or the mentioned issues)

Even though atom just checks for possible updates, and does not actually download or install them, people seem to expect that no such network traffic is generated when the option "Automatically Update" is disabled.

### Possible Drawbacks
When the option `core.automaticallyUpdate` is disabled, the message  `"All of your installed packages are up to date!"` is only shown directly after the check is performed, and is not shown the next time the pane is accessed. Ideally this message is displayed for the next ten minutes after a successful check.

### Applicable Issues
* atom/atom#15283
* atom/atom#12524
* atom/atom#11318
* atom/atom#7339
