### PR TITLE
Fix spacing of package versions

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -88,7 +88,6 @@ export default class PackageCard {
         <div className='body'>
           <h4 className='card-name'>
             <a className='package-name' ref='packageName'>{displayName}</a>
-            <span />
             <span className='package-version'>
               <span ref='versionValue' className='value'>{String(this.pack.version)}</span>
             </span>

--- a/styles/package-card.less
+++ b/styles/package-card.less
@@ -77,6 +77,7 @@
       }
     }
     .package-name {
+      margin-right: .5em;
       font-weight: bolder;
       color: @text-color-highlight;
     }


### PR DESCRIPTION
### Description of the Change

This adds some space before the version of packages.

#### Before:

![image](https://user-images.githubusercontent.com/22167388/51436674-663af200-1cdd-11e9-972b-7d7f5f021a6c.png)

#### After:

![image](https://user-images.githubusercontent.com/22167388/51436679-810d6680-1cdd-11e9-8403-b2a5043b9401.png)


### Benefits

Easier to read.

### Possible Drawbacks

None

### Applicable Issues

Fixes #1098
