### PR TITLE
Remove broken offline special-casing when retrieving cached data

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -27,27 +27,27 @@ class AtomIoClient
   # caching.
   package: (name, callback) ->
     packagePath = "packages/#{name}"
-    @fetchFromCache packagePath, (err, data) =>
-      if data
-        callback(null, data)
-      else
-        @request(packagePath, callback)
+    data = @fetchFromCache(packagePath)
+    if data
+      callback(null, data)
+    else
+      @request(packagePath, callback)
 
   featuredPackages: (callback) ->
     # TODO clean up caching copypasta
-    @fetchFromCache 'packages/featured', (err, data) =>
-      if data
-        callback(null, data)
-      else
-        @getFeatured(false, callback)
+    data = @fetchFromCache 'packages/featured'
+    if data
+      callback(null, data)
+    else
+      @getFeatured(false, callback)
 
   featuredThemes: (callback) ->
     # TODO clean up caching copypasta
-    @fetchFromCache 'themes/featured', (err, data) =>
-      if data
-        callback(null, data)
-      else
-        @getFeatured(true, callback)
+    data = @fetchFromCache 'themes/featured'
+    if data
+      callback(null, data)
+    else
+      @getFeatured(true, callback)
 
   getFeatured: (loadThemes, callback) ->
     # apm already does this, might as well use it instead of request i guess? The
@@ -92,15 +92,14 @@ class AtomIoClient
 
   # This could use a better name, since it checks whether it's appropriate to return
   # the cached data and pretends it's null if it's stale and we're online
-  # FIXME: Why is this even a callback when everything is sync? We never return an error anyway
-  fetchFromCache: (packagePath, callback) ->
+  fetchFromCache: (packagePath) ->
     cached = localStorage.getItem(@cacheKeyForPath(packagePath))
     cached = if cached then JSON.parse(cached)
     if cached? and (not @online() or Date.now() - cached.createdOn < @expiry)
-      callback(null, cached.data)
+      return cached.data
     else
       # falsy data means "try to hit the network"
-      callback(null, null)
+      return null
 
   createAvatarCache: ->
     fs.makeTree(@getCachePath())

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -105,7 +105,6 @@ class AtomIoClient
     cached = localStorage.getItem(@cacheKeyForPath(packagePath))
     cached = if cached then JSON.parse(cached)
     if cached? and (not @online() or options.force or (Date.now() - cached.createdOn < @expiry))
-      cached ?= data: {}
       callback(null, cached.data)
     else
       # falsy data means "try to hit the network"

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -92,6 +92,7 @@ class AtomIoClient
 
   # This could use a better name, since it checks whether it's appropriate to return
   # the cached data and pretends it's null if it's stale and we're online
+  # FIXME: Why is this even a callback when everything is sync? We never return an error anyway
   fetchFromCache: (packagePath, options, callback) ->
     unless callback
       callback = options
@@ -106,10 +107,6 @@ class AtomIoClient
     if cached? and (not @online() or options.force or (Date.now() - cached.createdOn < @expiry))
       cached ?= data: {}
       callback(null, cached.data)
-    else if not cached? and not @online()
-      # The user hasn't requested this resource before and there's no way for us
-      # to get it to them so just hand back an empty object so callers don't crash
-      callback(null, {})
     else
       # falsy data means "try to hit the network"
       callback(null, null)

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -27,7 +27,7 @@ class AtomIoClient
   # caching.
   package: (name, callback) ->
     packagePath = "packages/#{name}"
-    @fetchFromCache packagePath, {}, (err, data) =>
+    @fetchFromCache packagePath, (err, data) =>
       if data
         callback(null, data)
       else
@@ -35,7 +35,7 @@ class AtomIoClient
 
   featuredPackages: (callback) ->
     # TODO clean up caching copypasta
-    @fetchFromCache 'packages/featured', {}, (err, data) =>
+    @fetchFromCache 'packages/featured', (err, data) =>
       if data
         callback(null, data)
       else
@@ -43,7 +43,7 @@ class AtomIoClient
 
   featuredThemes: (callback) ->
     # TODO clean up caching copypasta
-    @fetchFromCache 'themes/featured', {}, (err, data) =>
+    @fetchFromCache 'themes/featured', (err, data) =>
       if data
         callback(null, data)
       else
@@ -93,18 +93,10 @@ class AtomIoClient
   # This could use a better name, since it checks whether it's appropriate to return
   # the cached data and pretends it's null if it's stale and we're online
   # FIXME: Why is this even a callback when everything is sync? We never return an error anyway
-  fetchFromCache: (packagePath, options, callback) ->
-    unless callback
-      callback = options
-      options = {}
-
-    unless options.force
-      # Set `force` to true if we can't reach the network.
-      options.force = not @online()
-
+  fetchFromCache: (packagePath, callback) ->
     cached = localStorage.getItem(@cacheKeyForPath(packagePath))
     cached = if cached then JSON.parse(cached)
-    if cached? and (not @online() or options.force or (Date.now() - cached.createdOn < @expiry))
+    if cached? and (not @online() or Date.now() - cached.createdOn < @expiry)
       callback(null, cached.data)
     else
       # falsy data means "try to hit the network"

