### PR TITLE
Add URI handler to show package pane

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,7 +26,7 @@ openPanel = (settingsView, panelName, uri) ->
   settingsView.showPanel(panelName, options)
 
 module.exports =
-  handleUrl: (parsed) ->
+  handleUri: (parsed) ->
     switch parsed.pathname
       when "/show-package" then @showPackage(parsed.query.package)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,6 +26,13 @@ openPanel = (settingsView, panelName, uri) ->
   settingsView.showPanel(panelName, options)
 
 module.exports =
+  handleUrl: (parsed) ->
+    switch parsed.pathname
+      when "/show-package" then @showPackage(parsed.query.package)
+
+  showPackage: (packageName) ->
+    atom.workspace.open("atom://config/packages/#{packageName}")
+
   activate: ->
     atom.workspace.addOpener (uri) =>
       if uri.startsWith(configUri)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "main": "./lib/main",
   "description": "Edit config settings, install packages, and change themes",
   "license": "MIT",
+  "urlHandler": {
+    "method": "handleUrl",
+    "deferActivation": false
+  },
   "dependencies": {
     "async": "~0.2.9",
     "dompurify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "./lib/main",
   "description": "Edit config settings, install packages, and change themes",
   "license": "MIT",
-  "urlHandler": {
-    "method": "handleUrl",
+  "uriHandler": {
+    "method": "handleUri",
     "deferActivation": false
   },
   "dependencies": {


### PR DESCRIPTION
Adds a URI handler for `atom://settings-view/show-package?package=package_name` that will open the package's page in Atom.

Depends on https://github.com/atom/atom/pull/11399