### PR TITLE
Sticky breadcrumbs II

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -23,7 +23,7 @@
     background-color: @base-background-color;
 
     + .section {
-      margin-top: 5rem; // space for breadcrumbs
+      margin-top: 3rem; // space for breadcrumbs
       border-top: none;
     }
 

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -15,8 +15,8 @@
     z-index: 1;
     margin-bottom: 0;
     padding: 0 @breadcrumb-padding;
-    font-size: 1.2em;
-    line-height: 5rem;
+    font-size: 1.125em;
+    line-height: 3rem;
     color: @text-color-subtle;
     list-style: none;
     border-bottom: 1px solid @base-border-color;
@@ -34,12 +34,13 @@
       }
 
       + li:before {
-        content: "/\00a0"; // Unicode space added since inline-block means non-collapsing white-space
-        padding: 0 5px;
+        content: "/"; // Unicode space added since inline-block means non-collapsing white-space
+        padding: 0 .75em ;
       }
     }
 
     > .active a {
+      font-weight: 600;
       color: @text-color-highlight;
     }
 


### PR DESCRIPTION
### Description of the Change

This is a follow up to #1105 that tweaks a bit the breadcrumb styling:

- Less height
- Smaller font
- Bolder active state
- Even divider spacing

Before | After
--- | ---
![screen shot 2019-02-01 at 9 54 25 am](https://user-images.githubusercontent.com/378023/52095682-512c6000-2607-11e9-902b-7143ccaf1440.png) | ![screen shot 2019-02-01 at 9 53 57 am](https://user-images.githubusercontent.com/378023/52095696-57bad780-2607-11e9-87ef-2a181d20c9c5.png)


### Benefits

- Less vertical space needed
- Visual improvements

### Possible Drawbacks

None

### Applicable Issues

Follow up to #1105
