### PR TITLE
Hide the collapsed icon when there are no items

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -255,7 +255,7 @@
     }
 
     &.collapsed {
-      .sub-section-heading:after {
+      .sub-section-heading.has-items:after {
         content: @unfold;
       }
       .package-container .package-card,


### PR DESCRIPTION
### Description of the Change

This hides the collapsed icon when there are no items available.

### Benefits

No more box.

![no-results-box](https://github-slack.s3.amazonaws.com/monosnap/Settings__githubatom_2017-10-06_18-32-25.png)

### Possible Drawbacks

None

### Applicable Issues

Fixes #1009
