### PR TITLE
:bug: Use latest tag for image source URL in the readme

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -372,21 +372,25 @@ export default class PackageDetailView {
       readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
     }
 
-    let readmeSrc
-
     if (this.pack.path) {
       // If package is installed, use installed path
-      readmeSrc = this.pack.path
+      let readmeSrc = this.pack.path
+      this.initView(readme, readmeSrc)
     } else {
       // If package isn't installed, use url path
-      let repoUrl = this.packageManager.getRepositoryUrl(this.pack)
+      let repoURL = this.packageManager.getRepositoryUrl(this.pack)
 
       // Check if URL is undefined (i.e. package is unpublished)
-      if (repoUrl) {
-        readmeSrc = repoUrl + `/blob/master/`
+      if (repoURL) {
+        // This only serves for img src
+        this.packageManager.getReadmeSrc(repoURL).then(readmeSrc =>
+          this.initView(readme, readmeSrc)
+        )
       }
     }
+  }
 
+  initView (readme, readmeSrc) {
     const readmeView = new PackageReadmeView(readme, readmeSrc)
     if (this.readmeView) {
       this.readmeView.element.parentElement.replaceChild(readmeView.element, this.readmeView.element)

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -435,6 +435,14 @@ class PackageManager
       repoUrl = "https://github.com/#{repoName}"
     repoUrl.replace(/\.git$/, '').replace(/\/+$/, '').replace(/^git\+/, '')
 
+  getReadmeSrc: (url) ->
+    repoData = url.split('/')
+    releaseURL = "https://api.github.com/repos/#{repoData[3]}/#{repoData[4]}/tags"
+    # Builds the url to img src from the readme based on latest tag
+    fetch(releaseURL)
+    .then((res) => res.json())
+    .then((json) => return "#{url}/raw/#{json[0].name}/")
+
   checkNativeBuildTools: ->
     new Promise (resolve, reject) =>
       apmProcess = @runCommand ['install', '--check'], (code, stdout, stderr) ->


### PR DESCRIPTION
### Description of the Change

The source for the images of the README of uninstalled packages are now taken from the latest tag instread of defaulting to repo/blob/master.

### Alternate Designs

It is also possible to fall back on the latest release but some repositories have tags and no release.

### Benefits

Some repo do not have a master branch or the README has changed since the latest tag (no more images or filenames have changed), causing the images to not appear. Here it is not the case anymore.

### Possible Drawbacks

Maybe the latest tag will be in advance compared to the available version on the package.

### Applicable Issues

READMEs should fall back to latest tag, not master #1012
