### PR TITLE
feat(update-panel): implement update queue

### DIFF
--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -14,7 +14,6 @@ export default class UpdatesPanel {
     this.disposables = new CompositeDisposable()
     this.updatingPackages = []
     this.packageCards = []
-    this.maxApmInstances = 3
 
     etch.initialize(this)
 
@@ -161,7 +160,7 @@ export default class UpdatesPanel {
     this.refs.checkButton.disabled = true
     this.refs.updateAllButton.disabled = true
 
-    const maxApmInstances = this.maxApmInstances
+    const maxApmInstances = atom.config.get('settings-view.maxApmInstances')
 
     let updatingPackages = this.updatingPackages
     let packageCards = this.packageCards

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -14,6 +14,7 @@ export default class UpdatesPanel {
     this.disposables = new CompositeDisposable()
     this.updatingPackages = []
     this.packageCards = []
+    this.maxApmInstances = 3
 
     etch.initialize(this)
 
@@ -160,12 +161,19 @@ export default class UpdatesPanel {
     this.refs.checkButton.disabled = true
     this.refs.updateAllButton.disabled = true
 
+    const maxApmInstances = this.maxApmInstances
+
+    let updatingPackages = this.updatingPackages
+    let packageCards = this.packageCards
     let successfulUpdatesCount = 0
     let remainingPackagesCount = this.packageCards.length
-    let totalUpdatesCount = this.packageCards.length // This value doesn't change unlike remainingPackagesCount
+    let totalUpdatesCount = this.packageCards.length
+    let nextUpdatePointer = 0
 
     const notifyIfDone = () => {
-      if (remainingPackagesCount === 0) {
+      if (remainingPackagesCount > 0) {
+        queue()
+      } else if (updatingPackages.length === 0) {
         if (successfulUpdatesCount > 0) {
           let pluralizedPackages = 'package'
           if (successfulUpdatesCount > 1) {
@@ -206,14 +214,19 @@ export default class UpdatesPanel {
       notifyIfDone()
     }
 
-    for (const packageCard of this.packageCards) {
-      if (!this.updatingPackages.includes(packageCard.pack)) {
-        packageCard.update().then(onUpdateResolved, onUpdateRejected)
-      } else {
-        remainingPackagesCount--
-        totalUpdatesCount--
+    const queue = function() {
+      while (nextUpdatePointer < packageCards.length && (updatingPackages.length < maxApmInstances || maxApmInstances < 1)) {
+        if (!updatingPackages.includes(packageCards[nextUpdatePointer].pack)) {
+          packageCards[nextUpdatePointer].update().then(onUpdateResolved, onUpdateRejected)
+        } else {
+          remainingPackagesCount--
+          totalUpdatesCount--
+        }
+        nextUpdatePointer++
       }
     }
+
+    queue()
   }
 
   clearPackageCards () {

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -174,11 +174,7 @@ export default class UpdatesPanel {
         queue()
       } else if (updatingPackages.length === 0) {
         if (successfulUpdatesCount > 0) {
-          let pluralizedPackages = 'package'
-          if (successfulUpdatesCount > 1) {
-            pluralizedPackages += 's'
-          }
-          const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralizedPackages}:`
+          const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`
           let detail = ''
           this.packageCards.forEach((card) => {
             detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}\n`
@@ -258,4 +254,8 @@ export default class UpdatesPanel {
   scrollToBottom () {
     this.element.scrollTop = this.element.scrollHeight
   }
+}
+
+function pluralize (word, count) {
+  return (count > 1) ? `${word}s` : word
 }

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -165,8 +165,8 @@ export default class UpdatesPanel {
     let successfulUpdatesCount = 0
     let failedUpdatesCount = 0
 
-    const concurrency = atom.config.get('settings-view.maxApmInstances') > 0
-      ? atom.config.get('settings-view.maxApmInstances')
+    const concurrency = atom.config.get('settings-view.packageUpdateConcurrency') > 0
+      ? atom.config.get('settings-view.packageUpdateConcurrency')
       : Number.POSITIVE_INFINITY
 
     const queue = async.queue(function (packageCard, callback) {

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -2,6 +2,7 @@
 /** @jsx etch.dom */
 
 import {CompositeDisposable} from 'atom'
+import async from 'async'
 import etch from 'etch'
 
 import ErrorView from './error-view'
@@ -156,72 +157,62 @@ export default class UpdatesPanel {
     }
   }
 
-  updateAll () {
+  async updateAll () {
     this.refs.checkButton.disabled = true
     this.refs.updateAllButton.disabled = true
 
-    const maxApmInstances = atom.config.get('settings-view.maxApmInstances')
-
     let updatingPackages = this.updatingPackages
-    let packageCards = this.packageCards
     let successfulUpdatesCount = 0
-    let remainingPackagesCount = this.packageCards.length
-    let totalUpdatesCount = this.packageCards.length
-    let nextUpdatePointer = 0
+    let failedUpdatesCount = 0
 
-    const notifyIfDone = () => {
-      if (remainingPackagesCount > 0) {
-        queue()
-      } else if (updatingPackages.length === 0) {
-        if (successfulUpdatesCount > 0) {
-          const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`
-          let detail = ''
-          this.packageCards.forEach((card) => {
-            detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}\n`
-          });
-          detail.trim()
+    const concurrency = atom.config.get('settings-view.maxApmInstances') > 0
+      ? atom.config.get('settings-view.maxApmInstances')
+      : Number.POSITIVE_INFINITY
 
-          const buttons = [{
-            text: 'Restart',
-            onDidClick() { return atom.restartApplication() }
-          }]
-          atom.notifications.addSuccess(message, {dismissable: true, buttons, detail})
-        }
-
-        if (successfulUpdatesCount === totalUpdatesCount) {
-          this.refs.checkButton.disabled = false
-          this.refs.updateAllButton.style.display = 'none'
-        } else { // Some updates failed
-          this.refs.checkButton.disabled = false
-          this.refs.updateAllButton.disabled = false
-        }
+    const queue = async.queue(function (packageCard, callback) {
+      const onUpdateCompleted = function (err) {
+        err == null ? successfulUpdatesCount++ : failedUpdatesCount++
       }
-    }
 
-    const onUpdateResolved = function() {
-      remainingPackagesCount--
-      successfulUpdatesCount++
-      notifyIfDone()
-    }
-
-    const onUpdateRejected = function() {
-      remainingPackagesCount--
-      notifyIfDone()
-    }
-
-    const queue = function() {
-      while (nextUpdatePointer < packageCards.length && (updatingPackages.length < maxApmInstances || maxApmInstances < 1)) {
-        if (!updatingPackages.includes(packageCards[nextUpdatePointer].pack)) {
-          packageCards[nextUpdatePointer].update().then(onUpdateResolved, onUpdateRejected)
-        } else {
-          remainingPackagesCount--
-          totalUpdatesCount--
-        }
-        nextUpdatePointer++
+      if (updatingPackages.includes(packageCard.pack)) {
+        callback()
+      } else {
+        packageCard.update().then(onUpdateCompleted, onUpdateCompleted).then(callback)
       }
+    }, concurrency)
+
+    const queueDrainedPromise = new Promise((resolve) => {
+      queue.drain = resolve
+    })
+
+    for (let packageCard of this.packageCards) {
+      queue.push(packageCard)
     }
 
-    queue()
+    await queueDrainedPromise
+
+    if (successfulUpdatesCount > 0) {
+      const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`
+      let detail = ''
+      this.packageCards.forEach((card) => {
+        detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}\n`
+      });
+      detail.trim()
+
+      const buttons = [{
+        text: 'Restart',
+        onDidClick() { return atom.restartApplication() }
+      }]
+      atom.notifications.addSuccess(message, {dismissable: true, buttons, detail})
+    }
+
+    if (failedUpdatesCount === 0) {
+      this.refs.checkButton.disabled = false
+      this.refs.updateAllButton.style.display = 'none'
+    } else {
+      this.refs.checkButton.disabled = false
+      this.refs.updateAllButton.disabled = false
+    }
   }
 
   clearPackageCards () {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
     "method": "handleURI",
     "deferActivation": false
   },
+  "configSchema": {
+    "maxApmInstances": {
+      "title": "Max APM Instances",
+      "description": "Limit how many apm processes may run simultaneously during package updates. Use this, if updating many packages at once slows down your machine.",
+      "type": "integer",
+      "default": -1
+    }
+  },
   "dependencies": {
     "async": "~0.2.9",
     "dompurify": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deferActivation": false
   },
   "configSchema": {
-    "maxApmInstances": {
+    "packageUpdateConcurrency": {
       "title": "Maximum simultaneous package updates",
       "description": "Limit how many processes run simultaenously during package updates. Use this if updating many packages at once slows down your machine.",
       "type": "integer",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "configSchema": {
     "maxApmInstances": {
-      "title": "Maximum APM Instances",
-      "description": "Limit how many apm processes may run simultaneously during package updates. Use this, if updating many packages at once slows down your machine.",
+      "title": "Maximum simultaneous package updates",
+      "description": "Limit how many processes run simultaenously during package updates. Use this if updating many packages at once slows down your machine.",
       "type": "integer",
       "default": -1
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "configSchema": {
     "packageUpdateConcurrency": {
       "title": "Maximum simultaneous package updates",
-      "description": "Limit how many processes run simultaneously during package updates. Use this if updating many packages at once slows down your machine.",
+      "description": "Limit how many processes run simultaneously during package updates. If your machine slows down while updating many packages at once, set this value to a small positive number (e.g., `1` or `2`).",
       "type": "integer",
       "default": -1
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "configSchema": {
     "packageUpdateConcurrency": {
       "title": "Maximum simultaneous package updates",
-      "description": "Limit how many processes run simultaenously during package updates. Use this if updating many packages at once slows down your machine.",
+      "description": "Limit how many processes run simultaneously during package updates. Use this if updating many packages at once slows down your machine.",
       "type": "integer",
       "default": -1
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "configSchema": {
     "maxApmInstances": {
-      "title": "Max APM Instances",
+      "title": "Maximum APM Instances",
       "description": "Limit how many apm processes may run simultaneously during package updates. Use this, if updating many packages at once slows down your machine.",
       "type": "integer",
       "default": -1

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -74,6 +74,8 @@ describe 'UpdatesPanel', ->
       spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> [resolveB, rejectB] = [resolve, reject]))
       spyOn(cardC, 'update').andReturn(new Promise((resolve, reject) -> [resolveC, rejectC] = [resolve, reject]))
 
+      atom.config.set("settings-view.maxApmInstances", -1)
+
     it 'attempts to update all packages and prompts to restart if at least one package updates successfully', ->
       expect(atom.notifications.getNotifications().length).toBe 0
       expect(panel.refs.updateAllButton).toBeVisible()
@@ -98,9 +100,26 @@ describe 'UpdatesPanel', ->
         notifications[0].options.buttons[0].onDidClick()
         expect(atom.restartApplication).toHaveBeenCalled()
 
-    it 'becomes hidden if all updates succeed', ->
-      expect(panel.refs.updateAllButton.disabled).toBe false
+    it 'works with queue enabled', ->
+      expect(panel.refs.updateAllButton).not.toBeDisabled()
+      atom.config.set("settings-view.maxApmInstances", 2)
+
       panel.updateAll()
+
+      resolveA()
+      resolveB()
+      resolveC()
+
+      waits 0
+      runs ->
+        expect(panel.refs.updateAllButton).toBeHidden()
+
+    it 'becomes hidden if all updates succeed', ->
+      expect(panel.refs.updateAllButton).not.toBeDisabled()
+
+      panel.updateAll()
+
+      expect(panel.refs.updateAllButton).toBeDisabled()
 
       resolveA()
       resolveB()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -111,7 +111,7 @@ describe 'UpdatesPanel', ->
       resolveC()
 
       waitsFor ->
-        panel.refs.updateAllButton.style.display == 'none'
+        panel.refs.updateAllButton.style.display === 'none'
 
     it 'becomes hidden if all updates succeed', ->
       expect(panel.refs.updateAllButton).not.toBeDisabled()
@@ -125,7 +125,7 @@ describe 'UpdatesPanel', ->
       resolveC()
 
       waitsFor ->
-        panel.refs.updateAllButton.style.display == 'none'
+        panel.refs.updateAllButton.style.display === 'none'
 
     it 'remains enabled and visible if not all updates succeed', ->
       panel.updateAll()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -128,15 +128,20 @@ describe 'UpdatesPanel', ->
         panel.refs.updateAllButton.style.display is 'none'
 
     it 'remains enabled and visible if not all updates succeed', ->
+      expect(panel.refs.updateAllButton).not.toBeDisabled()
+
       panel.updateAll()
+
+      expect(panel.refs.updateAllButton).toBeDisabled()
 
       resolveA()
       rejectB('Error updating package')
       resolveC()
 
-      waits 0
+      waitsFor ->
+        panel.refs.updateAllButton.disabled is false
+
       runs ->
-        expect(panel.refs.updateAllButton.disabled).toBe false
         expect(panel.refs.updateAllButton).toBeVisible()
 
     it 'does not attempt to update packages that are already updating', ->

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -74,7 +74,7 @@ describe 'UpdatesPanel', ->
       spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> [resolveB, rejectB] = [resolve, reject]))
       spyOn(cardC, 'update').andReturn(new Promise((resolve, reject) -> [resolveC, rejectC] = [resolve, reject]))
 
-      atom.config.set("settings-view.maxApmInstances", -1)
+      atom.config.set("settings-view.packageUpdateConcurrency", -1)
 
     it 'attempts to update all packages and prompts to restart if at least one package updates successfully', ->
       expect(atom.notifications.getNotifications().length).toBe 0
@@ -102,7 +102,7 @@ describe 'UpdatesPanel', ->
 
     it 'works with queue enabled', ->
       expect(panel.refs.updateAllButton).not.toBeDisabled()
-      atom.config.set("settings-view.maxApmInstances", 2)
+      atom.config.set("settings-view.packageUpdateConcurrency", 2)
 
       panel.updateAll()
 

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -2,7 +2,7 @@ UpdatesPanel = require '../lib/updates-panel'
 PackageManager = require '../lib/package-manager'
 SettingsView = require '../lib/settings-view'
 
-fdescribe 'UpdatesPanel', ->
+describe 'UpdatesPanel', ->
   panel = null
   settingsView = null
   packageManager = null

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -2,7 +2,7 @@ UpdatesPanel = require '../lib/updates-panel'
 PackageManager = require '../lib/package-manager'
 SettingsView = require '../lib/settings-view'
 
-describe 'UpdatesPanel', ->
+fdescribe 'UpdatesPanel', ->
   panel = null
   settingsView = null
   packageManager = null
@@ -111,7 +111,7 @@ describe 'UpdatesPanel', ->
       resolveC()
 
       waitsFor ->
-        panel.refs.updateAllButton.style.display === 'none'
+        panel.refs.updateAllButton.style.display is 'none'
 
     it 'becomes hidden if all updates succeed', ->
       expect(panel.refs.updateAllButton).not.toBeDisabled()
@@ -125,7 +125,7 @@ describe 'UpdatesPanel', ->
       resolveC()
 
       waitsFor ->
-        panel.refs.updateAllButton.style.display === 'none'
+        panel.refs.updateAllButton.style.display is 'none'
 
     it 'remains enabled and visible if not all updates succeed', ->
       panel.updateAll()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -110,9 +110,8 @@ describe 'UpdatesPanel', ->
       resolveB()
       resolveC()
 
-      waits 0
-      runs ->
-        expect(panel.refs.updateAllButton).toBeHidden()
+      waitsFor ->
+        panel.refs.updateAllButton.style.display == 'none'
 
     it 'becomes hidden if all updates succeed', ->
       expect(panel.refs.updateAllButton).not.toBeDisabled()
@@ -125,9 +124,8 @@ describe 'UpdatesPanel', ->
       resolveB()
       resolveC()
 
-      waits 0
-      runs ->
-        expect(panel.refs.updateAllButton).toBeHidden()
+      waitsFor ->
+        panel.refs.updateAllButton.style.display == 'none'
 
     it 'remains enabled and visible if not all updates succeed', ->
       panel.updateAll()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -91,13 +91,12 @@ describe 'UpdatesPanel', ->
 
         resolveC()
 
-      waits 0
-      runs ->
-        notifications = atom.notifications.getNotifications()
-        expect(notifications.length).toBe 1
+      waitsFor ->
+        atom.notifications.getNotifications().length is 1
 
+      runs ->
         spyOn(atom, 'restartApplication')
-        notifications[0].options.buttons[0].onDidClick()
+        atom.notifications.getNotifications()[0].options.buttons[0].onDidClick()
         expect(atom.restartApplication).toHaveBeenCalled()
 
     it 'works with queue enabled', ->


### PR DESCRIPTION
### Description of the Change

Implements an update queue for the Update All process.
Instead of opening one instance of APM per update this PR introduces ```maxApmInstances```
to limit the number of simultaniously running updates.
![peek 2017-11-01 22-53](https://user-images.githubusercontent.com/19377375/32248040-ae31f350-be84-11e7-9e84-75dcc30fd766.gif)

Setting ```maxApmInstances``` to a value < 1 will fall back to the old behaviour, starting all updates at once.


### ToDo 

- [x] give the user the ability to change ```maxApmInstances```  (it is in the Package card, should it go somewhere else?)
- [x] testing
- [x] the default value for ```maxApmInstances``` should be discussed (first thoughts have been expressed here: #756 )

### Benefits

+ prevents lower end systems from sluggishness through high cpu usage, or even crashing
+ unblocks #937  (I will do a follow up PR soon after merge)
+ closes #756 
+ closes #746 
+ closes #546 
+ closes #519 

### Possible Drawbacks

This might slow down the update process on beefy systems (with non optimal settings).