### PR TITLE
Fix themes dropdown alignment described in issue #995

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -472,6 +472,12 @@
       flex: 1;
       min-width: 320px; // Enough for the UI Theme description
       padding: 0 @component-padding;
+      .controls {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
     }
   }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixed misaligned theme dropdown in Themes panel. When changing the size of the window the dropdowns for choosing UI Theme and Syntax Theme was not aligned. Fixed so the Syntax Theme dropdown is at the same height as UI Theme.


### Alternate Designs

As this only exists of CSS changes to match the other dropdown's behaviour no other alternatives was considered.

### Benefits

This fixes the bug with misaligned dropdowns and makes it more aesthetically pleasing. 

### Possible Drawbacks

None that I can see.

### Applicable Issues

Misaligned theme dropdowns in Themes panel #995
