### PR TITLE
Always return a promise for PackageCard::update

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -659,7 +659,7 @@ export default class PackageCard {
 
   update () {
     if (!this.newVersion && !this.newSha) {
-      return
+      return Promise.resolve()
     }
 
     const pack = this.installablePack != null ? this.installablePack : this.pack

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -260,6 +260,26 @@ describe "PackageCard", ->
       runs ->
         expect(card.refs.updateButton).toBeVisible()
 
+    it 'does not error when attempting to update without any update available', ->
+      # While this cannot be done through the package card UI,
+      # updates can still be triggered through the Updates panel's Update All button
+      # https://github.com/atom/settings-view/issues/879
+
+      pack = atom.packages.getLoadedPackage('package-with-config')
+
+      originalLoadPackage = atom.packages.loadPackage
+      spyOn(atom.packages, 'loadPackage').andCallFake ->
+        originalLoadPackage.call(atom.packages, path.join(__dirname, 'fixtures', 'package-with-config'))
+
+      card = new PackageCard(pack, new SettingsView(), packageManager)
+      jasmine.attachToDOM(card.element)
+      expect(card.refs.updateButton).not.toBeVisible()
+
+      waitsForPromise -> card.update()
+
+      runs ->
+        expect(card.refs.updateButton).not.toBeVisible()
+
     it "will stay disabled after an update", ->
       pack = atom.packages.getLoadedPackage('package-with-config')
       pack.latestVersion = '1.1.0'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is a quick fix for #879.  `PackageCard::update` would not return a Promise when there was no update available, which was causing exceptions in methods that expected `update` to always return a Promise.

### Alternate Designs

I would like to revisit the Updates panel code to make it smarter and not attempt to call `update` on packages that have no updates available.  But as for this specific change, there are no alternatives as it is strictly a bugfix to consistently return the same type.

### Benefits

One less bug.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #879