### PR TITLE
Speed up search by not invoking apm

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -69,17 +69,16 @@ class AtomIoClient
     options = {
       url: "#{@baseURL}#{path}"
       headers: {'User-Agent': navigator.userAgent}
+      json: true
+      gzip: true
     }
 
     request options, (err, res, body) =>
-      try
-        data = JSON.parse(body)
-      catch error
-        return callback(error)
+      return callback(err) if err
 
-      delete data.versions
+      delete body.versions
       cached =
-        data: data
+        data: body
         createdOn: Date.now()
       localStorage.setItem(@cacheKeyForPath(path), JSON.stringify(cached))
       callback(err, cached.data)

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -196,9 +196,6 @@ class AtomIoClient
     else if options.packages
       qs.filter = 'package'
 
-    if options.sort
-      qs.sort = options.sort
-
     options = {
       url: "#{@baseURL}packages/search"
       headers: {'User-Agent': navigator.userAgent}
@@ -217,4 +214,5 @@ class AtomIoClient
             body.filter (pkg) -> pkg.releases?.latest?
                 .map ({readme, metadata, downloads, stargazers_count}) ->
                   Object.assign metadata, {readme, downloads, stargazers_count}
+                .sort (a, b) -> b.downloads - a.downloads
           )

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -213,7 +213,8 @@ class AtomIoClient
           error.stderr = err.message
           reject error
         else
-          body = body.filter (pkg) -> pkg.releases?.latest?
-                     .map ({readme, metadata, downloads, stargazers_count}) ->
-                       Object.assign metadata, {readme, downloads, stargazers_count}
-          resolve body
+          resolve(
+            body.filter (pkg) -> pkg.releases?.latest?
+                .map ({readme, metadata, downloads, stargazers_count}) ->
+                  Object.assign metadata, {readme, downloads, stargazers_count}
+          )

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -201,6 +201,7 @@ class AtomIoClient
       headers: {'User-Agent': navigator.userAgent}
       qs: qs
       json: true
