### PR TITLE
add 'description' for object setting

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -590,6 +590,11 @@ function elementForObject (namespace, name, value) {
     h3.textContent = getSettingTitle(keyPath, name)
     section.appendChild(h3)
 
+    const descriptionDiv = document.createElement('div')
+    descriptionDiv.classList.add('setting-description')
+    descriptionDiv.innerHTML = getSettingDescription(keyPath)
+    section.appendChild(descriptionDiv);
+
     const div = document.createElement('div')
     div.classList.add('sub-section-body')
     for (const key of sortSettings(keyPath, value)) {

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -163,6 +163,7 @@ describe "SettingsPanel", ->
           barGroup:
             type: 'object'
             title: 'Bar group'
+            description: 'description of bar group'
             properties:
               bar:
                 title: 'Bar'
@@ -214,6 +215,13 @@ describe "SettingsPanel", ->
       expect(controlGroups[1].querySelector('.sub-section .sub-section-heading').classList.contains('has-items')).toBe true
       # Should be already collapsed
       expect(controlGroups[1].querySelector('.sub-section .sub-section-heading').parentElement.classList.contains('collapsed')).toBe true
+
+    it 'ensures grouped settings can have a description', ->
+      expect(settingsPanel.element.querySelectorAll('.section-container > .section-body')).toHaveLength 1
+      controlGroups = settingsPanel.element.querySelectorAll('.section-body > .control-group')
+      expect(controlGroups).toHaveLength 3
+      expect(controlGroups[0].querySelectorAll('.sub-section > .setting-description')).toHaveLength 1
+      expect(controlGroups[0].querySelector('.sub-section > .setting-description').textContent).toBe 'description of bar group'
 
   describe 'settings validation', ->
     beforeEach ->


### PR DESCRIPTION
### Description of the Change

This PR adds a description to configurations of type 'object'.

Currently a 'description' for a configuration of type 'object' is ignored.  This is problematic because objects allow for a grouping or subset of options which may need a description applying to all of them.  Without the object description field, settings under a scope are forced to repeatedly describe something. 

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

No alternate designs were considered.  I figured this was a straight forward change and I honestly have no clue what an alternate solution could even be.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- Removes the need to repeat descriptions for object properties [such as these](https://github.com/olsonpm/prettier-atom/blob/permalink-for-pr/src/config-schema.json#L180-L276)
  *Note: the above link contains a repetitive note inside each scoped config description*
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

- Due to poor nested object UI, a description for a nested property of type 'object' will not visually be understood as applying to its scoped configurations.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

fixes #857
<!-- Enter any applicable Issues here -->
