### PR TITLE
Display search results in order returned from apm

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -211,7 +211,8 @@ class AtomIoClient
           reject(error)
         else
           resolve(
-            body.filter (pack) ->
-              pack.releases?.latest?.map ({readme, metadata, downloads, stargazers_count}) ->
+            body
+              .filter (pack) -> pack.releases?.latest?
+              .map ({readme, metadata, downloads, stargazers_count}) ->
                 Object.assign metadata, {readme, downloads, stargazers_count}
           )

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -208,11 +208,10 @@ class AtomIoClient
         if err
           error = new Error("Searching for \u201C#{query}\u201D failed.")
           error.stderr = err.message
-          reject error
+          reject(error)
         else
           resolve(
-            body.filter (pkg) -> pkg.releases?.latest?
-                .map ({readme, metadata, downloads, stargazers_count}) ->
-                  Object.assign metadata, {readme, downloads, stargazers_count}
-                .sort (a, b) -> b.downloads - a.downloads
+            body.filter (pack) ->
+              pack.releases?.latest?.map ({readme, metadata, downloads, stargazers_count}) ->
+                Object.assign metadata, {readme, downloads, stargazers_count}
           )

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -214,37 +214,14 @@ export default class InstallPanel {
       this.refs.resultsContainer.innerHTML = ''
       this.refs.searchMessage.style.display = 'none'
       if (packages.length === 0) {
-        this.showNoResultMessage(query)
+        this.refs.searchMessage.textContent = `No ${this.searchType.replace(/s$/, '')} results for \u201C${query}\u201D`
+        this.refs.searchMessage.style.display = ''
       }
-      this.highlightExactMatch(this.refs.resultsContainer, query, packages)
-      this.addCloseMatches(this.refs.resultsContainer, query, packages)
+
       this.addPackageViews(this.refs.resultsContainer, packages)
     } catch (error) {
       this.refs.searchMessage.style.display = 'none'
       this.refs.searchErrors.appendChild(new ErrorView(this.packageManager, error).element)
-    }
-  }
-
-  showNoResultMessage (query) {
-    this.refs.searchMessage.textContent = `No ${this.searchType.replace(/s$/, '')} results for \u201C${query}\u201D`
-    this.refs.searchMessage.style.display = ''
-  }
-
-  highlightExactMatch (container, query, packages) {
-    const exactMatch = packages.filter(pkg => pkg.name.toLowerCase() === query)[0]
-
-    if (exactMatch) {
-      this.addPackageCardView(container, this.getPackageCardView(exactMatch))
-      packages.splice(packages.indexOf(exactMatch), 1)
-    }
-  }
-
-  addCloseMatches (container, query, packages) {
-    const matches = packages.filter(pkg => pkg.name.toLowerCase().indexOf(query) >= 0)
-
-    for (let pack of matches) {
-      this.addPackageCardView(container, this.getPackageCardView(pack))
-      packages.splice(packages.indexOf(pack), 1)
     }
   }
 

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -59,29 +59,16 @@ describe 'InstallPanel', ->
       expect(@panel.search.callCount).toBe 3
 
   describe "searching packages", ->
-    it "highlights exact name matches", ->
-      spyOn(@panel.client, 'search').andCallFake ->
-        new Promise (resolve, reject) -> resolve([ {name: 'not-first'}, {name: 'first'} ])
+    it "displays the packages in the order returned", ->
+      spyOn(@panel.client, 'search').andCallFake -> Promise.resolve([{name: 'not-first'}, {name: 'first'}])
       spyOn(@panel, 'getPackageCardView').andCallThrough()
 
       waitsForPromise =>
         @panel.search('first')
 
       runs ->
-        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'first'
-        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'not-first'
-
-    it "prioritizes partial name matches", ->
-      spyOn(@panel.client, 'search').andCallFake ->
-        new Promise (resolve, reject) -> resolve([ {name: 'something else'}, {name: 'partial name match'} ])
-      spyOn(@panel, 'getPackageCardView').andCallThrough()
-
-      waitsForPromise =>
-        @panel.search('match')
-
-      runs ->
-        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'partial name match'
-        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'something else'
+        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'not-first'
+        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'first'
 
   describe "searching git packages", ->
     beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR removes the custom sorting logic that the setting-view performs after getting search results from apm.  My reasoning is that with the [recent changes](https://github.com/atom/settings-view/issues/984#issuecomment-354875049) to apm's sorting we should no longer need to add extra sorting in settings-view.  This also means that the search results will be consistent regardless of whether the search was executed through settings-view, apm, or https://atom.io/packages/search.

### Alternate Designs

None.

### Benefits

Removal of code that had minimum benefits as well as consistency with other search methods.

### Possible Drawbacks

It is possible that some people might prefer the custom sorting settings-view did.

### Applicable Issues

None.

/cc @Ingramz do you have any opinions about this?