### PR TITLE
Fix package detail view when behind a proxy

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -13,6 +13,13 @@ class AtomIoClient
     @expiry = 1000 * 60 * 60 * 12
     @createAvatarCache()
     @expireAvatarCache()
+    @packageManager.isStrictSsl()
+      .then (resolve) =>
+        @strictSsl = resolve
+    @packageManager.getHttpsProxy()
+      .then (resolve) =>
+        @httpsProxy = resolve
+
 
   # Public: Get an avatar image from the filesystem, fetching it first if necessary
   avatar: (login, callback) ->
@@ -70,6 +77,10 @@ class AtomIoClient
       url: "#{@baseURL}#{path}"
       headers: {'User-Agent': navigator.userAgent}
     }
+    if @httpsProxy?
+      options.proxy = @httpsProxy
+    if @strictSsl is false
+      options.rejectUnauthorized = false
 
     request options, (err, res, body) =>
       try

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -214,6 +214,45 @@ class PackageManager
 
     handleProcessErrors(apmProcess, errorMessage, callback)
 
+  isStrictSsl: ->
+    new Promise (resolve, reject) =>
+      args = ['config' ,'get', 'strict-ssl']
+      errorMessage = 'Checking strict-ssl configuration failed'
+      apmProcess = @runCommand args, (code, stdout, stderr) ->
+        if code is 0
+          if stdout.trim() is 'false'
+            resolve(false)
+          else
+            resolve(true)
+        else
+          error = new Error(errorMessage)
+          error.stdout = stdout
+          error.stderr = stderr
+          reject(error)
+
+      handleProcessErrors apmProcess, errorMessage, (error) ->
+        reject(error)
+
+  getHttpsProxy: ->
+    new Promise (resolve, reject) =>
+      args = ['config' ,'get', 'https-proxy']
+      errorMessage = 'Checking https-proxy configuration failed'
+      apmProcess = @runCommand args, (code, stdout, stderr) ->
+        if code is 0
+          result = stdout.trim()
+          if result isnt 'null'
+            resolve(result)
+          else
+            resolve(null)
+        else
+          error = new Error(errorMessage)
+          error.stdout = stdout
+          error.stderr = stderr
+          reject(error)
+
+      handleProcessErrors apmProcess, errorMessage, (error) ->
+        reject(error)
+
   getInstalled: ->
     new Promise (resolve, reject) =>
       @loadInstalled (error, result) ->


### PR DESCRIPTION
### Description of the Change

To download packages behind a proxy or a firewall that requires trusting self-signed CA certificates, the user must set apm's configuration parameters `proxy`, `https-proxy` and `strict-ssl`. However, these settings are only applied to requests sent from apm itself. When trying to view package details in this environment, users are presented with an error because these requests are sent using the [Request](https://github.com/request/request) package, thus the three parameters are ignored.

This fixes package detail view from not being able to load when behind a proxy by using the same parameters set at apm config when sending requests.

### Alternate Designs

An alternative is to create atom's own proxy settings and pass them to apm instead of being the other way around.

### Benefits

Users behind a proxy or corporate firewall will be able to view package details.

### Possible Drawbacks
Server certificates are not verified when `strict-ssl` is set to false.

### Applicable Issues

atom/atom#15662
