### PR TITLE
always open existing setting item in 'settings-view:open' command

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,11 +26,11 @@ module.exports = {
   activate() {
     atom.workspace.addOpener(uri => {
       if (uri.startsWith(CONFIG_URI)) {
-        if (settingsView && !settingsView.destroyed) {
+        if (settingsView == null || settingsView.destroyed) {
+          settingsView = this.createSettingsView({uri})
+        } else {
           const pane = atom.workspace.paneForItem(settingsView)
           if (pane) pane.activate()
-        } else {
-          settingsView = this.createSettingsView({uri})
         }
 
         settingsView.showPanelForURI(uri)

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,7 +44,10 @@ module.exports = {
   activate() {
     atom.workspace.addOpener(uri => {
       if (uri.startsWith(CONFIG_URI)) {
-        if (settingsView == null || settingsView.destroyed) {
+        if (settingsView && !settingsView.destroyed) {
+          const pane = atom.workspace.paneForItem(settingsView)
+          if (pane) pane.activate()
+        } else {
           settingsView = this.createSettingsView({uri})
         }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,24 +11,6 @@ const SnippetsProvider = {
 }
 
 const CONFIG_URI = 'atom://config'
-const uriRegex = /config\/([a-z]+)\/?([a-zA-Z0-9_-]+)?/i
-
-const openPanel = (settingsView, panelName, uri) => {
-  const match = uriRegex.exec(uri)
-
-  const options = {uri}
-  if (match) {
-    const panel = match[1]
-    const detail = match[2]
-    if (panel === 'packages' && detail != null) {
-      panelName = detail
-      options.pack = {name: detail}
-      if (atom.packages.getLoadedPackage(detail)) options.back = 'Packages'
-    }
-  }
-
-  settingsView.showPanel(panelName, options)
-}
 
 module.exports = {
   handleURI(parsed) {
@@ -51,12 +33,7 @@ module.exports = {
           settingsView = this.createSettingsView({uri})
         }
 
-        const match = uriRegex.exec(uri)
-        if (match) {
-          let panelName = match[1]
-          panelName = panelName[0].toUpperCase() + panelName.slice(1)
-          openPanel(settingsView, panelName, uri)
-        }
+        settingsView.showPanelForURI(uri)
         return settingsView
       }
     })

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -301,17 +301,19 @@ export default class SettingsView {
     const match = regex.exec(uri)
 
     if (match) {
-      let panelName = match[1]
-      panelName = panelName[0].toUpperCase() + panelName.slice(1)
+      const path1 = match[1]
+      const path2 = match[2]
 
-      const options = {uri}
-      if (panelName === 'Packages' && match[2] != null) {
-        const packageName = match[2]
-        panelName = packageName
-        options.pack = {name: packageName}
-        if (atom.packages.getLoadedPackage(packageName)) options.back = 'Packages'
+      if (path1 === "packages" && path2 != null) {
+        this.showPanel(path2, {
+          uri: uri,
+          pack: {name: path2},
+          back: atom.packages.getLoadedPackage(path2) ? "Packages" : null
+        })
+      } else {
+        const panelName = path1[0].toUpperCase() + path1.slice(1)
+        this.showPanel(panelName, {uri})
       }
-      this.showPanel(panelName, options)
     }
   }
 

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -296,6 +296,25 @@ export default class SettingsView {
     }
   }
 
+  showPanelForURI (uri) {
+    const regex = /config\/([a-z]+)\/?([a-zA-Z0-9_-]+)?/i
+    const match = regex.exec(uri)
+
+    if (match) {
+      let panelName = match[1]
+      panelName = panelName[0].toUpperCase() + panelName.slice(1)
+
+      const options = {uri}
+      if (panelName === 'Packages' && match[2] != null) {
+        const packageName = match[2]
+        panelName = packageName
+        options.pack = {name: packageName}
+        if (atom.packages.getLoadedPackage(packageName)) options.back = 'Packages'
+      }
+      this.showPanel(panelName, options)
+    }
+  }
+
   appendPanel (panel, options) {
     for (let i = 0; i < this.refs.panels.children.length; i++) {
       this.refs.panels.children[i].style.display = 'none'

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -304,11 +304,11 @@ export default class SettingsView {
       const path1 = match[1]
       const path2 = match[2]
 
-      if (path1 === "packages" && path2 != null) {
+      if (path1 === 'packages' && path2 != null) {
         this.showPanel(path2, {
           uri: uri,
           pack: {name: path2},
-          back: atom.packages.getLoadedPackage(path2) ? "Packages" : null
+          back: atom.packages.getLoadedPackage(path2) ? 'Packages' : null
         })
       } else {
         const panelName = path1[0].toUpperCase() + path1.slice(1)

--- a/spec/settings-view-spec.coffee
+++ b/spec/settings-view-spec.coffee
@@ -141,6 +141,31 @@ describe "SettingsView", ->
             expect(atom.workspace.getActivePaneItem().activePanel)
               .toEqual name: 'Core', options: {}
 
+        it "always open existing item in workspace", ->
+          center = atom.workspace.getCenter()
+          [pane1, pane2] = []
+
+          waitsForPromise -> atom.workspace.open(null, split: 'right')
+          runs ->
+            expect(center.getPanes()).toHaveLength(2)
+            [pane1, pane2] = center.getPanes()
+            expect(atom.workspace.getActivePane()).toBe(pane2)
+
+          openWithCommand('settings-view:open')
+
+          runs ->
+            expect(atom.workspace.getActivePaneItem().activePanel).toEqual name: 'Core', options: {}
+            expect(atom.workspace.getActivePane()).toBe(pane2)
+
+          runs ->
+            pane1.activate()
+
+          openWithCommand('settings-view:open')
+
+          runs ->
+            expect(atom.workspace.getActivePaneItem().activePanel).toEqual name: 'Core', options: {}
+            expect(atom.workspace.getActivePane()).toBe(pane2)
+
       describe "settings-view:core", ->
         it "opens the core settings view", ->
           openWithCommand('settings-view:editor')


### PR DESCRIPTION
Fix #723

### Description of the Change

Condition #723 happens is

- When workspace have two or more panes and setting-view is already opened in currently not active pane.
- User invoke `settings-view:open`(it try to open `atom://config`)

Why happens is
- `atom.worksace.open` try to open already opened `setting-view` item also in different pane

### Changes

- If setting-view is already opened in workspace, activate it's pane in opener so that `workspace.open` always open already opened item in workpace.
- This hacky help is necessary since **singleton settingView** item is opened as **different URI**(workpace.open cannot open existing seting-view item by URI). 
- It eventually simulate `searchAllPanes: true` option in `workspace.open`.

Plus(I can remove this refactoring part if requested)
- Add `SettingsView::showPanelForURI` method which open matching URI's panel

Background investigation why I chose this approach is explained in https://github.com/atom/settings-view/issues/723#issuecomment-360067800.

### Alternate Designs

Currently settingsView is singleton.
Quit singleton and instantiate settingsView always is another solution.
As a result user can open multiple settingsView on every pane like one file can open in multiple editors.
But I think this is too much/big change.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

User no loner see exception
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Nothing
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#723

<!-- Enter any applicable Issues here -->
