### PR TITLE
Perform search in "Install Panel" automatically after user stops typing

### DIFF
--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -43,10 +43,11 @@ export default class InstallPanel {
         }
       })
     )
-
-    this.disposables.add(atom.commands.add(this.refs.searchEditor.element, 'core:confirm', () => {
-      this.performSearch()
-    }))
+    this.disposables.add(
+      this.refs.searchEditor.onDidStopChanging(() => { 
+        this.performSearch() 
+      })
+    )
     this.disposables.add(atom.commands.add(this.element, {
       'core:move-up': () => { this.scrollUp() },
       'core:move-down': () => { this.scrollDown() },


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When searching packages in the "Packages" section in settings, it searches automatically upon typing ("onDidStopChanging").
This functionality is missing in the "Install" section. Searching should be consistent and more user friendly. When the user finishes typing, it should just search for him.

Example:
![example](https://user-images.githubusercontent.com/7537694/39608129-28e4fb88-4ef4-11e8-97ca-4988207c59e7.gif)

### Alternate Designs

The previous implementation was search by pressing "enter".

### Benefits

A better UX and more consistent experience

### Possible Drawbacks

More network requests

### Applicable Issues

