### PR TITLE
Merge Packages/Themes installation from Install to respective panels

### DIFF
--- a/lib/installed-packages-panel.js
+++ b/lib/installed-packages-panel.js
@@ -23,6 +23,8 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
     etch.initialize(this)
     this.settingsView = settingsView
     this.packageManager = packageManager
+    this.client = this.packageManager.getClient()
+    this.searchType = 'installed'
     this.items = {
       dev: new List('name'),
       core: new List('name'),
@@ -39,11 +41,14 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
     }
 
     this.subscriptions = new CompositeDisposable()
-    this.subscriptions.add(
-      this.refs.filterEditor.onDidStopChanging(() => { this.matchPackages() })
+    // this.subscriptions.add(
+    //   this.refs.filterEditor.onDidStopChanging(() => { this.matchPackages() })
+    // )
+    this.subscriptions.add(atom.commands.add(
+      this.refs.filterEditor.element, 'core:confirm', () => { this.matchPackages() })
     )
     this.subscriptions.add(
-      this.packageManager.on('package-install-failed theme-install-failed package-uninstall-failed theme-uninstall-failed package-update-failed theme-update-failed', ({pack, error}) => {
+      this.packageManager.on('package-install-failed package-uninstall-failed package-update-failed', ({pack, error}) => {
         this.refs.updateErrors.appendChild(new ErrorView(this.packageManager, error).element)
       })
     )
@@ -87,18 +92,27 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
   render () {
     return (
       <div className='panels-item' tabIndex="-1">
-        <section className='section'>
+        <div className='section packages'>
           <div className='section-container'>
             <div className='section-heading icon icon-package'>
-              Installed Packages
+              <span ref='installHeading'>Installed Packages</span>
               <span ref='totalPackages' className='section-heading-count badge badge-flexible'>…</span>
             </div>
-            <div className='editor-container'>
-              <TextEditor ref='filterEditor' mini={true} placeholderText='Filter packages by name' />
+            <div className='search-container clearfix'>
+              <div className='editor-container'>
+                <TextEditor ref='filterEditor' mini={true} placeholderText='Search packages' />
+              </div>
+              <div className='btn-group'>
+                <button ref='searchInstalledPackagesButton' className='btn btn-default selected' onclick={this.didClickInstalledPackagesButton.bind(this)}>Installed</button>
+                <button ref='searchDiscoverPackagesButton' className='btn btn-default' onclick={this.didClickDiscoverPackagesButton.bind(this)}>Discover</button>
+              </div>
             </div>
 
             <div ref='updateErrors'></div>
-
+          </div>
+        </div>
+        <div ref='installedPackages' className='section packages'>
+          <div className='section-container'>
             <section ref='deprecatedSection' className='sub-section deprecated-packages'>
               <h3 ref='deprecatedPackagesHeader' className='sub-section-heading icon icon-package'>
                 Deprecated Packages
@@ -150,7 +164,17 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
               </div>
             </section>
           </div>
-        </section>
+        </div>
+        <div ref='discoverPackages' className='section packages' style={{display: 'none'}}>
+          <div className='section-container'>
+            <div ref='discoverHeading' className='section-heading icon icon-star'>
+              Featured Packages
+            </div>
+            <div ref='resultErrors' />
+            <div ref='loadingMessage' className='alert alert-info icon icon-hourglass' />
+            <div ref='resultsContainer' className='container package-container' />
+          </div>
+        </div>
       </div>
     )
   }
@@ -228,6 +252,28 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
     })
   }
 