+      gzip: true
     }
 
     new Promise (resolve, reject) ->

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -206,12 +206,8 @@ export default class InstallPanel {
     this.refs.searchMessage.textContent = `Searching ${this.searchType} for \u201C${query}\u201D\u2026`
     this.refs.searchMessage.style.display = ''
 
-    const opts = {}
-    opts[this.searchType] = true
-    opts['sortBy'] = 'downloads'
-
     try {
-      let packages = (await this.packageManager.search(query, opts)) || []
+      const packages = (await this.client.search(query, this.searchType)) || []
       this.refs.resultsContainer.innerHTML = ''
       this.refs.searchMessage.style.display = 'none'
       if (packages.length === 0) {

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -231,7 +231,7 @@ export default class InstallPanel {
   }
 
   highlightExactMatch (container, query, packages) {
-    const exactMatch = packages.filter(pkg => pkg.name === query)[0]
+    const exactMatch = packages.filter(pkg => pkg.name.toLowerCase() === query)[0]
 
     if (exactMatch) {
       this.addPackageCardView(container, this.getPackageCardView(exactMatch))
@@ -240,7 +240,7 @@ export default class InstallPanel {
   }
 
   addCloseMatches (container, query, packages) {
-    const matches = packages.filter(pkg => pkg.name.indexOf(query) >= 0)
+    const matches = packages.filter(pkg => pkg.name.toLowerCase().indexOf(query) >= 0)
 
     for (let pack of matches) {
       this.addPackageCardView(container, this.getPackageCardView(pack))

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -206,7 +206,7 @@ export default class InstallPanel {
     this.refs.searchMessage.textContent = `Searching ${this.searchType} for \u201C${query}\u201D\u2026`
     this.refs.searchMessage.style.display = ''
 
-    const options = {sort: {downloads: 'desc'}}
+    const options = {}
     options[this.searchType] = true
 
     try {

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -3,7 +3,6 @@
 
 import path from 'path'
 import electron from 'electron'
-import _ from 'underscore-plus'
 import {CompositeDisposable, TextEditor} from 'atom'
 import etch from 'etch'
 
@@ -233,7 +232,7 @@ export default class InstallPanel {
   }
 
   highlightExactMatch (container, query, packages) {
-    const exactMatch = _.filter(packages, pkg => pkg.name === query)[0]
+    const exactMatch = packages.filter(pkg => pkg.name === query)[0]
 
     if (exactMatch) {
       this.addPackageCardView(container, this.getPackageCardView(exactMatch))
@@ -242,7 +241,7 @@ export default class InstallPanel {
   }
 
   addCloseMatches (container, query, packages) {
-    const matches = _.filter(packages, pkg => pkg.name.indexOf(query) >= 0)
+    const matches = packages.filter(pkg => pkg.name.indexOf(query) >= 0)
 
     for (let pack of matches) {
       this.addPackageCardView(container, this.getPackageCardView(pack))

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -206,8 +206,11 @@ export default class InstallPanel {
     this.refs.searchMessage.textContent = `Searching ${this.searchType} for \u201C${query}\u201D\u2026`
     this.refs.searchMessage.style.display = ''
 
+    const options = {sort: {downloads: 'desc'}}
+    options[this.searchType] = true
+
     try {
-      const packages = (await this.client.search(query, this.searchType)) || []
+      const packages = (await this.client.search(query, options)) || []
       this.refs.resultsContainer.innerHTML = ''
       this.refs.searchMessage.style.display = 'none'
       if (packages.length === 0) {

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -255,36 +255,6 @@ class PackageManager
     [version] = version.split('-') if typeof version is 'string'
     version
 
-  search: (query, options = {}) ->
-    new Promise (resolve, reject) =>
-      args = ['search', query, '--json']
-      if options.themes
-        args.push '--themes'
-      else if options.packages
-        args.push '--packages'
-      errorMessage = "Searching for \u201C#{query}\u201D failed."
-
-      apmProcess = @runCommand args, (code, stdout, stderr) ->
-        if code is 0
-          try
-            packages = JSON.parse(stdout) ? []
-            if options.sortBy
-              packages = _.sortBy packages, (pkg) ->
-                return pkg[options.sortBy]*-1
-
-            resolve(packages)
-          catch parseError
-            error = createJsonParseError(errorMessage, parseError, stdout)
-            reject(error)
-        else
-          error = new Error(errorMessage)
-          error.stdout = stdout
-          error.stderr = stderr
-          reject(error)
-
-      handleProcessErrors apmProcess, errorMessage, (error) ->
-        reject(error)
-
   update: (pack, newVersion, callback) ->
     {name, theme, apmInstallSource} = pack
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "glob": "4.3.1",
     "hosted-git-info": "^2.1.4",
     "marked": "^0.3.6",
-    "request": "^2.40",
+    "request": "^2.83.0",
     "roaster": "^1.1.2",
     "season": "^6.0.2",
     "semver": "^5.3.0",

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -60,7 +60,7 @@ describe 'InstallPanel', ->
 
   describe "searching packages", ->
     it "highlights exact name matches", ->
-      spyOn(@packageManager, 'search').andCallFake ->
+      spyOn(@panel.client, 'search').andCallFake ->
         new Promise (resolve, reject) -> resolve([ {name: 'not-first'}, {name: 'first'} ])
       spyOn(@panel, 'getPackageCardView').andCallThrough()
 
@@ -72,7 +72,7 @@ describe 'InstallPanel', ->
         expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'not-first'
 
     it "prioritizes partial name matches", ->
-      spyOn(@packageManager, 'search').andCallFake ->
+      spyOn(@panel.client, 'search').andCallFake ->
         new Promise (resolve, reject) -> resolve([ {name: 'something else'}, {name: 'partial name match'} ])
       spyOn(@panel, 'getPackageCardView').andCallThrough()
 

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -11,7 +11,6 @@ describe "PackageManager", ->
 
   it "handle errors spawning apm", ->
     noSuchCommandError = if process.platform is 'win32' then ' cannot find the path ' else 'ENOENT'
-    waitsForPromise shouldReject: true, -> packageManager.search('test')
     waitsForPromise shouldReject: true, -> packageManager.getInstalled()
     waitsForPromise shouldReject: true, -> packageManager.getOutdated()
     waitsForPromise shouldReject: true, -> packageManager.getFeatured()


### PR DESCRIPTION
### Description of the Change

This pull request implements the search capability equivalent to previously used `apm search --json (--packages|--themes)? term`, sorted by download count in descending order. Measuring the web request that is done inside `apm`, with ~118ms network latency it takes around 750-800ms to respond (according to Chrome devtools), whereas the total execution time for `apm search` takes around 1.5 seconds.

Searching for `github` and measuring using `performance.now()`:
Before: `packageManager.search()` 1587ms average
After: `client.search()` 853ms average

Although using just `apm` would be cleaner, this is a significant gain in terms of perceived responsiveness. Search functionality doesn't depend on `apm` existing in any way and being one of the most frequently used parts of settings-view where user has to wait, it makes sense to reduce any delays where possible. Ideally there should be a library which both `settings-view` and `apm` use as that eliminates the duplication concern.

It is possible that by enabling compression at atom.io, the request response time can be further improved, making responses a fair amount faster on slower connections as huge amounts of text typically compress well.

### Alternate Designs

None considered.

### Benefits

Search returns faster ⚡️, doesn't feel as slow to the user.

### Possible Drawbacks

A little bit more code duplication between `apm` and this package.

### Applicable Issues

None.
