### PR TITLE
Poll bundledSnippetsLoaded() rather than waiting for a hook

### DIFF
--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -50,8 +50,7 @@ describe "InstalledPackageView", ->
     waitsForPromise ->
       atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
-    waitsFor 'snippets to load', (done) ->
-      snippetsModule.onDidLoadSnippets(done)
+    waitsFor 'snippets to load', -> snippetsModule.provideSnippets().bundledSnippetsLoaded()
 
     runs ->
       pack = atom.packages.getActivePackage('language-test')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I realized that `onDidLoadSnippets()` might already have been called by the time we hook it, meaning that we'll never receive the event.  Therefore I have changed our approach to rely on polling `provideSnippets().bundledSnippetsLoaded()` instead, which should ensure that we will continue if snippets have already been loaded by the time we reach the waitsFor.

### Alternate Designs

I considered moving this waitsFor block above the waitsForPromise block so that it had a higher chance of catching the `did-load-snippets` event but that would still have the chance to fail.

### Benefits

Less test flakiness.

### Possible Drawbacks

Until atom/snippets#259 makes it to stable, running this test multiple times will fail.  I think that is a compromise I'm willing to take as these specs are run only once on CI.

### Applicable Issues

Fixes #998