### PR TITLE
Sticky sub-sections

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -252,7 +252,7 @@ export default class PackageDetailView {
       )
     }
     return (
-      <div tabIndex='0' className='package-detail panels-item'>
+      <div tabIndex='0' className='package-detail'>
         <ol ref='breadcrumbContainer' className='native-key-bindings breadcrumb' tabIndex='-1'>
           <li>
             <a ref='breadcrumb' />
@@ -262,28 +262,31 @@ export default class PackageDetailView {
           </li>
         </ol>
 
-        <section className='section'>
-          <form className='section-container package-detail-view'>
-            <div className='container package-container'>
-              {packageCardView}
-            </div>
+        <div className='panels-item'>
+          <section className='section'>
+            <form className='section-container package-detail-view'>
+              <div className='container package-container'>
+                {packageCardView}
+              </div>
 
-            <p ref='packageRepo' className='link icon icon-repo repo-link hidden' />
-            <p ref='startupTime' className='text icon icon-dashboard hidden' tabIndex='-1' />
+              <p ref='packageRepo' className='link icon icon-repo repo-link hidden' />
+              <p ref='startupTime' className='text icon icon-dashboard hidden' tabIndex='-1' />
 
-            <div ref='buttons' className='btn-wrap-group hidden'>
-              <button ref='learnMoreButton' className='btn btn-default icon icon-link'>View on Atom.io</button>
-              <button ref='issueButton' className='btn btn-default icon icon-bug'>Report Issue</button>
-              <button ref='changelogButton' className='btn btn-default icon icon-squirrel'>CHANGELOG</button>
-              <button ref='licenseButton' className='btn btn-default icon icon-law'>LICENSE</button>
-              <button ref='openButton' className='btn btn-default icon icon-link-external'>View Code</button>
-            </div>
+              <div ref='buttons' className='btn-wrap-group hidden'>
+                <button ref='learnMoreButton' className='btn btn-default icon icon-link'>View on Atom.io</button>
+                <button ref='issueButton' className='btn btn-default icon icon-bug'>Report Issue</button>
+                <button ref='changelogButton' className='btn btn-default icon icon-squirrel'>CHANGELOG</button>
+                <button ref='licenseButton' className='btn btn-default icon icon-law'>LICENSE</button>
+                <button ref='openButton' className='btn btn-default icon icon-link-external'>View Code</button>
+              </div>
 
-            <div ref='errors' />
-          </form>
-        </section>
+              <div ref='errors' />
+            </form>
+          </section>
 
-        <div ref='sections' />
+          <div ref='sections' />
+
+        </div>
       </div>
     )
   }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -231,7 +231,6 @@
   }
 
   .sub-section {
-    margin: @section-padding 0;
 
     .sub-section-heading {
       position: sticky;
@@ -274,7 +273,7 @@
         content: @chevron-right;
       }
       .package-container .package-card,
-      .sub-section-body .control-group {
+      .sub-section-body {
         display: none !important;
       }
     }

--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -2,17 +2,13 @@
 @import "octicon-utf-codes";
 @import "ui-variables";
 
-@section-padding: 4 * @component-padding;
+@section-padding: 2 * @component-padding;
 @breadcrumb-padding: 2 * @component-padding;
 
 .settings-view {
   display: flex;
-  overflow: auto;
 
   .breadcrumb {
-    position: fixed;
-    width: 100%;
-    z-index: 1;
     margin-bottom: 0;
     padding: 0 @breadcrumb-padding;
     font-size: 1.125em;
@@ -23,7 +19,6 @@
     background-color: @base-background-color;
 
     + .section {
-      margin-top: 3rem; // space for breadcrumbs
       border-top: none;
     }
 
@@ -239,20 +234,24 @@
     margin: @section-padding 0;
 
     .sub-section-heading {
-      color: @text-color-highlight;
+      position: sticky;
+      top: 0px;
+      z-index: 1;
+      margin: 0;
+      padding: @component-padding 0;
       font-size: 1.4em;
       font-weight: bold;
       line-height: 1;
+      color: @text-color-highlight;
+      background-color: @base-background-color;
       -webkit-user-select: none;
 
       &.has-items {
         cursor: pointer;
 
-        &::after {
-          .icon(16px);
-          content: @fold;
-          position: absolute;
-          right: 0;
+        &::before {
+          .icon(20px);
+          content: @chevron-down;
           color: @text-color-subtle;
         }
 
@@ -263,12 +262,16 @@
     }
 
     .sub-section-body {
-      margin-top: 20px;
+      margin-top: @component-padding;
+      margin-bottom: @component-padding*3;
+      margin-left: 6px;
+      padding-left: 14px;
+      border-left: 1px solid @base-border-color;
     }
 
     &.collapsed {
-      .sub-section-heading.has-items:after {
-        content: @unfold;
+      .sub-section-heading.has-items:before {
+        content: @chevron-right;
       }
       .package-container .package-card,
       .sub-section-body .control-group {
@@ -430,6 +433,10 @@
   }
 
   .package-detail {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
     .package-keymap-table,
     .package-grammars-table,
     .package-snippets-table {


### PR DESCRIPTION
### Description of the Change

This PR makes the sub-sections "sticky". Also, the collapsed and uncollapsed icons got replaced with "chevrons" and placed in front.

![sticky](https://user-images.githubusercontent.com/378023/52108665-0bd75500-263e-11e9-9c7d-f0a298d695b3.gif)

### Benefits

- Easier to see what belongs to which subsection.
- Easier to see if a sub-section is collapsed or not. The fold icons are hard to differentiate.
- Sub-section can be collapsed after scrolling down.

### Possible Drawbacks

None.

### Applicable Issues

Inspired by #1105
