### PR TITLE
Invalidate cached pkg detail panel  on activate/deactivate package

### DIFF
--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -36,7 +36,19 @@ export default class SettingsView {
       'core:move-to-top': () => { this.scrollToTop() },
       'core:move-to-bottom': () => { this.scrollToBottom() }
     }))
+
+    this.disposables.add(atom.packages.onDidActivateInitialPackages(() => {
+      this.disposables.add(
+        atom.packages.onDidActivatePackage(pack => this.removePanelCache(pack.name)),
+        atom.packages.onDidDeactivatePackage(pack => this.removePanelCache(pack.name))
+      )
+    }))
+
     process.nextTick(() => this.initializePanels())
+  }
+
+  removePanelCache (name) {
+    delete this.panelsByName[name]
   }
 
   update () {}
@@ -212,33 +224,20 @@ export default class SettingsView {
   }
 
   getOrCreatePanel (name, options) {
-    let panel = this.panelsByName ? this.panelsByName[name] : null
-    // These nested conditionals are not great but I feel like it's the most
-    // expedient thing to do - I feel like the "right way" involves refactoring
-    // this whole file.
-    if (!panel) {
-      let callback = this.panelCreateCallbacks ? this.panelCreateCallbacks[name] : null
+    let panel = this.panelsByName[name]
+    if (panel) return panel
 
-      if (options && options.pack && !callback) {
-        callback = () => {
-          if (!options.pack.metadata) {
-            const metadata = _.clone(options.pack)
-            options.pack.metadata = metadata
-          }
-          return new PackageDetailView(options.pack, this, this.packageManager, this.snippetsProvider)
-        }
+    if (name in this.panelCreateCallbacks) {
+      panel = this.panelCreateCallbacks[name]()
+      delete this.panelCreateCallbacks[name]
+    } else if (options && options.pack) {
+      if (!options.pack.metadata) {
+        options.pack.metadata = _.clone(options.pack)
       }
-
-      if (callback) {
-        panel = callback()
-        if (this.panelsByName == null) {
-          this.panelsByName = {}
-        }
-        this.panelsByName[name] = panel
-        if (this.panelCreateCallbacks) {
-          delete this.panelCreateCallbacks[name]
-        }
-      }
+      panel = new PackageDetailView(options.pack, this, this.packageManager, this.snippetsProvider)
+    }
+    if (panel) {
+      this.panelsByName[name] = panel
     }
 
     return panel

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -190,7 +190,7 @@ export default class SettingsView {
     return this.packages
   }
 
-  addCorePanel (name, iconName, panel) {
+  addCorePanel (name, iconName, panelCreateCallback) {
     const panelMenuItem = document.createElement('li')
     panelMenuItem.name = name
     panelMenuItem.setAttribute('name', name)
@@ -201,7 +201,7 @@ export default class SettingsView {
     panelMenuItem.appendChild(a)
 
     this.refs.menuSeparator.parentElement.insertBefore(panelMenuItem, this.refs.menuSeparator)
-    this.addPanel(name, panel)
+    this.addPanel(name, panelCreateCallback)
   }
 
   addPanel (name, panelCreateCallback) {

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -24,6 +24,8 @@ export default class SettingsView {
     this.snippetsProvider = snippetsProvider
     this.deferredPanel = activePanel
     this.destroyed = false
+    this.panelsByName = {}
+    this.panelCreateCallbacks = {}
 
     etch.initialize(this)
     this.disposables = new CompositeDisposable()
@@ -86,7 +88,6 @@ export default class SettingsView {
       return
     }
 
-    this.panelsByName = {}
     const clickHandler = (event) => {
       const target = event.target.closest('.panels-menu li a, .panels-packages li a')
       if (target) {
@@ -207,9 +208,6 @@ export default class SettingsView {
   }
 
   addPanel (name, panelCreateCallback) {
-    if (this.panelCreateCallbacks == null) {
-      this.panelCreateCallbacks = {}
-    }
     this.panelCreateCallbacks[name] = panelCreateCallback
     if (this.deferredPanel && this.deferredPanel.name === name) {
       this.showDeferredPanel()
@@ -317,7 +315,7 @@ export default class SettingsView {
   }
 
   removePanel (name) {
-    const panel = this.panelsByName ? this.panelsByName[name] : null
+    const panel = this.panelsByName[name]
     if (panel) {
       panel.destroy()
       delete this.panelsByName[name]

--- a/lib/settings-view.js
+++ b/lib/settings-view.js
@@ -15,7 +15,6 @@ import ThemesPanel from './themes-panel'
 import InstalledPackagesPanel from './installed-packages-panel'
 import UpdatesPanel from './updates-panel'
 import UriHandlerPanel from './uri-handler-panel'
-import PackageManager from './package-manager'
 
 export default class SettingsView {
   constructor ({uri, packageManager, snippetsProvider, activePanel} = {}) {
@@ -103,7 +102,6 @@ export default class SettingsView {
     this.element.addEventListener('focus', focusHandler)
     this.disposables.add(new Disposable(() => this.element.removeEventListener('focus', focusHandler)))
 
-
     const openDotAtomClickHandler = () => {
       atom.open({pathsToOpen: [atom.getConfigDirPath()]})
     }
@@ -148,7 +146,6 @@ export default class SettingsView {
 
   getPackages () {
     let bundledPackageMetadataCache
-    let left
     if (this.packages != null) { return this.packages }
 
     this.packages = atom.packages.getLoadedPackages()


### PR DESCRIPTION
### Requirements

### Description of the Change

Fix #1003

- Invalidate `PackageDetailView` panel cache kept in `this.panelsByName[pkgName]` on activating/deactivating package.
  - Original issue #1003 was happened by returning cached panel.
- Includes some cleanup
  - Remove unused variables/ library require
  - Quit awkward conditional initialization of instance variable

### Alternate Designs

Ideally setting-vew should refresh pkg detail-view on clicking "Enable", "Disable" timing, but that improvement should come as different PR.

### Benefits

Enabling/Disabling package from setting-view and accessing setting menu is more intuitive.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Nothing.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#1003
<!-- Enter any applicable Issues here -->

![setting-view](https://user-images.githubusercontent.com/155205/35481639-d0d8a9fe-046a-11e8-857f-4561b1eaaa3f.gif)


