### PR TITLE
Add option to display config enums as radio buttons

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -379,7 +379,7 @@ function elementForSetting (namespace, name, value) {
 
   let schema = atom.config.getSchema(`${namespace}.${name}`)
   if (schema && schema.enum) {
-    controls.appendChild(elementForOptions(namespace, name, value))
+    controls.appendChild(elementForOptions(namespace, name, value, {radio: schema.radio}))
   } else if (schema && schema.type === 'color') {
     controls.appendChild(elementForColor(namespace, name, value))
   } else if (_.isBoolean(value) || (schema && schema.type === 'boolean')) {
@@ -406,7 +406,7 @@ function getSettingTitle (keyPath, name) {
   return title || _.uncamelcase(name).split('.').map(_.capitalize).join(' ')
 }
 
-function elementForOptions (namespace, name, value) {
+function elementForOptions (namespace, name, value, {radio = false}) {
   let keyPath = `${namespace}.${name}`
   let schema = atom.config.getSchema(keyPath)
   let options = (schema && schema.enum) ? schema.enum : []
@@ -428,22 +428,49 @@ function elementForOptions (namespace, name, value) {
 
   fragment.appendChild(label)
 
-  const select = document.createElement('select')
-  select.id = keyPath
-  select.classList.add('form-control')
-  for (const option of options) {
-    const optionElement = document.createElement('option')
-    if (option.hasOwnProperty('value')) {
-      optionElement.value = option.value
-      optionElement.textContent = option.description
-    } else {
-      optionElement.value = option
-      optionElement.textContent = option
-    }
-    select.appendChild(optionElement)
-  }
+  // TODO: remove duplication between branches.
 
-  fragment.appendChild(select)
+  if (radio) {
+    const fieldset = document.createElement('fieldset')
+    fieldset.id = keyPath
+    for (const option of options) {
+      const button = document.createElement('input')
+      const label = document.createElement('label')
+      let value
+      let description = ''
+      if (option.hasOwnProperty('value')) {
+        value = option.value
+        description = option.description
+      } else {
+        value = option
+        description = option
+      }
+      button.id = `${keyPath}[${value}]`
+      button.setAttribute('type', 'radio')
+      button.setAttribute('value', value)
+      label.appendChild(button)
+      label.appendChild(document.createTextNode(description))
+      fieldset.appendChild(label)
+    }
+    fragment.appendChild(fieldset)
+  } else {
+    const select = document.createElement('select')
+    select.id = keyPath
+    select.classList.add('form-control')
+    for (const option of options) {
+      const optionElement = document.createElement('option')
+      if (option.hasOwnProperty('value')) {
+        optionElement.value = option.value
+        optionElement.textContent = option.description
+      } else {
+        optionElement.value = option
+        optionElement.textContent = option
+      }
+      select.appendChild(optionElement)
+    }
+
+    fragment.appendChild(select)
+  }
 
   return fragment
 }

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -442,24 +442,9 @@ function elementForOptions (namespace, name, value, {radio = false}) {
   // TODO: remove duplication between branches.
 
   if (radio) {
-    fragment.appendChild(elementForRadio(options, {keyPath}))
+    fragment.appendChild(enumAsRadio(options, {keyPath}))
   } else {
-    const select = document.createElement('select')
-    select.id = keyPath
-    select.classList.add('form-control')
-    for (const option of options) {
-      const optionElement = document.createElement('option')
-      if (option.hasOwnProperty('value')) {
-        optionElement.value = option.value
-        optionElement.textContent = option.description
-      } else {
-        optionElement.value = option
-        optionElement.textContent = option
-      }
-      select.appendChild(optionElement)
-    }
-
-    fragment.appendChild(select)
+    fragment.appendChild(enumAsSelect(options, {keyPath}))
   }
 
   // End duplication
@@ -625,7 +610,7 @@ function elementForObject (namespace, name, value) {
   }
 }
 
-function elementForRadio (options, {keyPath}) {
+function enumAsRadio (options, {keyPath}) {
   const fieldset = document.createElement('fieldset')
   fieldset.id = keyPath
   fieldset.classList.add('input-radio-group')
@@ -652,4 +637,23 @@ function elementForRadio (options, {keyPath}) {
     fieldset.appendChild(label)
   }
   return fieldset
+}
+
+function enumAsSelect (options, {keyPath}) {
+  const select = document.createElement('select')
+  select.id = keyPath
+  select.classList.add('form-control')
+  for (const option of options) {
+    const optionElement = document.createElement('option')
+    if (option.hasOwnProperty('value')) {
+      optionElement.value = option.value
+      optionElement.textContent = option.description
+    } else {
+      optionElement.value = option
+      optionElement.textContent = option
+    }
+    select.appendChild(optionElement)
+  }
+
+  return select
 }

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -106,11 +106,11 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       let type = input.type
       let name = type === 'radio' ? input.name : input.id
 
-      this.observe(name, function(value) {
+      this.observe(name, (value) => {
         if (type === 'checkbox') {
           input.checked = value
         } else if (type === 'radio') {
-          input.checked = (value === input.value)
+          input.checked = (value === this.parseValue(atom.config.getSchema(name).type, input.value))
         } else {
           if (type === 'color') {
             if (value && value.toHexString && value.toHexString()) {
@@ -128,6 +128,8 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
         let value = input.value
         if (type === 'checkbox') {
           value = input.checked
+        } else if (type === 'radio') {
+          value = this.parseValue(atom.config.getSchema(name).type, value)
         } else {
           value = this.parseValue(type, value)
         }
@@ -323,6 +325,13 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
         return value
       } else {
         return floatValue
+      }
+    } else if (type === 'integer') {
+      let intValue = parseInt(value)
+      if (isNaN(intValue)) {
+        return value
+      } else {
+        return intValue
       }
     } else if (type === 'array') {
       let arrayValue = (value || '').split(',')

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -442,32 +442,7 @@ function elementForOptions (namespace, name, value, {radio = false}) {
   // TODO: remove duplication between branches.
 
   if (radio) {
-    const fieldset = document.createElement('fieldset')
-    fieldset.id = keyPath
-    fieldset.classList.add('input-radio-group')
-    for (const option of options) {
-      const button = document.createElement('input')
-      const label = document.createElement('label')
-      label.classList.add('input-label')
-      let value
-      let description = ''
-      if (option.hasOwnProperty('value')) {
-        value = option.value
-        description = option.description
-      } else {
-        value = option
-        description = option
-      }
-      button.classList.add('input-radio')
-      button.id = `${keyPath}[${value}]`
-      button.name = keyPath
-      button.type = 'radio'
-      button.value = value
-      label.appendChild(button)
-      label.appendChild(document.createTextNode(description))
-      fieldset.appendChild(label)
-    }
-    fragment.appendChild(fieldset)
+    fragment.appendChild(elementForRadio(options, {keyPath}))
   } else {
     const select = document.createElement('select')
     select.id = keyPath
@@ -486,6 +461,8 @@ function elementForOptions (namespace, name, value, {radio = false}) {
 
     fragment.appendChild(select)
   }
+
+  // End duplication
 
   return fragment
 }
@@ -646,4 +623,33 @@ function elementForObject (namespace, name, value) {
 
     return section
   }
+}
+
+function elementForRadio (options, {keyPath}) {
+  const fieldset = document.createElement('fieldset')
+  fieldset.id = keyPath
+  fieldset.classList.add('input-radio-group')
+  for (const option of options) {
+    const button = document.createElement('input')
+    const label = document.createElement('label')
+    label.classList.add('input-label')
+    let value
+    let description = ''
+    if (option.hasOwnProperty('value')) {
+      value = option.value
+      description = option.description
+    } else {
+      value = option
+      description = option
+    }
+    button.classList.add('input-radio')
+    button.id = `${keyPath}[${value}]`
+    button.name = keyPath
+    button.type = 'radio'
+    button.value = value
+    label.appendChild(button)
+    label.appendChild(document.createTextNode(description))
+    fieldset.appendChild(label)
+  }
+  return fieldset
 }

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -613,48 +613,45 @@ function enumOptions(options, {keyPath, radio}) {
   const containerClass = radio ? 'input-radio-group' : 'form-control'
   container.classList.add(containerClass)
 
-  const optionElements = radio ? optionsForRadio(options, {keyPath}) : optionsForSelect(options, {keyPath})
+  const conversion = radio ? optionToRadio : optionToSelect
+  const optionElements = options.map(option => conversion(option, keyPath))
 
   for (const optionElement of optionElements) { container.appendChild(optionElement) }
 
   return container
 }
 
-function optionsForRadio(options, {keyPath}) {
-  return options.map((option) => {
-    const button = document.createElement('input')
-    const label = document.createElement('label')
-    label.classList.add('input-label')
-    let value
-    let description = ''
-    if (option.hasOwnProperty('value')) {
-      value = option.value
-      description = option.description
-    } else {
-      value = option
-      description = option
-    }
-    button.classList.add('input-radio')
-    button.id = `${keyPath}[${value}]`
-    button.name = keyPath
-    button.type = 'radio'
-    button.value = value
-    label.appendChild(button)
-    label.appendChild(document.createTextNode(description))
-    return label
-  })
+function optionToRadio(option, keyPath) {
+  const button = document.createElement('input')
+  const label = document.createElement('label')
+  label.classList.add('input-label')
+  let value
+  let description = ''
+  if (option.hasOwnProperty('value')) {
+    value = option.value
+    description = option.description
+  } else {
+    value = option
+    description = option
+  }
+  button.classList.add('input-radio')
+  button.id = `${keyPath}[${value}]`
+  button.name = keyPath
+  button.type = 'radio'
+  button.value = value
+  label.appendChild(button)
+  label.appendChild(document.createTextNode(description))
+  return label
 }
 
-function optionsForSelect(options, {keyPath}) {
-  return options.map((option) => {
-    const optionElement = document.createElement('option')
-    if (option.hasOwnProperty('value')) {
-      optionElement.value = option.value
-      optionElement.textContent = option.description
-    } else {
-      optionElement.value = option
-      optionElement.textContent = option
-    }
-    return optionElement
-  })
+function optionToSelect(option, keyPath) {
+  const optionElement = document.createElement('option')
+  if (option.hasOwnProperty('value')) {
+    optionElement.value = option.value
+    optionElement.textContent = option.description
+  } else {
+    optionElement.value = option
+    optionElement.textContent = option
+  }
+  return optionElement
 }

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -444,9 +444,11 @@ function elementForOptions (namespace, name, value, {radio = false}) {
   if (radio) {
     const fieldset = document.createElement('fieldset')
     fieldset.id = keyPath
+    fieldset.classList.add('input-radio-group')
     for (const option of options) {
       const button = document.createElement('input')
       const label = document.createElement('label')
+      label.classList.add('input-label')
       let value
       let description = ''
       if (option.hasOwnProperty('value')) {

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -601,7 +601,7 @@ function elementForObject (namespace, name, value) {
   }
 }
 
-function enumOptions(options, {keyPath, radio}) {
+function enumOptions (options, {keyPath, radio}) {
   const containerTag = radio ? 'fieldset' : 'select'
   const container = document.createElement(containerTag)
   container.id = keyPath
@@ -616,7 +616,7 @@ function enumOptions(options, {keyPath, radio}) {
   return container
 }
 
-function optionToRadio(option, keyPath) {
+function optionToRadio (option, keyPath) {
   const button = document.createElement('input')
   const label = document.createElement('label')
   label.classList.add('input-label')
@@ -639,7 +639,7 @@ function optionToRadio(option, keyPath) {
   return label
 }
 
-function optionToSelect(option, keyPath) {
+function optionToSelect (option, keyPath) {
   const optionElement = document.createElement('option')
   if (option.hasOwnProperty('value')) {
     optionElement.value = option.value

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -103,12 +103,14 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
 
   bindInputFields() {
     const disposables = Array.from(this.element.querySelectorAll('input[id]')).map((input) => {
-      let name = input.id
       let type = input.type
+      let name = type === 'radio' ? input.name : input.id
 
       this.observe(name, function(value) {
         if (type === 'checkbox') {
           input.checked = value
+        } else if (type === 'radio') {
+          input.checked = (value === input.value)
         } else {
           if (type === 'color') {
             if (value && value.toHexString && value.toHexString()) {
@@ -445,9 +447,11 @@ function elementForOptions (namespace, name, value, {radio = false}) {
         value = option
         description = option
       }
+      button.classList.add('input-radio')
       button.id = `${keyPath}[${value}]`
-      button.setAttribute('type', 'radio')
-      button.setAttribute('value', value)
+      button.name = keyPath
+      button.type = 'radio'
+      button.value = value
       label.appendChild(button)
       label.appendChild(document.createTextNode(description))
       fieldset.appendChild(label)

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -441,11 +441,7 @@ function elementForOptions (namespace, name, value, {radio = false}) {
 
   // TODO: remove duplication between branches.
 
-  if (radio) {
-    fragment.appendChild(enumAsRadio(options, {keyPath}))
-  } else {
-    fragment.appendChild(enumAsSelect(options, {keyPath}))
-  }
+  fragment.appendChild(enumOptions(options, {keyPath, radio}))
 
   // End duplication
 
@@ -610,11 +606,22 @@ function elementForObject (namespace, name, value) {
   }
 }
 
-function enumAsRadio (options, {keyPath}) {
-  const fieldset = document.createElement('fieldset')
-  fieldset.id = keyPath
-  fieldset.classList.add('input-radio-group')
-  for (const option of options) {
+function enumOptions(options, {keyPath, radio}) {
+  const containerTag = radio ? 'fieldset' : 'select'
+  const container = document.createElement(containerTag)
+  container.id = keyPath
+  const containerClass = radio ? 'input-radio-group' : 'form-control'
+  container.classList.add(containerClass)
+
+  const optionElements = radio ? optionsForRadio(options, {keyPath}) : optionsForSelect(options, {keyPath})
+
+  for (const optionElement of optionElements) { container.appendChild(optionElement) }
+
+  return container
+}
+
+function optionsForRadio(options, {keyPath}) {
+  return options.map((option) => {
     const button = document.createElement('input')
     const label = document.createElement('label')
     label.classList.add('input-label')
@@ -634,16 +641,12 @@ function enumAsRadio (options, {keyPath}) {
     button.value = value
     label.appendChild(button)
     label.appendChild(document.createTextNode(description))
-    fieldset.appendChild(label)
-  }
-  return fieldset
+    return label
+  })
 }
 
-function enumAsSelect (options, {keyPath}) {
-  const select = document.createElement('select')
-  select.id = keyPath
-  select.classList.add('form-control')
-  for (const option of options) {
+function optionsForSelect(options, {keyPath}) {
+  return options.map((option) => {
     const optionElement = document.createElement('option')
     if (option.hasOwnProperty('value')) {
       optionElement.value = option.value
@@ -652,8 +655,6 @@ function enumAsSelect (options, {keyPath}) {
       optionElement.value = option
       optionElement.textContent = option
     }
-    select.appendChild(optionElement)
-  }
-
-  return select
+    return optionElement
+  })
 }

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -438,12 +438,7 @@ function elementForOptions (namespace, name, value, {radio = false}) {
   label.appendChild(descriptionDiv)
 
   fragment.appendChild(label)
-
-  // TODO: remove duplication between branches.
-
   fragment.appendChild(enumOptions(options, {keyPath, radio}))
-
-  // End duplication
 
   return fragment
 }

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -78,7 +78,7 @@ describe "SettingsPanel", ->
     it "presents radio options with their descriptions", ->
       radio = settingsPanel.element.querySelector('#foo\\.radio')
       options = for label in radio.querySelectorAll 'label'
-        button = label.querySelector('input[type=radio]')
+        button = label.querySelector('input[type=radio][name="foo.radio"]')
         [button.id, button.value, label.innerText]
       expect(options).toEqual([['foo.radio[one]', 'one', 'One'], ['foo.radio[Two]', 'Two', 'Two']])
 
@@ -109,9 +109,19 @@ describe "SettingsPanel", ->
             description: 'Setting for testing zero as a default'
             type: 'integer'
             default: 0
+          radio:
+            title: 'An enum with radio buttons'
+            radio: true
+            type: 'string'
+            default: 'Two'
+            enum: [
+              {value: 'one', description: 'One'}
+              'Two'
+              'Three'
+            ]
       atom.config.setSchema("foo", config)
       atom.config.setDefaults("foo", gong: 'gong')
-      expect(_.size(atom.config.get('foo'))).toBe 4
+      expect(_.size(atom.config.get('foo'))).toBe 5
       settingsPanel = new SettingsPanel({namespace: "foo", includeTitle: false})
 
     it 'ensures default stays default', ->
@@ -155,6 +165,11 @@ describe "SettingsPanel", ->
 
       settingsPanel.set('foo.testZero', 0)
       expect(settingsPanel.isDefault('foo.testZero')).toBe true
+
+    it "selects the default choice for radio options", ->
+      expect(settingsPanel.getDefault 'foo.radio').toBe 'Two'
+      settingsPanel.set 'foo.radio', 'Two'
+      expect(settingsPanel.element.querySelector '#foo\\.radio\\[Two\\]').toBeChecked()
 
     describe 'scoped settings', ->
       beforeEach ->

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -39,14 +39,23 @@ describe "SettingsPanel", ->
               {value: 'one', description: 'One'}
               'Two'
             ]
+          radio:
+            title: 'An enum with radio buttons'
+            radio: true
+            type: 'string'
+            default: 'Two'
+            enum: [
+              {value: 'one', description: 'One'}
+              'Two'
+            ]
       atom.config.setSchema("foo", config)
       atom.config.setDefaults("foo", gong: 'gong')
-      expect(_.size(atom.config.get('foo'))).toBe 6
+      expect(_.size(atom.config.get('foo'))).toBe 7
       settingsPanel = new SettingsPanel({namespace: "foo", includeTitle: false})
 
     it "sorts settings by order and then alphabetically by the key", ->
       settings = atom.config.get('foo')
-      expect(_.size(settings)).toBe 6
+      expect(_.size(settings)).toBe 7
       sortedSettings = settingsPanel.sortSettings("foo", settings)
       expect(sortedSettings[0]).toBe 'zing'
       expect(sortedSettings[1]).toBe 'zang'
@@ -54,6 +63,7 @@ describe "SettingsPanel", ->
       expect(sortedSettings[3]).toBe 'enum'
       expect(sortedSettings[4]).toBe 'gong'
       expect(sortedSettings[5]).toBe 'haz'
+      expect(sortedSettings[6]).toBe 'radio'
 
     it "gracefully deals with a null settings object", ->
       sortedSettings = settingsPanel.sortSettings("foo", null)
@@ -64,6 +74,13 @@ describe "SettingsPanel", ->
       select = settingsPanel.element.querySelector('#foo\\.enum')
       pairs = ([opt.value, opt.innerText] for opt in select.children)
       expect(pairs).toEqual([['one', 'One'], ['Two', 'Two']])
+
+    it "presents radio options with their descriptions", ->
+      radio = settingsPanel.element.querySelector('#foo\\.radio')
+      options = for label in radio.querySelectorAll 'label'
+        button = label.querySelector('input[type=radio]')
+        [button.id, button.value, label.innerText]
+      expect(options).toEqual([['foo.radio[one]', 'one', 'One'], ['foo.radio[Two]', 'Two', 'Two']])
 
   describe 'default settings', ->
     beforeEach ->

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -415,6 +415,10 @@
     .grammar-filetypes {
       margin-top: @component-padding;
     }
+
+    .input-radio-group .input-label {
+      margin-right: 1em;
+    }
   }
 
   .package-detail {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This pull request adds support for a `radio` option in the config schema, for `enum` config values. If `radio` is `true`, then the enum will be displayed as a group of radio buttons. 

*Edit by @rsese to add screenshot from https://github.com/atom/settings-view/pull/1089#issuecomment-435422204*

![image](https://user-images.githubusercontent.com/34378/47925356-5ce77980-de94-11e8-8eec-5c86f953e71f.png)

### Alternate Designs

I chose to add an option here because it seemed like the easiest way to not break existing config files, and to maintain backwards compatibility for new config files. If a config file using the `radio: true` feature is processed by an older version of Atom, the extra key will simply be ignored and the option will be displayed as a `<select>` element.

### Benefits

For small numbers of options, radio buttons often provide a better user experience than a drop-down menu would. This is especially true if the option descriptions are on the long side.

*Edit by @rsese to add extra context from https://github.com/atom/settings-view/pull/1089#issuecomment-435248703*

If there are fewer than approximately 5 options, radio buttons show them all at a glance, without needing to click. Likewise, it takes only 1 click to select a radio button, as opposed to 2 clicks for a drop-down option. There are other reasons too, but those are the most prominent.

### Possible Drawbacks

I designed this to be as free of negative impact as I could manage.
