### PR TITLE
Show enum description as default in tooltip

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -283,8 +283,12 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
 
   bindTooltips () {
     const disposables = Array.from(this.element.querySelectorAll('input[id], select[id], atom-text-editor[id]')).map((element) => {
+      const schema = atom.config.getSchema(element.id)
       let defaultValue = this.valueToString(this.getDefault(element.id))
       if (defaultValue != null) {
+        if (schema.enum && _.findWhere(schema.enum, {value: defaultValue})) {
+          defaultValue = _.findWhere(schema.enum, {value: defaultValue}).description;
+        }
         return atom.tooltips.add(element, {
           title: `Default: ${defaultValue}`,
           delay: {show: 100},

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -76,6 +76,16 @@ describe "SettingsPanel", ->
             description: 'The haz setting'
             type: 'string'
             default: 'haz'
+          qux:
+            name: 'qux'
+            title: 'Qux'
+            description: 'The qux setting'
+            type: 'string'
+            default: 'a'
+            enum: [
+              {value: 'a', description: 'Alice'},
+              {value: 'b', description: 'Bob'}
+            ]
           testZero:
             name: 'testZero'
             title: 'Test Zero'
@@ -84,7 +94,7 @@ describe "SettingsPanel", ->
             default: 0
       atom.config.setSchema("foo", config)
       atom.config.setDefaults("foo", gong: 'gong')
-      expect(_.size(atom.config.get('foo'))).toBe 3
+      expect(_.size(atom.config.get('foo'))).toBe 4
       settingsPanel = new SettingsPanel({namespace: "foo", includeTitle: false})
 
     it 'ensures default stays default', ->
@@ -99,6 +109,20 @@ describe "SettingsPanel", ->
       settingsPanel.set('foo.haz', 'newhaz')
       expect(settingsPanel.isDefault('foo.haz')).toBe false
       expect(atom.config.get('foo.haz')).toBe 'newhaz'
+
+    it 'has a tooltip showing the default value', ->
+      hazEditor = settingsPanel.element.querySelector('[id="foo.haz"]')
+      tooltips = atom.tooltips.findTooltips(hazEditor)
+      expect(tooltips).toHaveLength 1
+      title = tooltips[0].options.title
+      expect(title).toBe "Default: haz"
+
+    it 'has a tooltip showing the description of the default value', ->
+      quxEditor = settingsPanel.element.querySelector('[id="foo.qux"]')
+      tooltips = atom.tooltips.findTooltips(quxEditor)
+      expect(tooltips).toHaveLength 1
+      title = tooltips[0].options.title
+      expect(title).toBe "Default: Alice"
 
     # Regression test for #783
     it 'allows 0 to be a default', ->


### PR DESCRIPTION
### Description of the Change

The default value of a configuration setting is shown next to it in a tooltip. Configuration settings also support an [`enum` key](https://atom.io/docs/api/v1.28.1/Config#enum) with `description` properties which will be displayed instead of the raw values. This description, however, only applies to the drop-down itself but not the tooltip. For example:

![Screenshot showing the tooltip with “Default: default”](https://user-images.githubusercontent.com/652793/42496723-40f3a98c-8427-11e8-9531-7b288e22f530.png)

Since the `value` and `description` properties may not be similar, one can’t be sure which value is actually the default one. The “Color Profile” setting above is actually a good example: What’s `default`?

This pull request changes the tooltip to show the description instead (so it matches the drop-down’s choices):

![Screenshot showing the tooltip with “Default: Use color profile configured in the operating system”](https://user-images.githubusercontent.com/652793/42496721-40ac5b2c-8427-11e8-97e5-7da5cb34e240.png)

### Alternate Designs

The default value could also be marked in the drop-down itself, for example by suffixing “(default)”. The proposed version was selected because it fits with the existing style of indicating default values.

### Benefits

It will be more obvious which value is the default value, especially in cases where the raw value (`value`) and the description (`description`) aren’t similar.

### Possible Drawbacks

- It will no longer be possible to view the raw value of such a configuration setting.
- Tooltips may become quite large since descriptions are usually longer than their raw values.