### PR TITLE
Enhanced the report issue link derivation to respect the package.json bugs property

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -50,9 +50,9 @@ export default class PackageDetailView {
 
     const issueButtonClickHandler = (event) => {
       event.preventDefault()
-      const repoUrl = this.packageManager.getRepositoryUrl(this.pack)
-      if (repoUrl) {
-        shell.openExternal(`${repoUrl}/issues/new`)
+      let bugUri = this.packageManager.getRepositoryBugUri(this.pack)
+      if (bugUri) {
+        shell.openExternal(bugUri)
       }
     }
     this.refs.issueButton.addEventListener('click', issueButtonClickHandler)

--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -56,7 +56,7 @@ export default class PackageDetailView {
       }
     }
     this.refs.issueButton.addEventListener('click', issueButtonClickHandler)
-    this.disposables.add(new Disposable(() => { this.refs.changelogButton.removeEventListener('click', issueButtonClickHandler) }))
+    this.disposables.add(new Disposable(() => { this.refs.issueButton.removeEventListener('click', issueButtonClickHandler) }))
 
     const changelogButtonClickHandler = (event) => {
       event.preventDefault()

--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -402,6 +402,16 @@ class PackageManager
       repoUrl = "https://github.com/#{repoName}"
     repoUrl.replace(/\.git$/, '').replace(/\/+$/, '').replace(/^git\+/, '')
 
+  getRepositoryBugUri: ({metadata}) ->
+    {bugs} = metadata
+    if typeof bugs is 'string'
+      bugUri = bugs
+    else
+      bugUri = bugs?.url ? bugs?.email ? this.getRepositoryUrl({metadata}) + '/issues/new'
+      if bugUri.includes('@')
+        bugUri = 'mailto:' + bugUri
+    bugUri
+
   checkNativeBuildTools: ->
     new Promise (resolve, reject) =>
       apmProcess = @runCommand ['install', '--check'], (code, stdout, stderr) ->

--- a/spec/fixtures/package-with-bugs-property-email/package.json
+++ b/spec/fixtures/package-with-bugs-property-email/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-with-bugs-property-email",
+  "version": "1.0.0",
+  "repository": "https://github.com/example/package-with-bugs-property-email",
+  "bugs": {"email": "issues@example.com"},
+  "main": "main"
+}

--- a/spec/fixtures/package-with-bugs-property-url-string/package.json
+++ b/spec/fixtures/package-with-bugs-property-url-string/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-with-bugs-property-url-string",
+  "version": "1.0.0",
+  "repository": "https://github.com/example/package-with-bugs-property-url-string",
+  "bugs": "https://example.com/custom-issue-tracker/new",
+  "main": "main"
+}

--- a/spec/fixtures/package-with-bugs-property-url/package.json
+++ b/spec/fixtures/package-with-bugs-property-url/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-with-bugs-property-url",
+  "version": "1.0.0",
+  "repository": "https://github.com/example/package-with-bugs-property-url",
+  "bugs": {"url": "https://example.com/custom-issue-tracker/new", "email": "issues@example.com"},
+  "main": "main"
+}

--- a/spec/fixtures/package-without-bugs-property/package.json
+++ b/spec/fixtures/package-without-bugs-property/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-without-bugs-property",
+  "version": "1.0.0",
+  "repository": "https://github.com/example/package-without-bugs-property",
+  "main": "main"
+}

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 path = require 'path'
+{shell} = require 'electron'
 
 PackageDetailView = require '../lib/package-detail-view'
 PackageManager = require '../lib/package-manager'
@@ -104,6 +105,12 @@ describe "PackageDetailView", ->
     expect(view.packageCard).toBeDefined()
     expect(view.packageCard.refs.packageName.textContent).toBe('package-with-readme')
     expect(view.element.querySelectorAll('.package-readme').length).toBe(1)
+
+  it "triggers a report issue button click and checks that the fallback repository issue tracker URL was opened", ->
+    loadPackageFromRemote()
+    spyOn(shell, 'openExternal')
+    view.refs.issueButton.click()
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/example/package-with-readme/issues/new')
 
   it "should show 'Install' as the first breadcrumb by default", ->
     loadPackageFromRemote()

--- a/spec/package-detail-view-spec.coffee
+++ b/spec/package-detail-view-spec.coffee
@@ -30,6 +30,15 @@ describe "PackageDetailView", ->
     view = new PackageDetailView({name: 'package-with-readme'}, new SettingsView(), packageManager, SnippetsProvider)
     view.beforeShow(opts)
 
+  loadCustomPackageFromRemote = (packageName, opts) ->
+    opts ?= {}
+    packageManager.client = createClientSpy()
+    packageManager.client.package.andCallFake (name, cb) ->
+      packageData = require(path.join(__dirname, 'fixtures', packageName, 'package.json'))
+      cb(null, packageData)
+    view = new PackageDetailView({name: packageName}, new SettingsView(), packageManager, SnippetsProvider)
+    view.beforeShow(opts)
+
   it "renders a package when provided in `initialize`", ->
     atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-config'))
     pack = atom.packages.getLoadedPackage('package-with-config')
@@ -107,10 +116,28 @@ describe "PackageDetailView", ->
     expect(view.element.querySelectorAll('.package-readme').length).toBe(1)
 
   it "triggers a report issue button click and checks that the fallback repository issue tracker URL was opened", ->
-    loadPackageFromRemote()
+    loadCustomPackageFromRemote('package-without-bugs-property')
     spyOn(shell, 'openExternal')
     view.refs.issueButton.click()
-    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/example/package-with-readme/issues/new')
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/example/package-without-bugs-property/issues/new')
+
+  it "triggers a report issue button click and checks that the bugs URL string was opened", ->
+    loadCustomPackageFromRemote('package-with-bugs-property-url-string')
+    spyOn(shell, 'openExternal')
+    view.refs.issueButton.click()
+    expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/custom-issue-tracker/new')
+
+  it "triggers a report issue button click and checks that the bugs URL was opened", ->
+    loadCustomPackageFromRemote('package-with-bugs-property-url')
+    spyOn(shell, 'openExternal')
+    view.refs.issueButton.click()
+    expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/custom-issue-tracker/new')
+
+  it "triggers a report issue button click and checks that the bugs email link was opened", ->
+    loadCustomPackageFromRemote('package-with-bugs-property-email')
+    spyOn(shell, 'openExternal')
+    view.refs.issueButton.click()
+    expect(shell.openExternal).toHaveBeenCalledWith('mailto:issues@example.com')
 
   it "should show 'Install' as the first breadcrumb by default", ->
     loadPackageFromRemote()


### PR DESCRIPTION
The existing implementation ignores the package.json `bugs` property, when deriving the report issue link. The proposed solution checks if the `bugs` property is a string or an object, if it's an object it's parsed for an URL or email, according to the [NPM package specification](https://docs.npmjs.com/files/package.json#bugs). The repository issue URL is used as fallback.

### Requirements
None.

### Description of the Change
Replaces the old getRepositoryUrl with a new getRepositoryBugUri that respects the `bugs` property in `package.json`. 

### Alternate Designs
None.

### Benefits

For Atom packages using an issue tracker outside of GitHub or an email, the **Report Issue** button will now link to the correct place.

![report-issue-button](https://i.imgur.com/AO0MlIa.gif)

### Possible Drawbacks

As the proposed solution uses the old solution as fallback, there's no identified drawbacks.

### Applicable Issues
#966
#1040 