### PR TITLE
Deactivate correctly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,8 @@ let settingsView = null
 
 let statusView = null
 
+const {CompositeDisposable} = require('atom')
+
 const PackageManager = require('./package-manager')
 let packageManager = null
 
@@ -42,7 +44,9 @@ module.exports = {
   },
 
   activate() {
-    atom.workspace.addOpener(uri => {
+    this.disposables = new ComositeDisposable()
+
+    this.disposables.add(atom.workspace.addOpener(uri => {
       if (uri.startsWith(CONFIG_URI)) {
         if (settingsView == null || settingsView.destroyed) {
           settingsView = this.createSettingsView({uri})
@@ -56,9 +60,9 @@ module.exports = {
         }
         return settingsView
       }
-    })
+    }))
 
-    atom.commands.add('atom-workspace', {
+    this.dispsoables.add(atom.commands.add('atom-workspace', {
       'settings-view:open'() { atom.workspace.open(CONFIG_URI) },
       'settings-view:core'() { atom.workspace.open(`${CONFIG_URI}/core`) },
       'settings-view:editor'() { atom.workspace.open(`${CONFIG_URI}/editor`) },
@@ -70,10 +74,10 @@ module.exports = {
       'settings-view:view-installed-packages'() { atom.workspace.open(`${CONFIG_URI}/packages`) },
       'settings-view:uninstall-packages'() { atom.workspace.open(`${CONFIG_URI}/packages`) },
       'settings-view:check-for-package-updates'() { atom.workspace.open(`${CONFIG_URI}/updates`) }
-    })
+    }))
 
     if (process.platform === 'win32' && require('atom').WinShell != null) {
-      atom.commands.add('atom-workspace', {'settings-view:system'() { atom.workspace.open(`${CONFIG_URI}/system`) }})
+      this.disposables.add(atom.commands.add('atom-workspace', {'settings-view:system'() { atom.workspace.open(`${CONFIG_URI}/system`) }}))
     }
 
     if (!localStorage.getItem('hasSeenDeprecatedNotification')) {
@@ -85,8 +89,10 @@ module.exports = {
   },
 
   deactivate() {
+    if (this.disposables) this.disposables.dispose()
     if (settingsView) settingsView.destroy()
     if (statusView) statusView.destroy()
+    this.disposables = null
     settingsView = null
     packageManager = null
     statusView = null

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,6 +91,7 @@ module.exports = {
   deactivate() {
     if (this.disposables) this.disposables.dispose()
     if (settingsView) settingsView.destroy()
+    if (packageManager) packageManager.destroy()
     if (statusView) statusView.destroy()
     this.disposables = null
     settingsView = null

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,7 +44,7 @@ module.exports = {
   },
 
   activate() {
-    this.disposables = new ComositeDisposable()
+    this.disposables = new CompositeDisposable()
 
     this.disposables.add(atom.workspace.addOpener(uri => {
       if (uri.startsWith(CONFIG_URI)) {
@@ -62,7 +62,7 @@ module.exports = {
       }
     }))
 
-    this.dispsoables.add(atom.commands.add('atom-workspace', {
+    this.disposables.add(atom.commands.add('atom-workspace', {
       'settings-view:open'() { atom.workspace.open(CONFIG_URI) },
       'settings-view:core'() { atom.workspace.open(`${CONFIG_URI}/core`) },
       'settings-view:editor'() { atom.workspace.open(`${CONFIG_URI}/editor`) },

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -18,6 +18,9 @@ class PackageManager
 
     @emitter = new Emitter
 
+  destroy: ->
+    @emitter.dispose()
+
   getClient: ->
     @client ?= new Client(this)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Properly dispose of any disposables on deactivation to prevent lingering traces of Settings View from lying around.

### Alternate Designs

None.

### Benefits

Better package deactivation.

### Possible Drawbacks

None.

### Applicable Issues

This addresses #764 to the maximum extent possible without changing code in Atom core.