### PR TITLE
Ensure snippets are displayed in a package’s settings view.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -87,6 +87,9 @@ module.exports = {
     if (typeof snippets.getUnparsedSnippets === 'function') {
       SnippetsProvider.getSnippets = snippets.getUnparsedSnippets.bind(snippets)
     }
+    if (typeof snippets.getUserSnippetsPath === 'function') {
+      SnippetsProvider.getUserSnippetsPath = snippets.getUserSnippetsPath.bind(snippets)
+    }
   },
 
   createSettingsView(params) {

--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -339,7 +339,7 @@ export default class PackageDetailView {
 
         if (this.pack.path) {
           this.grammarsView = new PackageGrammarsView(this.pack.path)
-          this.snippetsView = new PackageSnippetsView(this.pack.path, this.snippetsProvider)
+          this.snippetsView = new PackageSnippetsView(this.pack, this.snippetsProvider)
           this.refs.sections.appendChild(this.grammarsView.element)
           this.refs.sections.appendChild(this.snippetsView.element)
         }

--- a/lib/package-snippets-view.js
+++ b/lib/package-snippets-view.js
@@ -4,18 +4,39 @@
 import path from 'path'
 import _ from 'underscore-plus'
 import etch from 'etch'
+import {CompositeDisposable, Disposable} from 'atom'
 
 // View to display the snippets that a package has registered.
 export default class PackageSnippetsView {
-  constructor (packagePath, snippetsProvider) {
+  constructor (pack, snippetsProvider) {
+    this.pack = pack
+    this.namespace = this.pack.name
     this.snippetsProvider = snippetsProvider
-    this.packagePath = path.join(packagePath, path.sep)
+    this.packagePath = path.join(pack.path, path.sep)
     etch.initialize(this)
-    this.element.style.display = 'none'
-    this.addSnippets()
+    this.disposables = new CompositeDisposable()
+    this.updateSnippetsView()
+
+    const packagesWithSnippetsDisabled = atom.config.get('core.packagesWithSnippetsDisabled') || []
+    this.refs.snippetToggle.checked = !packagesWithSnippetsDisabled.includes(this.namespace)
+
+    const changeHandler = (event) => {
+      event.stopPropagation()
+      const value = this.refs.snippetToggle.checked
+      if (value) {
+        atom.config.removeAtKeyPath('core.packagesWithSnippetsDisabled', this.namespace)
+      } else {
+        atom.config.pushAtKeyPath('core.packagesWithSnippetsDisabled', this.namespace)
+      }
+      this.updateSnippetsView()
+    }
+
+    this.refs.snippetToggle.addEventListener('change', changeHandler)
+    this.disposables.add(new Disposable(() => { this.refs.snippetToggle.removeEventListener('change', changeHandler) }))
   }
 
   destroy () {
+    this.disposables.dispose()
     return etch.destroy(this)
   }
 
@@ -25,11 +46,22 @@ export default class PackageSnippetsView {
     return (
       <section className='section'>
         <div className='section-heading icon icon-code'>Snippets</div>
+        <div className='checkbox'>
+          <label for='toggleSnippets'>
+            <input id='toggleSnippets' className='input-checkbox' type='checkbox' ref='snippetToggle'></input>
+            <div className='setting-title'>Enable</div>
+          </label>
+          <div className='setting-description'>
+            {"Disable this if you want to prevent this package’s snippets from appearing as suggestions or if you want to customize them in your snippets file."}
+          </div>
+        </div>
+
         <table className='package-snippets-table table native-key-bindings text' tabIndex={-1}>
           <thead>
             <tr>
               <th>Trigger</th>
               <th>Name</th>
+              <th>Scope</th>
               <th>Body</th>
             </tr>
           </thead>
@@ -41,14 +73,15 @@ export default class PackageSnippetsView {
 
   getSnippetProperties () {
     const packageProperties = {}
-    for (const {name, properties} of this.snippetsProvider.getSnippets()) {
+    for (const {name, properties, selectorString} of this.snippetsProvider.getSnippets()) {
       if (name && name.indexOf && name.indexOf(this.packagePath) === 0) {
         const object = properties.snippets != null ? properties.snippets : {}
         for (let key in object) {
           const snippet = object[key]
           if (snippet != null) {
+            snippet.selectorString = selectorString
             if (packageProperties[key] == null) {
-              packageProperties[name] = snippet
+              packageProperties[key] = snippet
             }
           }
         }
@@ -76,11 +109,25 @@ export default class PackageSnippetsView {
     }
   }
 
-  addSnippets () {
+  getSnippetsModule () {
+    const snippetsPackage = atom.packages.getLoadedPackage('snippets')
+    return snippetsPackage ? snippetsPackage.mainModule : null
+  }
+
+  updateSnippetsView () {
+    const packagesWithSnippetsDisabled = atom.config.get('core.packagesWithSnippetsDisabled') || []
+    const snippetsDisabled = packagesWithSnippetsDisabled.includes(this.namespace)
+
     this.getSnippets((snippets) => {
       this.refs.snippets.innerHTML = ''
 
-      for (let {body, bodyText, name, prefix} of snippets) {
+      if (snippetsDisabled) {
+        this.refs.snippets.classList.add('text-subtle')
+      } else {
+        this.refs.snippets.classList.remove('text-subtle')
+      }
+
+      for (let {body, bodyText, name, prefix, selectorString} of snippets) {
         if (name == null) {
           name = ''
         }
@@ -90,13 +137,11 @@ export default class PackageSnippetsView {
         }
 
         if (body == null) {
-          body = bodyText
+          body = bodyText || ''
         }
 
-        if (body) {
-          body = body.replace(/\t/g, '\\t').replace(/\n/g, '\\n')
-        } else {
-          body = ''
+        if (selectorString == null) {
+          selectorString = ''
         }
 
         const row = document.createElement('tr')
@@ -110,19 +155,86 @@ export default class PackageSnippetsView {
         nameTd.textContent = name
         row.appendChild(nameTd)
 
+        const scopeTd = document.createElement('td')
+        scopeTd.classList.add('snippet-scope-name')
+        scopeTd.textContent = selectorString
+        row.appendChild(scopeTd)
+
         const bodyTd = document.createElement('td')
         bodyTd.classList.add('snippet-body')
-        bodyTd.textContent = body
         row.appendChild(bodyTd)
 
         this.refs.snippets.appendChild(row)
+        this.createButtonsForSnippetRow(bodyTd, {body, prefix, scope: selectorString, name})
       }
 
       if (this.refs.snippets.children.length > 0) {
-        this.refs.snippets.style.display = ''
+        this.element.style.display = ''
       } else {
-        this.refs.snippets.style.display = 'none'
+        this.element.style.display = 'none'
       }
     })
+  }
+
+  createButtonsForSnippetRow (td, {scope, body, name, prefix}) {
+    let buttonContainer = document.createElement('div')
+    buttonContainer.classList.add('btn-group', 'btn-group-xs')
+
+    let viewButton = document.createElement('button')
+    let copyButton = document.createElement('button')
+
+    viewButton.setAttribute('type', 'button')
+    viewButton.textContent = 'View'
+    viewButton.classList.add('btn', 'snippet-view-btn')
+
+    let tooltip = atom.tooltips.add(viewButton, {
+      title: body,
+      html: false,
+      trigger: 'click',
+      placement: 'auto left',
+      'class': 'snippet-body-tooltip'
+    })
+
+    this.disposables.add(tooltip)
+
+    copyButton.setAttribute('type', 'button')
+    copyButton.textContent = 'Copy'
+    copyButton.classList.add('btn', 'snippet-copy-btn')
+
+    copyButton.addEventListener('click', (event) => {
+      event.preventDefault()
+      return this.writeSnippetToClipboard({scope, body, name, prefix})
+    })
+
+    buttonContainer.appendChild(viewButton)
+    buttonContainer.appendChild(copyButton)
+
+    td.appendChild(buttonContainer)
+  }
+
+  writeSnippetToClipboard ({scope, body, name, prefix}) {
+    let content
+    const extension = path.extname(this.getSnippetsModule().getUserSnippetsPath())
+    if (extension === '.cson') {
+      body = body.replace(/'/g, `\\'`)
+      content = `
+'${scope}':
+  '${name}':
+    'prefix': '${prefix}'
+    'body': '${body}'
+`
+    } else {
+      body = body.replace(/"/g, `\\"`)
+      content = `
+  "${scope}": {
+    "${name}": {
+      "prefix": "${prefix}",
+      "body": "${body}"
+    }
+  }
+`
+    }
+
+    atom.clipboard.write(content)
   }
 }

--- a/lib/package-snippets-view.js
+++ b/lib/package-snippets-view.js
@@ -109,11 +109,6 @@ export default class PackageSnippetsView {
     }
   }
 
-  getSnippetsModule () {
-    const snippetsPackage = atom.packages.getLoadedPackage('snippets')
-    return snippetsPackage ? snippetsPackage.mainModule : null
-  }
-
   updateSnippetsView () {
     const packagesWithSnippetsDisabled = atom.config.get('core.packagesWithSnippetsDisabled') || []
     const snippetsDisabled = packagesWithSnippetsDisabled.includes(this.namespace)
@@ -214,9 +209,9 @@ export default class PackageSnippetsView {
 
   writeSnippetToClipboard ({scope, body, name, prefix}) {
     let content
-    const extension = path.extname(this.getSnippetsModule().getUserSnippetsPath())
+    const extension = path.extname(this.snippetsProvider.getUserSnippetsPath())
     if (extension === '.cson') {
-      body = body.replace(/'/g, `\\'`)
+      body = body.replace(/'/g, `\\'`).replace(/\n/g, '\\n')
       content = `
 '${scope}':
   '${name}':
@@ -224,7 +219,7 @@ export default class PackageSnippetsView {
     'body': '${body}'
 `
     } else {
-      body = body.replace(/"/g, `\\"`)
+      body = body.replace(/"/g, `\\"`).replace(/\n/g, '\\n')
       content = `
   "${scope}": {
     "${name}": {

--- a/lib/package-snippets-view.js
+++ b/lib/package-snippets-view.js
@@ -210,8 +210,9 @@ export default class PackageSnippetsView {
   writeSnippetToClipboard ({scope, body, name, prefix}) {
     let content
     const extension = path.extname(this.snippetsProvider.getUserSnippetsPath())
+    body = body.replace(/\n/g, '\\n').replace(/\t/g, '\\t')
     if (extension === '.cson') {
-      body = body.replace(/'/g, `\\'`).replace(/\n/g, '\\n')
+      body = body.replace(/'/g, `\\'`)
       content = `
 '${scope}':
   '${name}':
@@ -219,7 +220,7 @@ export default class PackageSnippetsView {
     'body': '${body}'
 `
     } else {
-      body = body.replace(/"/g, `\\"`).replace(/\n/g, '\\n')
+      body = body.replace(/"/g, `\\"`)
       content = `
   "${scope}": {
     "${name}": {

--- a/spec/fixtures/language-test/snippets/bar.json
+++ b/spec/fixtures/language-test/snippets/bar.json
@@ -2,7 +2,7 @@
   ".source.b": {
     "BAR": {
       "prefix": "b",
-      "body": "bar?"
+      "body": "bar?\nline two"
     }
   }
 }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -417,7 +417,7 @@
     }
   }
 
-  .package-detail-view {
+  .package-detail {
     .package-keymap-table,
     .package-grammars-table,
     .package-snippets-table {
@@ -428,10 +428,13 @@
         white-space: nowrap;
       }
 
-      .snippet-body,
       .snippet-prefix {
         font-family: monospace;
       }
+    }
+
+    .package-snippets-table {
+      max-width: 100%;
     }
 
     .update-message {
@@ -640,6 +643,14 @@
       margin: 2px 0;
     }
   }
+}
+
+// A tooltip that shows the body of a snippet should treat whitespace literally
+// and should align to the left so that indentation is clearer.
+.snippet-body-tooltip .tooltip-inner {
+  font-family: monospace;
+  white-space: pre !important;
+  text-align: left;
 }
 
 .package-updates-status-view:hover {


### PR DESCRIPTION
Add an “Enable” checkbox inside the snippet view to add/remove the current package from the snippets blacklist.

### Description of the Change

`PackageSnippetsView` is rehabilitated and made to show a package’s snippets (should a package have any snippets to display). The issues described in #1076 have been fixed.

An “Enable” checkbox has been added at the top of the section — identical to the one at the top of a Keybindings panel. Just as unchecking the Keybindings panel’s Enable checkbox immediately disables that package’s key bindings, unchecking the Snippet panel’s Enable checkbox immediately disables all snippets provided by that package. No reloading of the window is necessary.

The snippets themselves are listed in the table with columns for prefix, name, scope, and body. Since the body of a snippet is arbitrary text of arbitrary length, we don’t show it in the table; we show it in a tooltip that is shown when the <kbd>View</kbd> button is clicked. The <kbd>Copy</kbd> button writes a string to the clipboard that can be pasted into a user’s `snippets.cson` (or `snippets.json`) for further customization.

### Alternate Designs

I mooted this change in #1076 before contributing this PR because I wasn’t yet certain how snippet bodies ought to be displayed in the UI.

### Benefits

First of all, this fixes the bug (described in #1076) that prevented a package's settings page from listing snippets altogether.

This is also the UI side of atom/snippets#277, which allows package-provided snippets to be disabled on a per-package basis. This is one of the oldest and most-requested enhancements for the snippets package.

### Possible Drawbacks

Can't think of any. This fixes a regression. We were already paying the cost of retrieving the snippets for display in `PackageSnippetsView`; we were merely failing to display them.

### Applicable Issues

* #1076 has discussion about the bugfix and the UI for the snippets table.
* atom/snippets#55 is the original feature request, and atom/snippets#277 is **a prerequisite change** for this PR. Ideally these two PRs should be landed simultaneously, but under no circumstances should this one land before the other, or else this UI will be hooked up to nothing at all.