### PR TITLE
Sticky breadcrumbs

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -10,11 +10,22 @@
   overflow: auto;
 
   .breadcrumb {
+    position: fixed;
+    width: 100%;
+    z-index: 1;
     margin-bottom: 0;
-    padding: @breadcrumb-padding;
+    padding: 0 @breadcrumb-padding;
     font-size: 1.2em;
+    line-height: 5rem;
     color: @text-color-subtle;
     list-style: none;
+    border-bottom: 1px solid @base-border-color;
+    background-color: @base-background-color;
+
+    + .section {
+      margin-top: 5rem; // space for breadcrumbs
+      border-top: none;
+    }
 
     > li {
       display: inline-block;


### PR DESCRIPTION
### Description of the Change

This makes the breadcrumbs sticky.

![breadcrumbs](https://user-images.githubusercontent.com/378023/52040232-1af4cf00-257a-11e9-967f-bc9a812f9e4b.gif)

### Alternate Designs

You can use the navigation on the left to go back, but some users might want to click the breadcrumb navigation instead.

### Benefits

When scrolled down a bit, it allows to click the breadcrumbs without having to scroll up again.

### Possible Drawbacks

A bit less vertical scrolling space.

### Applicable Issues

Resolves #1097
