### PR TITLE
:bug: Fix base64 encoded image viewing in package README files.

### DIFF
--- a/lib/package-readme-view.js
+++ b/lib/package-readme-view.js
@@ -23,6 +23,11 @@ function sanitize (html, readmeSrc) {
       changeImageSrc = false
     }
 
+    // If src contains a base64 encoded image it must be left unchanged
+    if (/^data:image\/.*;base64/i.test(imageSrc)) {
+      changeImageSrc = false;
+    }
+
     // If path is absolute on file system it must be a local file, e.g. emoji
     if (path.isAbsolute(imageSrc)) {
       changeImageSrc = false

--- a/spec/fixtures/package-with-readme/README.md
+++ b/spec/fixtures/package-with-readme/README.md
@@ -6,6 +6,7 @@ I am a Readme!
 
 ![AbsoluteImage](https://example.com/static/image.jpg)
 ![RelativeImage](static/image.jpg)
+![Base64Image](data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)
 
 <script>alert('oh, hai');</script>
 <iframe src="https://atom.io"></iframe>

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -93,6 +93,7 @@ describe "PackageDetailView", ->
     expect(view.element.querySelectorAll('.package-readme input[type="checkbox"][disabled]').length).toBe(2)
     expect(view.element.querySelector('img[alt="AbsoluteImage"]').getAttribute('src')).toBe('https://example.com/static/image.jpg')
     expect(view.element.querySelector('img[alt="RelativeImage"]').getAttribute('src')).toBe('https://github.com/example/package-with-readme/blob/master/static/image.jpg')
+    expect(view.element.querySelector('img[alt="Base64Image"]').getAttribute('src')).toBe('data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==')
 
   it "renders the README when the package path is undefined", ->
     atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-readme'))


### PR DESCRIPTION
The sanitize function merges the package path with the image source,
a check is needed for base64 encoded images, to ensure they are properly
shown in the package readme view.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds a regex based check for base64 encoded images in package README files, with a similar syntax as surrounding checks.

### Alternate Designs

None.

### Benefits

Prior to this change, all base64 images in README files would break, when viewed from the settings view.

### Possible Drawbacks

None.

### Applicable Issues

Fixes https://github.com/atom/settings-view/issues/1030