### PR TITLE
Deactivate correctly, take 2

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,8 @@ let settingsView = null
 
 let statusView = null
 
+const {CompositeDisposable} = require('atom')
+
 const PackageManager = require('./package-manager')
 let packageManager = null
 
@@ -42,7 +44,9 @@ module.exports = {
   },
 
   activate() {
-    atom.workspace.addOpener(uri => {
+    this.disposables = new CompositeDisposable()
+
+    this.disposables.add(atom.workspace.addOpener(uri => {
       if (uri.startsWith(CONFIG_URI)) {
         if (settingsView == null || settingsView.destroyed) {
           settingsView = this.createSettingsView({uri})
@@ -56,9 +60,9 @@ module.exports = {
         }
         return settingsView
       }
-    })
+    }))
 
-    atom.commands.add('atom-workspace', {
+    this.disposables.add(atom.commands.add('atom-workspace', {
       'settings-view:open'() { atom.workspace.open(CONFIG_URI) },
       'settings-view:core'() { atom.workspace.open(`${CONFIG_URI}/core`) },
       'settings-view:editor'() { atom.workspace.open(`${CONFIG_URI}/editor`) },
@@ -70,10 +74,10 @@ module.exports = {
       'settings-view:view-installed-packages'() { atom.workspace.open(`${CONFIG_URI}/packages`) },
       'settings-view:uninstall-packages'() { atom.workspace.open(`${CONFIG_URI}/packages`) },
       'settings-view:check-for-package-updates'() { atom.workspace.open(`${CONFIG_URI}/updates`) }
-    })
+    }))
 
     if (process.platform === 'win32' && require('atom').WinShell != null) {
-      atom.commands.add('atom-workspace', {'settings-view:system'() { atom.workspace.open(`${CONFIG_URI}/system`) }})
+      this.disposables.add(atom.commands.add('atom-workspace', {'settings-view:system'() { atom.workspace.open(`${CONFIG_URI}/system`) }}))
     }
 
     if (!localStorage.getItem('hasSeenDeprecatedNotification')) {
@@ -85,8 +89,11 @@ module.exports = {
   },
 
   deactivate() {
+    if (this.disposables) this.disposables.dispose()
     if (settingsView) settingsView.destroy()
+    if (packageManager) packageManager.destroy()
     if (statusView) statusView.destroy()
+    this.disposables = null
     settingsView = null
     packageManager = null
     statusView = null

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -18,6 +18,9 @@ class PackageManager
 
     @emitter = new Emitter
 
+  destroy: ->
+    @emitter.dispose()
+
   getClient: ->
     @client ?= new Client(this)
 

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -199,106 +199,109 @@ describe "SettingsView", ->
             expect(atom.workspace.getActivePaneItem().activePanel)
               .toEqual name: 'Updates', options: uri: 'atom://config/updates'
 
-    describe "when atom.workspace.open() is used with a config URI", ->
-      focusIsWithinActivePanel = ->
-        activePanel = settingsView.panelsByName[settingsView.activePanel.name]
-        activePanel.element is document.activeElement or activePanel.element.contains(document.activeElement)
+    for i in [1..100]
+      describe "when atom.workspace.open() is used with a config URI #{i}", ->
+        focusIsWithinActivePanel = ->
+          activePanel = settingsView.panelsByName[settingsView.activePanel.name]
+          if activePanel.element isnt document.activeElement and not activePanel.element.contains(document.activeElement)
+            console.log document.activeElement
+          activePanel.element is document.activeElement or activePanel.element.contains(document.activeElement)
 
-      expectActivePanelToBeKeyboardScrollable = ->
-        activePanel = settingsView.panelsByName[settingsView.activePanel.name]
-        spyOn(activePanel, 'pageDown')
-        atom.commands.dispatch(activePanel.element, 'core:page-down')
-        expect(activePanel.pageDown).toHaveBeenCalled()
-        spyOn(activePanel, 'pageUp')
-        atom.commands.dispatch(activePanel.element, 'core:page-up')
-        expect(activePanel.pageUp).toHaveBeenCalled()
+        expectActivePanelToBeKeyboardScrollable = ->
+          activePanel = settingsView.panelsByName[settingsView.activePanel.name]
+          spyOn(activePanel, 'pageDown')
+          atom.commands.dispatch(activePanel.element, 'core:page-down')
+          expect(activePanel.pageDown).toHaveBeenCalled()
+          spyOn(activePanel, 'pageUp')
+          atom.commands.dispatch(activePanel.element, 'core:page-up')
+          expect(activePanel.pageUp).toHaveBeenCalled()
 
-      beforeEach ->
-        settingsView = null
+        beforeEach ->
+          settingsView = null
 
-      it "opens the settings to the correct panel with atom://config/<panel-name> and that panel is keyboard-scrollable", ->
-        waitsForPromise ->
-          atom.workspace.open('atom://config').then (s) -> settingsView = s
-
-        waitsFor (done) -> process.nextTick(done)
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Core', options: {}
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/editor').then (s) -> settingsView = s
-
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Editor', options: uri: 'atom://config/editor'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/keybindings').then (s) -> settingsView = s
-
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Keybindings', options: uri: 'atom://config/keybindings'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/packages').then (s) -> settingsView = s
-
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Packages', options: uri: 'atom://config/packages'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/themes').then (s) -> settingsView = s
-
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Themes', options: uri: 'atom://config/themes'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/updates').then (s) -> settingsView = s
-
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Updates', options: uri: 'atom://config/updates'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-
-        waitsForPromise ->
-          atom.workspace.open('atom://config/install').then (s) -> settingsView = s
-
-        hasSystemPanel = false
-        waits 1
-        runs ->
-          expect(settingsView.activePanel)
-            .toEqual name: 'Install', options: uri: 'atom://config/install'
-          expect(focusIsWithinActivePanel()).toBe true
-          expectActivePanelToBeKeyboardScrollable()
-          hasSystemPanel = settingsView.panelsByName['System']?
-
-        if hasSystemPanel
+        it "opens the settings to the correct panel with atom://config/<panel-name> and that panel is keyboard-scrollable", ->
           waitsForPromise ->
-            atom.workspace.open('atom://config/system').then (s) -> settingsView = s
+            atom.workspace.open('atom://config').then (s) -> settingsView = s
+
+          waitsFor (done) -> process.nextTick(done)
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Core', options: {}
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/editor').then (s) -> settingsView = s
 
           waits 1
           runs ->
             expect(settingsView.activePanel)
-              .toEqual name: 'System', options: uri: 'atom://config/system'
+              .toEqual name: 'Editor', options: uri: 'atom://config/editor'
             expect(focusIsWithinActivePanel()).toBe true
             expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/keybindings').then (s) -> settingsView = s
+
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Keybindings', options: uri: 'atom://config/keybindings'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/packages').then (s) -> settingsView = s
+
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Packages', options: uri: 'atom://config/packages'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/themes').then (s) -> settingsView = s
+
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Themes', options: uri: 'atom://config/themes'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/updates').then (s) -> settingsView = s
+
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Updates', options: uri: 'atom://config/updates'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+
+          waitsForPromise ->
+            atom.workspace.open('atom://config/install').then (s) -> settingsView = s
+
+          hasSystemPanel = false
+          waits 1
+          runs ->
+            expect(settingsView.activePanel)
+              .toEqual name: 'Install', options: uri: 'atom://config/install'
+            expect(focusIsWithinActivePanel()).toBe true
+            expectActivePanelToBeKeyboardScrollable()
+            hasSystemPanel = settingsView.panelsByName['System']?
+
+          if hasSystemPanel
+            waitsForPromise ->
+              atom.workspace.open('atom://config/system').then (s) -> settingsView = s
+
+            waits 1
+            runs ->
+              expect(settingsView.activePanel)
+                .toEqual name: 'System', options: uri: 'atom://config/system'
+              expect(focusIsWithinActivePanel()).toBe true
+              expectActivePanelToBeKeyboardScrollable()
 
       it "opens the package settings view with atom://config/packages/<package-name>", ->
         waitsForPromise ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Investigating pretty persistent failures of #976.

See #1027 for the previous PR.