### PR TITLE
fix(restart-notification): undefined latestVersion

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -211,7 +211,22 @@ export default class PackageCard {
           text: 'Restart',
           onDidClick () { return atom.restartApplication() }
         }]
-        const detail = `${this.pack.version} -> ${this.pack.latestVersion}`
+
+        let oldVersion = ''
+        let newVersion = ''
+
+        if (this.pack.apmInstallSource && this.pack.apmInstallSource.type === 'git') {
+          oldVersion = this.pack.apmInstallSource.sha.substr(0, 8)
+          newVersion = `${this.pack.latestSha.substr(0, 8)}`
+        } else if (this.pack.version && this.pack.latestVersion) {
+          oldVersion = this.pack.version
+          newVersion = this.pack.latestVersion
+        }
+
+        let detail = ''
+        if (oldVersion && newVersion) {
+          detail = `${oldVersion} -> ${newVersion}`
+        }
 
         atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
           dismissable: true, buttons, detail

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -174,7 +174,20 @@ export default class UpdatesPanel {
           const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralizedPackages}:`
           let detail = ''
           this.packageCards.forEach((card) => {
-            detail += `${card.pack.name}@${card.pack.version} -> ${card.pack.latestVersion}\n`
+            let oldVersion = ''
+            let newVersion = ''
+
+            if (card.pack.apmInstallSource && card.pack.apmInstallSource.type === 'git') {
+              oldVersion = card.pack.apmInstallSource.sha.substr(0, 8)
+              newVersion = `${card.pack.latestSha.substr(0, 8)}`
+            } else if (card.pack.version && card.pack.latestVersion) {
+              oldVersion = card.pack.version
+              newVersion = card.pack.latestVersion
+            }
+
+            if (oldVersion && newVersion) {
+              detail += `${card.pack.name}@${oldVersion} -> ${newVersion}\n`
+            }
           });
           detail.trim()
 

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -189,7 +189,7 @@ export default class UpdatesPanel {
               detail += `${card.pack.name}@${oldVersion} -> ${newVersion}\n`
             }
           });
-          detail.trim()
+          detail = detail.trim()
 
           const buttons = [{
             text: 'Restart',

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -209,7 +209,7 @@ export default class UpdatesPanel {
         if (oldVersion && newVersion) {
           detail += `${card.pack.name}@${oldVersion} -> ${newVersion}\n`
         }
-      });
+      })
       detail = detail.trim()
 
       const buttons = [{

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -70,6 +70,10 @@ describe 'UpdatesPanel', ->
 
       [cardA, cardB, cardC] = panel.packageCards
 
+      # fake a git url package
+      cardC.pack.apmInstallSource = {type: 'git', sha: 'cf23df2207d99a74fbe169e3eba035e633b65d94'}
+      cardC.pack.latestSha = 'a296114f3d0deec519a41f4c62e7fc56075b7f01'
+
       spyOn(cardA, 'update').andReturn(new Promise((resolve, reject) -> [resolveA, rejectA] = [resolve, reject]))
       spyOn(cardB, 'update').andReturn(new Promise((resolve, reject) -> [resolveB, rejectB] = [resolve, reject]))
       spyOn(cardC, 'update').andReturn(new Promise((resolve, reject) -> [resolveC, rejectC] = [resolve, reject]))
@@ -93,6 +97,7 @@ describe 'UpdatesPanel', ->
       runs ->
         notifications = atom.notifications.getNotifications()
         expect(notifications.length).toBe 1
+        expect(notifications[0].options.detail).toBe 'test-package-a@1.0.0 -> 99.0.0\ntest-package-b@1.0.0 -> 99.0.0\ntest-package-c@cf23df22 -> a296114f'
 
         spyOn(atom, 'restartApplication')
         notifications[0].options.buttons[0].onDidClick()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -95,14 +95,16 @@ describe 'UpdatesPanel', ->
 
         resolveC()
 
-      waits 0
+      waitsFor (done) ->
+        atom.notifications.onDidAddNotification(done)
+
       runs ->
         notifications = atom.notifications.getNotifications()
         expect(notifications.length).toBe 1
         expect(notifications[0].options.detail).toBe 'test-package-a@1.0.0 -> 99.0.0\ntest-package-b@1.0.0 -> 99.0.0\ntest-package-c@cf23df22 -> a296114f'
 
         spyOn(atom, 'restartApplication')
-        atom.notifications.getNotifications()[0].options.buttons[0].onDidClick()
+        notifications[0].options.buttons[0].onDidClick()
         expect(atom.restartApplication).toHaveBeenCalled()
 
     it 'works with queue enabled', ->


### PR DESCRIPTION
### Description of the Change

When installing a package from [git url](https://github.com/atom/apm/pull/518) this [bug](https://github.com/atom/settings-view/issues/1056) occurs on the first update.
The second update shouldn't be affected because the package gets convertet from git style to normal as part of the update.

This PR makes the code for the detail message more robust and adds sha's for git packages:

![git-packages](https://user-images.githubusercontent.com/19377375/38202108-e5df2082-369a-11e8-9758-cb327f972401.png)
![git-packages2](https://user-images.githubusercontent.com/19377375/38202110-e7a7cf86-369a-11e8-86f9-a53f11a5b521.png)

closes: #1056

To reproduce the bug reset a git package:
1. `apm install thomaslindstrom/color-picker`
2. `cd ~/.atom/packages/color-picker`
3. `g stash`
4. `g reset --hard a296114f3d0deec519a41f4c62e7fc56075b7f01`
5. `g stash pop`
6. replace the sha in `package.json`

Btw. what is the point of having git packages in the first place, when we convert them after the first update?