+  // Load and display the featured packages that are available to install.
+  loadFeaturedPackages () {
+    this.refs.resultsContainer.innerHTML = ''
+
+    this.refs.loadingMessage.textContent = 'Loading featured packages\u2026'
+    this.refs.loadingMessage.style.display = ''
+
+    const handle = error => {
+      this.refs.loadingMessage.style.display = 'none'
+      this.refs.resultErrors.appendChild(new ErrorView(this.packageManager, error).element)
+    }
+
+    this.client.featuredPackages((error, packages) => {
+      if (error) {
+        handle(error)
+      } else {
+        this.refs.loadingMessage.style.display = 'none'
+        this.addPackageViews(this.refs.resultsContainer, packages)
+      }
+    })
+  }
+
   displayPackageUpdates (packagesWithUpdates) {
     for (const packageType of ['dev', 'core', 'user', 'git', 'deprecated']) {
       for (const packageCard of this.itemViews[packageType].getViews()) {
@@ -237,6 +283,19 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
         }
       }
     }
+  }
+
+  addPackageViews (container, packages) {
+    for (const pack of packages) {
+      this.addPackageCardView(container, this.createPackageCard(pack))
+    }
+  }
+
+  addPackageCardView (container, packageCard) {
+    const packageRow = document.createElement('div')
+    packageRow.classList.add('row')
+    packageRow.appendChild(packageCard.element)
+    container.appendChild(packageRow)
   }
 
   createPackageCard (pack) {
@@ -314,12 +373,64 @@ export default class InstalledPackagesPanel extends CollapsibleSectionPanel {
     this.refs.totalPackages.textContent = `${shownPackages}/${totalPackages}`
   }
 
+  didClickInstalledPackagesButton() {
+    this.refs.discoverPackages.style.display = 'none'
+    this.refs.installedPackages.style.display = 'block'
+    this.refs.searchInstalledPackagesButton.classList.add('selected')
+    this.refs.searchDiscoverPackagesButton.classList.remove('selected')
+    this.refs.installHeading.textContent = 'Installed Packages'
+    this.refs.totalPackages.style.display = 'inline'
+    this.searchType = 'installed'
+  }
+
+  didClickDiscoverPackagesButton() {
+    this.refs.installedPackages.style.display = 'none'
+    this.refs.discoverPackages.style.display = 'block'
+    this.refs.searchDiscoverPackagesButton.classList.add('selected')
+    this.refs.searchInstalledPackagesButton.classList.remove('selected')
+    this.refs.installHeading.textContent = 'Discover Packages'
+    this.refs.totalPackages.style.display = 'none'
+    this.searchType = 'discover'
+    this.loadFeaturedPackages()
+  }
+
   resetSectionHasItems() {
     this.resetCollapsibleSections([this.refs.deprecatedPackagesHeader, this.refs.communityPackagesHeader, this.refs.corePackagesHeader, this.refs.devPackagesHeader, this.refs.gitPackagesHeader])
   }
 
-  matchPackages () {
-    this.filterPackageListByText(this.refs.filterEditor.getText())
+  async matchPackages () {
+    const text = this.refs.filterEditor.getText()
+    if (this.searchType === 'installed') {
+      this.filterPackageListByText(text)
+    } else if (this.searchType === 'discover') {
+      if (text === '') {
+        this.refs.discoverHeading.textContent = "Featured Packages"
+        this.loadFeaturedPackages()
+        return
+      }
+      this.refs.discoverHeading.textContent = "Result Packages"
+      const query = text.toLowerCase()
+      this.refs.resultsContainer.innerHTML = ''
+      this.refs.loadingMessage.textContent = `Searching for \u201C${query}\u201D\u2026`
+      this.refs.loadingMessage.style.display = ''
+
+      const options = {}
+      options['packages'] = true
+
+      try {
+        const packages = (await this.client.search(query, options)) || []
+        this.refs.resultsContainer.innerHTML = ''
+        this.refs.loadingMessage.style.display = 'none'
+        if (packages.length === 0) {
+          this.refs.loadingMessage.style.display = ''
+          this.refs.loadingMessage.textContent = `No ${this.searchType.replace(/s$/, '')} results for \u201C${query}\u201D`
+        }
+        this.addPackageViews(this.refs.resultsContainer, packages)
+      } catch (error) {
+        this.refs.loadingMessage.style.display = 'none'
+        this.refs.resultErrors.appendChild(new ErrorView(this.packageManager, error).element)
+      }
+    }
   }
 
   scrollUp () {

--- a/lib/themes-panel.js
+++ b/lib/themes-panel.js
@@ -25,6 +25,8 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
     this.settingsView = settingsView
     this.packageManager = packageManager
     etch.initialize(this)
+    this.client = this.packageManager.getClient()
+    this.searchType = 'installed'
     this.items = {
       dev: new List('name'),
       core: new List('name'),
@@ -71,7 +73,10 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
     this.disposables.add(atom.tooltips.add(this.refs.activeSyntaxThemeSettings, {title: 'Settings'}))
     this.updateActiveThemes()
 
-    this.disposables.add(this.refs.filterEditor.onDidStopChanging(() => { this.matchPackages() }))
+    // this.disposables.add(this.refs.filterEditor.onDidStopChanging(() => { this.matchPackages() }))
+    this.disposables.add(atom.commands.add(
+      this.refs.filterEditor.element, 'core:confirm', () => { this.matchPackages() })
+    )
   }
 
   update () {}
@@ -137,59 +142,76 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
           </div>
         </div>
 
-        <section className='section'>
+        <div className='section packages'>
           <div className='section-container'>
             <div className='section-heading icon icon-paintcan'>
-              Installed Themes
+              <span ref='installHeading'>Installed Themes</span>
               <span ref='totalPackages' className='section-heading-count badge badge-flexible'>…</span>
             </div>
-            <div className='editor-container'>
-              <TextEditor ref='filterEditor' mini={true} placeholderText='Filter themes by name' />
+            <div className='search-container clearfix'>
+              <div className='editor-container'>
+                <TextEditor ref='filterEditor' mini={true} placeholderText='Search themes' />
+              </div>
+              <div className='btn-group'>
+                <button ref='searchInstalledThemesButton' className='btn btn-default selected' onclick={this.didClickInstalledThemesButton.bind(this)}>Installed</button>
+                <button ref='searchDiscoverThemesButton' className='btn btn-default' onclick={this.didClickDiscoverThemesButton.bind(this)}>Discover</button>
+              </div>
             </div>
 
             <div ref='themeErrors'></div>
-
-            <section className='sub-section installed-packages'>
-              <h3 ref='communityThemesHeader' className='sub-section-heading icon icon-paintcan'>
-                Community Themes
-                <span ref='communityCount' className='section-heading-count badge badge-flexible'>…</span>
-              </h3>
-              <div ref='communityPackages' className='container package-container'>
-                <div ref='communityLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
-              </div>
-            </section>
-
-            <section className='sub-section core-packages'>
-              <h3 ref='coreThemesHeader' className='sub-section-heading icon icon-paintcan'>
-                Core Themes
-                <span ref='coreCount' className='section-heading-count badge badge-flexible'>…</span>
-              </h3>
-              <div ref='corePackages' className='container package-container'>
-                <div ref='coreLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
-              </div>
-            </section>
-
-            <section className='sub-section dev-packages'>
-              <h3 ref='developmentThemesHeader' className='sub-section-heading icon icon-paintcan'>
-                Development Themes
-                <span ref='devCount' className='section-heading-count badge badge-flexible'>…</span>
-              </h3>
-              <div ref='devPackages' className='container package-container'>
-                <div ref='devLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
-              </div>
-            </section>
-
-            <section className='sub-section git-packages'>
-              <h3 ref='gitThemesHeader' className='sub-section-heading icon icon-paintcan'>
-                Git Themes
-                <span ref='gitCount' className='section-heading-count badge badge-flexible'>…</span>
-              </h3>
-              <div ref='gitPackages' className='container package-container'>
-                <div ref='gitLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
-              </div>
-            </section>
           </div>
-        </section>
+        </div>
+        <div ref='installedThemes' className='section packages'>
+          <section className='sub-section installed-packages'>
+            <h3 ref='communityThemesHeader' className='sub-section-heading icon icon-paintcan'>
+              Community Themes
+              <span ref='communityCount' className='section-heading-count badge badge-flexible'>…</span>
+            </h3>
+            <div ref='communityPackages' className='container package-container'>
+              <div ref='communityLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
+            </div>
+          </section>
+
+          <section className='sub-section core-packages'>
+            <h3 ref='coreThemesHeader' className='sub-section-heading icon icon-paintcan'>
+              Core Themes
+              <span ref='coreCount' className='section-heading-count badge badge-flexible'>…</span>
+            </h3>
+            <div ref='corePackages' className='container package-container'>
+              <div ref='coreLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
+            </div>
+          </section>
+
+          <section className='sub-section dev-packages'>
+            <h3 ref='developmentThemesHeader' className='sub-section-heading icon icon-paintcan'>
+              Development Themes
+              <span ref='devCount' className='section-heading-count badge badge-flexible'>…</span>
+            </h3>
+            <div ref='devPackages' className='container package-container'>
+              <div ref='devLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
+            </div>
+          </section>
+
+          <section className='sub-section git-packages'>
+            <h3 ref='gitThemesHeader' className='sub-section-heading icon icon-paintcan'>
+              Git Themes
+              <span ref='gitCount' className='section-heading-count badge badge-flexible'>…</span>
+            </h3>
+            <div ref='gitPackages' className='container package-container'>
+              <div ref='gitLoadingArea' className='alert alert-info loading-area icon icon-hourglass'>Loading themes…</div>
+            </div>
+          </section>
+        </div>
+        <div ref='discoverThemes' className='section packages' style={{display: 'none'}}>
+          <div className='section-container'>
+            <div ref='discoverHeading' className='section-heading icon icon-star'>
+              Featured Themes
+            </div>
+            <div ref='resultErrors' />
+            <div ref='loadingMessage' className='alert alert-info icon icon-hourglass' />
+            <div ref='resultsContainer' className='container package-container' />
+          </div>
+        </div>
       </div>
     )
   }
@@ -244,6 +266,28 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
       this.updateSectionCounts()
     }).catch((error) => {
       this.refs.themeErrors.appendChild(new ErrorView(this.packageManager, error).element)
+    })
+  }
+
+  // Load and display the featured packages that are available to install.
+  loadFeaturedPackages () {
+    this.refs.resultsContainer.innerHTML = ''
+
+    this.refs.loadingMessage.textContent = 'Loading featured themes\u2026'
+    this.refs.loadingMessage.style.display = ''
+
+    const handle = error => {
+      this.refs.loadingMessage.style.display = 'none'
+      this.refs.featuredErrors.appendChild(new ErrorView(this.packageManager, error).element)
+    }
+
+    this.client.featuredThemes((error, themes) => {
+      if (error) {
+        handle(error)
+      } else {
+        this.refs.loadingMessage.style.display = 'none'
+        this.addPackageViews(this.refs.resultsContainer, themes)
+      }
     })
   }
 
