### PR TITLE
Comma value in array

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -307,7 +307,7 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       if (value.length === 0) {
         return null
       }
-      return value.map((val) => val.toString().replace(/,/g, "\\,")).join(', ')
+      return value.map((val) => val.toString().replace(/,/g, '\\,')).join(', ')
     } else if (value != null) {
       return value.toString()
     } else {

--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -304,7 +304,10 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
 
   valueToString (value) {
     if (Array.isArray(value)) {
-      return value.join(', ') || null
+      if (value.length === 0) {
+        return null
+      }
+      return value.map((val) => val.toString().replace(/,/g, "\\,")).join(', ')
     } else if (value != null) {
       return value.toString()
     } else {
@@ -324,6 +327,15 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       }
     } else if (type === 'array') {
       let arrayValue = (value || '').split(',')
+      arrayValue = arrayValue.reduce((values, val) => {
+        const last = values.length - 1
+        if (last >= 0 && values[last].endsWith('\\')) {
+          values[last] = values[last].replace(/\\$/, ',') + val
+        } else {
+          values.push(val)
+        }
+        return values
+      }, [])
       return arrayValue.filter((val) => val).map((val) => val.trim())
     } else {
       return value

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -308,34 +308,34 @@ describe "SettingsPanel", ->
         commaValueArrayEditor = settingsPanel.element.querySelector('[id="foo.commaValueArray"]')
         commaValueArrayEditor.getModel().setText('1, \\,, 2')
         advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
-        expect(atom.config.get("foo.commaValueArray")).toEqual ["1", ",", "2"]
+        expect(atom.config.get("foo.commaValueArray")).toEqual ['1', ',', '2']
 
         commaValueArrayEditor.getModel().setText('1\\, 2')
         advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
-        expect(atom.config.get("foo.commaValueArray")).toEqual ["1, 2"]
+        expect(atom.config.get('foo.commaValueArray')).toEqual ['1, 2']
 
         commaValueArrayEditor.getModel().setText('1\\,')
         advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
-        expect(atom.config.get("foo.commaValueArray")).toEqual ["1,"]
+        expect(atom.config.get('foo.commaValueArray')).toEqual ['1,']
 
         commaValueArrayEditor.getModel().setText('\\, 2')
         advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
-        expect(atom.config.get("foo.commaValueArray")).toEqual [", 2"]
+        expect(atom.config.get('foo.commaValueArray')).toEqual [', 2']
 
       it 'renders an escaped comma', ->
         commaValueArrayEditor = settingsPanel.element.querySelector('[id="foo.commaValueArray"]')
-        atom.config.set("foo.commaValueArray", ["3", ",", "4"])
+        atom.config.set('foo.commaValueArray', ['3', ',', '4'])
         advanceClock(1000)
         expect(commaValueArrayEditor.getModel().getText()).toBe '3, \\,, 4'
 
-        atom.config.set("foo.commaValueArray", ["3, 4"])
+        atom.config.set('foo.commaValueArray', ['3, 4'])
         advanceClock(1000)
         expect(commaValueArrayEditor.getModel().getText()).toBe '3\\, 4'
 
-        atom.config.set("foo.commaValueArray", ["3,"])
+        atom.config.set('foo.commaValueArray', ['3,'])
         advanceClock(1000)
         expect(commaValueArrayEditor.getModel().getText()).toBe '3\\,'
 
-        atom.config.set("foo.commaValueArray", [", 4"])
+        atom.config.set('foo.commaValueArray', [', 4'])
         advanceClock(1000)
         expect(commaValueArrayEditor.getModel().getText()).toBe '\\, 4'

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -252,6 +252,12 @@ describe "SettingsPanel", ->
             default: 10
             minimum: 1
             maximum: 100
+          commaValueArray:
+            name: 'commaValueArray'
+            title: 'Comma value in array'
+            description: 'An array with a comma value'
+            type: 'array'
+            default: []
 
       atom.config.setSchema('foo', config)
       settingsPanel = new SettingsPanel({namespace: 'foo', includeTitle: false})
@@ -296,3 +302,40 @@ describe "SettingsPanel", ->
       minMaxEditor.getModel().setText('15')
       advanceClock(minMaxEditor.getModel().getBuffer().getStoppedChangingDelay())
       expect(minMaxEditor.getModel().getText()).toBe '15'
+
+    describe 'commaValueArray', ->
+      it 'comma in value is escaped', ->
+        commaValueArrayEditor = settingsPanel.element.querySelector('[id="foo.commaValueArray"]')
+        commaValueArrayEditor.getModel().setText('1, \\,, 2')
+        advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
+        expect(atom.config.get("foo.commaValueArray")).toEqual ["1", ",", "2"]
+
+        commaValueArrayEditor.getModel().setText('1\\, 2')
+        advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
+        expect(atom.config.get("foo.commaValueArray")).toEqual ["1, 2"]
+
+        commaValueArrayEditor.getModel().setText('1\\,')
+        advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
+        expect(atom.config.get("foo.commaValueArray")).toEqual ["1,"]
+
+        commaValueArrayEditor.getModel().setText('\\, 2')
+        advanceClock(commaValueArrayEditor.getModel().getBuffer().getStoppedChangingDelay())
+        expect(atom.config.get("foo.commaValueArray")).toEqual [", 2"]
+
+      it 'renders an escaped comma', ->
+        commaValueArrayEditor = settingsPanel.element.querySelector('[id="foo.commaValueArray"]')
+        atom.config.set("foo.commaValueArray", ["3", ",", "4"])
+        advanceClock(1000)
+        expect(commaValueArrayEditor.getModel().getText()).toBe '3, \\,, 4'
+
+        atom.config.set("foo.commaValueArray", ["3, 4"])
+        advanceClock(1000)
+        expect(commaValueArrayEditor.getModel().getText()).toBe '3\\, 4'
+
+        atom.config.set("foo.commaValueArray", ["3,"])
+        advanceClock(1000)
+        expect(commaValueArrayEditor.getModel().getText()).toBe '3\\,'
+
+        atom.config.set("foo.commaValueArray", [", 4"])
+        advanceClock(1000)
+        expect(commaValueArrayEditor.getModel().getText()).toBe '\\, 4'


### PR DESCRIPTION
### Description of the Change

`array` config type will allow an escaped comma in the value.

![image](https://user-images.githubusercontent.com/97994/51690348-20707900-1fbe-11e9-9095-272189f754f4.png)

the config value will be `["1", ",", "2"]`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Comma can be used in array values.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

fixes #1102
closes #1101
<!-- Enter any applicable Issues here -->
