### PR TITLE
[enhancement] Derive 'Report Issue' URI from bugs property

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -50,7 +50,7 @@ export default class PackageDetailView {
 
     const issueButtonClickHandler = (event) => {
       event.preventDefault()
-      var bugUri = this.packageManager.getRepositoryBugUri(this.pack)
+      const bugUri = this.packageManager.getRepositoryBugUri(this.pack)
       if (bugUri) {
         shell.openExternal(bugUri)
       }

--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -50,9 +50,9 @@ export default class PackageDetailView {
 
     const issueButtonClickHandler = (event) => {
       event.preventDefault()
-      const repoUrl = this.packageManager.getRepositoryUrl(this.pack)
-      if (repoUrl) {
-        shell.openExternal(`${repoUrl}/issues/new`)
+      var bugUri = this.packageManager.getRepositoryBugUri(this.pack)
+      if (bugUri) {
+        shell.openExternal(bugUri)
       }
     }
     this.refs.issueButton.addEventListener('click', issueButtonClickHandler)

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -432,6 +432,13 @@ class PackageManager
       repoUrl = "https://github.com/#{repoName}"
     repoUrl.replace(/\.git$/, '').replace(/\/+$/, '').replace(/^git\+/, '')
 
+  getRepositoryBugUri: ({metadata}) ->
+    {bugs} = metadata
+    bugUri = bugs ?.url ? bugs ?.email ? this.getRepositoryUrl({metadata}) + '/issues/new'
+    if bugUri.includes('@')
+      bugUri = 'mailto:' + bugUri
+    bugUri
+
   checkNativeBuildTools: ->
     new Promise (resolve, reject) =>
       apmProcess = @runCommand ['install', '--check'], (code, stdout, stderr) ->


### PR DESCRIPTION
### Description of the Change

use a new method ```getRepositoryBugUri()``` that does read from the package.json [bugs property](https://docs.npmjs.com/files/package.json#bugs).

### Benefits

closes #966 (repos without github bug tracking can now link to alternatives)