### PR TITLE
Make sure body was successfully parsed as JSON before filtering

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -205,9 +205,13 @@ class AtomIoClient
 
     new Promise (resolve, reject) ->
       request options, (err, res, body) ->
-        if err
+        # Interestingly, request does not treat failure to parse JSON as an error
+        # and returns the raw HTML instead as a string.
+        # Therefore, make sure the body has been successfully parsed before
+        # trying to filter package results.
+        if err or typeof body isnt 'object'
           error = new Error("Searching for \u201C#{query}\u201D failed.")
-          error.stderr = err.message
+          error.stderr = err?.message ? "Please try again later."
           reject error
         else
           resolve(

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -69,19 +69,23 @@ class AtomIoClient
     options = {
       url: "#{@baseURL}#{path}"
       headers: {'User-Agent': navigator.userAgent}
-      json: true
       gzip: true
     }
 
     request options, (err, res, body) =>
       return callback(err) if err
 
-      delete body.versions
-      cached =
-        data: body
-        createdOn: Date.now()
-      localStorage.setItem(@cacheKeyForPath(path), JSON.stringify(cached))
-      callback(err, cached.data)
+      try
+        body = JSON.parse(body)
+        delete body.versions
+
+        cached =
+          data: body
+          createdOn: Date.now()
+        localStorage.setItem(@cacheKeyForPath(path), JSON.stringify(cached))
+        callback(err, cached.data)
+      catch error
+        callback(error)
 
   cacheKeyForPath: (path) ->
     "settings-view:#{path}"
@@ -199,24 +203,25 @@ class AtomIoClient
       url: "#{@baseURL}packages/search"
       headers: {'User-Agent': navigator.userAgent}
       qs: qs
-      json: true
       gzip: true
     }
 
     new Promise (resolve, reject) ->
       request options, (err, res, body) ->
-        # Interestingly, request does not treat failure to parse JSON as an error
-        # and returns the raw HTML instead as a string.
-        # Therefore, make sure the body has been successfully parsed before
-        # trying to filter package results.
-        if err or typeof body isnt 'object'
+        if err
           error = new Error("Searching for \u201C#{query}\u201D failed.")
-          error.stderr = err?.message ? "Please try again later."
+          error.stderr = err.message
           reject error
         else
-          resolve(
-            body.filter (pkg) -> pkg.releases?.latest?
-                .map ({readme, metadata, downloads, stargazers_count}) ->
-                  Object.assign metadata, {readme, downloads, stargazers_count}
-                .sort (a, b) -> b.downloads - a.downloads
-          )
+          try
+            body = JSON.parse(body)
+            resolve(
+              body.filter (pkg) -> pkg.releases?.latest?
+                  .map ({readme, metadata, downloads, stargazers_count}) ->
+                    Object.assign metadata, {readme, downloads, stargazers_count}
+                  .sort (a, b) -> b.downloads - a.downloads
+            )
+          catch e
+            error = new Error("Searching for \u201C#{query}\u201D failed.")
+            error.stderr = e.message + '\n' + body
+            reject error

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -76,6 +76,8 @@ class AtomIoClient
       return callback(err) if err
 
       try
+        # NOTE: request's json option does not populate err if parsing fails,
+        # so we do it manually
         body = JSON.parse(body)
         delete body.versions
 
@@ -214,6 +216,8 @@ class AtomIoClient
           reject error
         else
           try
+            # NOTE: request's json option does not populate err if parsing fails,
+            # so we do it manually
             body = JSON.parse(body)
             resolve(
               body.filter (pkg) -> pkg.releases?.latest?

--- a/spec/atom-io-client-spec.coffee
+++ b/spec/atom-io-client-spec.coffee
@@ -11,15 +11,29 @@ describe "AtomIoClient", ->
     expect(@client.fetchAndCacheAvatar).not.toHaveBeenCalled()
     @client.avatar 'test-user', ->
 
-  it "fetches api json from cache if the network is unavailable", ->
-    spyOn(@client, 'online').andReturn(false)
-    spyOn(@client, 'fetchFromCache').andCallFake (path, opts, cb) ->
-      cb(null, {})
-    spyOn(@client, 'request')
-    @client.package 'test-package', ->
+  describe "request", ->
+    it "fetches api json from cache if the network is unavailable", ->
+      spyOn(@client, 'online').andReturn(false)
+      spyOn(@client, 'fetchFromCache').andCallFake (path, opts, cb) ->
+        cb(null, {})
+      spyOn(@client, 'request')
+      @client.package 'test-package', ->
 
-    expect(@client.fetchFromCache).toHaveBeenCalled()
-    expect(@client.request).not.toHaveBeenCalled()
+      expect(@client.fetchFromCache).toHaveBeenCalled()
+      expect(@client.request).not.toHaveBeenCalled()
+
+    it "returns an error if the API response is not JSON", ->
+      jsonParse = JSON.parse
+
+      waitsFor (done) ->
+        spyOn(JSON, 'parse').andThrow()
+        @client.request 'path', (error, data) ->
+          expect(error).not.toBeNull()
+          done()
+
+      runs ->
+        # Tests will throw without this as cleanup requires JSON.parse to work
+        JSON.parse = jsonParse
 
   it "handles glob errors", ->
     spyOn(@client, 'avatarGlob').andReturn "#{__dirname}/**"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In #1014, package searches were changed to use the atom.io API endpoint rather than calling out through apm.  As part of that change, parsing of the resulting JSON data was delegated to the `request` module.  Interestingly, `request` [does not throw an error](https://github.com/request/request/blob/a6741d415aba31cd01e9c4544c96f84ea6ed11e3/request.js#L1146-L1152) when it fails to parse the response body as JSON and instead returns the raw body as a string.  The new package search code failed to account for this scenario, which resulted in #1052.

### Alternate Designs

There are a couple of alternate designs:
* Manually invoke `JSON.parse()`, as before
* Check for the status code
* Use a combination of the above and a different library, such as `window.fetch()`

I haven't decided which one to go with yet.

### Benefits

Searching should be more resilient to server errors.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #1052