@@ -349,6 +393,19 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
     return new PackageCard(pack, this.settingsView, this.packageManager, {back: 'Themes'})
   }
 
+  addPackageViews (container, packages) {
+    for (const pack of packages) {
+      this.addPackageCardView(container, this.createPackageCard(pack))
+    }
+  }
+
+  addPackageCardView (container, packageCard) {
+    const packageRow = document.createElement('div')
+    packageRow.classList.add('row')
+    packageRow.appendChild(packageCard.element)
+    container.appendChild(packageRow)
+  }
+
   filterPackageListByText (text) {
     if (!this.packages) {
       return
@@ -412,12 +469,64 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
     this.refs.totalPackages.textContent = `${shownThemes}/${totalThemes}`
   }
 
+  didClickInstalledThemesButton() {
+    this.refs.discoverThemes.style.display = 'none'
+    this.refs.installedThemes.style.display = 'block'
+    this.refs.searchInstalledThemesButton.classList.add('selected')
+    this.refs.searchDiscoverThemesButton.classList.remove('selected')
+    this.refs.installHeading.textContent = 'Installed Themes'
+    this.refs.totalPackages.style.display = 'inline'
+    this.searchType = 'installed'
+  }
+
+  didClickDiscoverThemesButton() {
+    this.refs.installedThemes.style.display = 'none'
+    this.refs.discoverThemes.style.display = 'block'
+    this.refs.searchDiscoverThemesButton.classList.add('selected')
+    this.refs.searchInstalledThemesButton.classList.remove('selected')
+    this.refs.installHeading.textContent = 'Discover Themes'
+    this.refs.totalPackages.style.display = 'none'
+    this.searchType = 'discover'
+    this.loadFeaturedPackages()
+  }
+
   resetSectionHasItems () {
     this.resetCollapsibleSections([this.refs.communityThemesHeader, this.refs.coreThemesHeader, this.refs.developmentThemesHeader, this.refs.gitThemesHeader])
   }
 
-  matchPackages () {
-    this.filterPackageListByText(this.refs.filterEditor.getText())
+  async matchPackages () {
+    const text = this.refs.filterEditor.getText()
+    if (this.searchType === 'installed') {
+      this.filterPackageListByText(text)
+    } else if (this.searchType === 'discover') {
+      if (text === '') {
+        this.refs.discoverHeading.textContent = "Featured Themes"
+        this.loadFeaturedPackages()
+        return
+      }
+      this.refs.discoverHeading.textContent = "Result Themes"
+      const query = text.toLowerCase()
+      this.refs.resultsContainer.innerHTML = ''
+      this.refs.loadingMessage.textContent = `Searching for \u201C${query}\u201D\u2026`
+      this.refs.loadingMessage.style.display = ''
+
+      const options = {}
+      options['themes'] = true
+
+      try {
+        const packages = (await this.client.search(query, options)) || []
+        this.refs.resultsContainer.innerHTML = ''
+        this.refs.loadingMessage.style.display = 'none'
+        if (packages.length === 0) {
+          this.refs.loadingMessage.style.display = ''
+          this.refs.loadingMessage.textContent = `No ${this.searchType.replace(/s$/, '')} results for \u201C${query}\u201D`
+        }
+        this.addPackageViews(this.refs.resultsContainer, packages)
+      } catch (error) {
+        this.refs.loadingMessage.style.display = 'none'
+        this.refs.resultErrors.appendChild(new ErrorView(this.packageManager, error).element)
+      }
+    }
   }
 
   didClickOpenUserStyleSheet (e) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR makes several changes to packages and themes, the idea being to eventually remove the Install pane.  The Packages and Themes panes each now has a button group to toggle between `Installed` and `Discover`, the latter being what is currently in the Install pane.

The `Installed` view functions the same as it does today, except that I changed the search to not fire until the Enter/Return key is pressed versus when you stop typing.  Since Installed and Discover share the same search, I went with that so it doesn't do http requests when looking for new packages/themes.  I can change that back and add/remove the subscription/disposable when toggling between the two.

The `Discover` view functions the same as the Install pane does today.  It loads Featured Packages/Themes by default, and searching and hitting Enter/Return does a search.  Once you "blank" out the search bar and hit enter, it loads the Featured again, which looks to close #590.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I looked through all of the comments in #825 and incorporated various suggestions into this.

### Benefits

<!-- What benefits will be realized by the code change? -->

A bit cleaner Settings panel, since Install would eventually be removed.  Package and Theme related code, UI and functionality is moved into their respective panes instead of a whole different pane.  More efficient use of space.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There will be confusion as to how you install new packages and themes, especially if the Install pane is removed right away.  If it's not removed right away, perhaps a message can be displayed for a couple of 1.x releases in the Install pane to say it's moving to Packages and Themes.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#590 
#825 