--- a/spec/atom-io-client-spec.coffee
+++ b/spec/atom-io-client-spec.coffee
@@ -13,8 +13,7 @@ describe "AtomIoClient", ->
 
   it "fetches api json from cache if the network is unavailable", ->
     spyOn(@client, 'online').andReturn(false)
-    spyOn(@client, 'fetchFromCache').andCallFake (path, cb) ->
-      cb(null, {})
+    spyOn(@client, 'fetchFromCache').andReturn({})
     spyOn(@client, 'request')
     @client.package 'test-package', ->
 

--- a/spec/atom-io-client-spec.coffee
+++ b/spec/atom-io-client-spec.coffee
@@ -13,7 +13,7 @@ describe "AtomIoClient", ->
 
   it "fetches api json from cache if the network is unavailable", ->
     spyOn(@client, 'online').andReturn(false)
-    spyOn(@client, 'fetchFromCache').andCallFake (path, opts, cb) ->
+    spyOn(@client, 'fetchFromCache').andCallFake (path, cb) ->
       cb(null, {})
     spyOn(@client, 'request')
     @client.package 'test-package', ->

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -66,7 +66,7 @@ describe "PackageDetailView", ->
   it "shows an error when package metadata cannot be loaded from the cache and the network is unavailable", ->
     spyOn(AtomIoClient.prototype, 'online').andReturn(false)
     spyOn(AtomIoClient.prototype, 'request').andCallThrough()
-    spyOn(AtomIoClient.prototype, 'fetchFromCache').andCallFake (path, opts, cb) ->
+    spyOn(AtomIoClient.prototype, 'fetchFromCache').andCallFake (path, cb) ->
       # this is the special case which happens when the data is not in the cache
       # and there's no connectivity
       cb(null, {})

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -66,10 +66,7 @@ describe "PackageDetailView", ->
   it "shows an error when package metadata cannot be loaded from the cache and the network is unavailable", ->
     spyOn(AtomIoClient.prototype, 'online').andReturn(false)
     spyOn(AtomIoClient.prototype, 'request').andCallThrough()
-    spyOn(AtomIoClient.prototype, 'fetchFromCache').andCallFake (path, cb) ->
-      # this is the special case which happens when the data is not in the cache
-      # and there's no connectivity
-      cb(null, {})
+    spyOn(AtomIoClient.prototype, 'fetchFromCache').andReturn({})
 
     view = new PackageDetailView({name: 'some-package'}, new SettingsView(), packageManager, SnippetsProvider)
 

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -64,14 +64,16 @@ describe "PackageDetailView", ->
     expect(view.element.querySelectorAll('.package-card').length).toBe(0)
 
   it "shows an error when package metadata cannot be loaded from the cache and the network is unavailable", ->
+    localStorage.removeItem('settings-view:packages/some-package')
+
     spyOn(AtomIoClient.prototype, 'online').andReturn(false)
-    spyOn(AtomIoClient.prototype, 'request').andCallThrough()
-    spyOn(AtomIoClient.prototype, 'fetchFromCache').andReturn({})
+    spyOn(AtomIoClient.prototype, 'request').andCallFake (path, callback) ->
+      callback(new Error('getaddrinfo ENOENT atom.io:443'))
+    spyOn(AtomIoClient.prototype, 'fetchFromCache').andCallThrough()
 
     view = new PackageDetailView({name: 'some-package'}, new SettingsView(), packageManager, SnippetsProvider)
 
     expect(AtomIoClient.prototype.fetchFromCache).toHaveBeenCalled()
-    expect(AtomIoClient.prototype.request).not.toHaveBeenCalled()
 
     expect(view.refs.errorMessage.classList.contains('hidden')).not.toBe(true)
     expect(view.refs.loadingMessage.classList.contains('hidden')).toBe(true)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The `fetchFromCache` method looks up if there is cached data.  Then, if it hasn't expired yet or Atom doesn't have internet access, it returns the cached data.  Otherwise, if there was no cached data and Atom wasn't online, it used to return the empty object `{}` "so callers don't crash".  Ironically, this very line causes the featured packages lookup to "crash" with an exception since it expects an array.  Therefore in this PR I have removed the special-casing and always return `null` without internet access and let the callers deal with it (they already do).

Additionally I have simplified `fetchFromCache` by making it sync (there was nothing requiring it to accept a callback) and removing an unused `options` parameter.

### Alternate Designs

I'm going to rename this "Future Aspirations".  A `getaddrinfo` is much better than throwing an exception but I would still like to see a warning rather than an error; something like "Atom is currently offline and the following results may be outdated" or "Atom is currently offline.  Try again later" if there's no results.  That would require the implementation of a new `WarningView` however and is why I decided not to do that in this PR.

### Benefits

No uncaught exceptions when loading the Install page for the first time without internet access.

### Possible Drawbacks

Rather than generating an exception, we now generate a `getaddrinfo ENOENT atom.io:443` error, but at least that's gracefully handled by settings-view.

### Applicable Issues

Fixes #962
Going to say that this also fixes #668