### PR TITLE
feat(update-panel): add summary to notification

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -211,9 +211,10 @@ export default class PackageCard {
           text: 'Restart',
           onDidClick () { return atom.restartApplication() }
         }]
+        const detail = `${this.pack.version} -> ${this.pack.latestVersion}`
 
         atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
-          dismissable: true, buttons
+          dismissable: true, buttons, detail
         })
       })
     }

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -173,10 +173,10 @@ export default class UpdatesPanel {
           }
           const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralizedPackages}:`
           let detail = ''
-          this.packageCards.forEach((card, index, array) => {
-            detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}`
-            index === array.length - 1 ? null : detail += `\n`
+          this.packageCards.forEach((card) => {
+            detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}\n`
           });
+          detail.trim()
 
           const buttons = [{
             text: 'Restart',

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -171,13 +171,18 @@ export default class UpdatesPanel {
           if (successfulUpdatesCount > 1) {
             pluralizedPackages += 's'
           }
-          const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralizedPackages}.`
+          const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralizedPackages}:`
+          let detail = ''
+          this.packageCards.forEach((card, index, array) => {
+            detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}`
+            index === array.length - 1 ? null : detail += `\n`
+          });
 
           const buttons = [{
             text: 'Restart',
             onDidClick() { return atom.restartApplication() }
           }]
-          atom.notifications.addSuccess(message, {dismissable: true, buttons})
+          atom.notifications.addSuccess(message, {dismissable: true, buttons, detail})
         }
 
         if (successfulUpdatesCount === totalUpdatesCount) {


### PR DESCRIPTION
### Description of the Change

Add a summary of updated packages to the restart notification.
The summary contains package name, last version and new version:

![atom_settings-view_notify-summary](https://user-images.githubusercontent.com/19377375/32137782-c20de4fc-bc26-11e7-91a6-1b57960f02fa.png "Update All Notification")

![atom_settings-view_notify-summary_single_package](https://user-images.githubusercontent.com/19377375/32373094-d580e73a-c097-11e7-8083-00d55a46d5d8.png "Single Update Notification")

### Alternate Designs

Maybe some kind of scroll list is needed for large ammounts of updates,
since the restart button might disappear at the bottom.

### Benefits

A more compact summary compared to the possibly large large list of package cards.
The option to see pre and post update version when the update process is finished (package cards do not show the past version post update) .
