### PR TITLE
Escape CSON correctly

### DIFF
--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -153,7 +153,7 @@ export default class KeybindingsPanel {
 
       const escapeCSON = (input) => { // CSON.stringify does a lot of unncecessary work and gives us double quotes
         return input.replace(/\\.?|'/g, (match) => {
-          if (match.charAt(0) !== '\\') return "\\'" // escape single quote
+          if (match.charAt(0) === '\'') return "\\'" // escape single quote
           if (match.length === 1) return '\\\\' // last character is backslash; escape it
 
           switch (match.charAt(1)) {

--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -155,10 +155,12 @@ export default class KeybindingsPanel {
         return input.replace(/\\.?|'/g, (match) => {
           if (match.charAt(0) !== '\\') return "\\'" // escape single quote
           if (match.length === 1) return '\\\\' // last character is backslash; escape it
-          if (match.charAt(1) === '\\') {
-            return '\\\\\\\\' // we picked up a double backslash; escaping to two escaped double slashes
+
+          switch (match.charAt(1)) {
+            case '"': return '"' // unescape escaped double quote
+            case '\\': return '\\\\\\\\' // we picked up a double backslash; escaping to two escaped double slashes
+            default: return  '\\' + match // escape the backslash
           }
-          return '\\' + match // escape the backslash
         })
       }
 

--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -155,7 +155,7 @@ export default class KeybindingsPanel {
         return JSON.stringify(input)
           .slice(1, -1) // Remove wrapping double quotes
           .replace(/\\"/g, '"') // Unescape double quotes
-          .replace(/'/g, '\\\''); // Escape single quotes
+          .replace(/'/g, '\\\'') // Escape single quotes
       }
 
       if (keymapExtension === '.cson') {

--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -159,7 +159,7 @@ export default class KeybindingsPanel {
           switch (match.charAt(1)) {
             case '"': return '"' // unescape escaped double quote
             case '\\': return '\\\\\\\\' // we picked up a double backslash; escaping to two escaped double slashes
-            default: return  '\\' + match // escape the backslash
+            default: return '\\' + match // escape the backslash
           }
         })
       }

--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -151,17 +151,11 @@ export default class KeybindingsPanel {
       let content
       const keymapExtension = path.extname(atom.keymaps.getUserKeymapPath())
 
-      const escapeCSON = (input) => { // CSON.stringify does a lot of unncecessary work and gives us double quotes
-        return input.replace(/\\.?|'/g, (match) => {
-          if (match.charAt(0) === '\'') return "\\'" // escape single quote
-          if (match.length === 1) return '\\\\' // last character is backslash; escape it
-
-          switch (match.charAt(1)) {
-            case '"': return '"' // unescape escaped double quote
-            case '\\': return '\\\\\\\\' // we picked up a double backslash; escaping to two escaped double slashes
-            default: return '\\' + match // escape the backslash
-          }
-        })
+      const escapeCSON = (input) => {
+        return JSON.stringify(input)
+          .slice(1, -1) // Remove wrapping double quotes
+          .replace(/\\"/g, '"') // Unescape double quotes
+          .replace(/'/g, '\\\''); // Escape single quotes
       }
 
       if (keymapExtension === '.cson') {

--- a/lib/keybindings-panel.js
+++ b/lib/keybindings-panel.js
@@ -150,18 +150,22 @@ export default class KeybindingsPanel {
     copyIcon.onclick = () => {
       let content
       const keymapExtension = path.extname(atom.keymaps.getUserKeymapPath())
-      const escapedKeystrokes = keystrokes.replace(/\\/g, '\\\\') // Escape backslashes
+
+      const escapeCSON = (input) => { // CSON.stringify does a lot of unncecessary work and gives us double quotes
+        return input.replace(/\\.?|'/g, (match) => {
+          if (match.charAt(0) !== '\\') return "\\'" // escape single quote
+          if (match.length === 1) return '\\\\' // last character is backslash; escape it
+          if (match.charAt(1) === '\\') {
+            return '\\\\\\\\' // we picked up a double backslash; escaping to two escaped double slashes
+          }
+          return '\\' + match // escape the backslash
+        })
+      }
+
       if (keymapExtension === '.cson') {
-        content = `\
-'${selector}':
-  '${escapedKeystrokes}': '${command}'\
-`
+        content = `'${escapeCSON(selector)}':\n  '${escapeCSON(keystrokes)}': '${escapeCSON(command)}'`
       } else {
-        content = `\
-"${selector}": {
-  "${escapedKeystrokes}": "${command}"
-}\
-`
+        content = `${JSON.stringify(selector)}: {\n  ${JSON.stringify(keystrokes)}: ${JSON.stringify(command)}\n}`
       }
       return atom.clipboard.write(content)
     }

--- a/spec/keybindings-panel-spec.coffee
+++ b/spec/keybindings-panel-spec.coffee
@@ -6,37 +6,44 @@ describe "KeybindingsPanel", ->
 
   beforeEach ->
     expect(atom.keymaps).toBeDefined()
+    keySource = "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
     keyBindings = [
       {
-        source: "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
+        source: keySource
         keystrokes: 'ctrl-a'
         command: 'core:select-all'
         selector: '.editor, .platform-test'
       }
       {
-        source: "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
+        source: keySource
         keystrokes: 'ctrl-u'
         command: 'core:undo'
         selector: ".platform-test"
       }
       {
-        source: "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
+        source: keySource
         keystrokes: 'ctrl-u'
         command: 'core:undo'
         selector: ".platform-a, .platform-b"
       }
       {
-        source: "#{atom.getLoadSettings().resourcePath}#{path.sep}keymaps"
+        source: keySource
         keystrokes: 'shift-\\ \\'
         command: 'core:undo'
         selector: '.editor'
+      }
+      {
+        source: keySource
+        keystrokes: 'ctrl-z\''
+        command: 'core:toggle'
+        selector: 'atom-text-editor[data-grammar~=\'css\']'
       }
     ]
     spyOn(atom.keymaps, 'getKeyBindings').andReturn(keyBindings)
     panel = new KeybindingsPanel
 
   it "loads and displays core key bindings", ->
-    expect(panel.refs.keybindingRows.children.length).toBe 2
+    expect(panel.refs.keybindingRows.children.length).toBe 3
 
     row = panel.refs.keybindingRows.children[0]
     expect(row.querySelector('.keystroke').textContent).toBe 'ctrl-a'
@@ -64,13 +71,21 @@ describe "KeybindingsPanel", ->
           }
         """
 
-    describe "when the keybinding contains backslashes", ->
+    describe "when the keybinding contains special characters", ->
       it "escapes the backslashes before copying", ->
         spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.cson'
-        panel.element.querySelectorAll('.copy-icon')[1].click()
+        panel.element.querySelectorAll('.copy-icon')[2].click()
         expect(atom.clipboard.read()).toBe """
           '.editor':
             'shift-\\\\ \\\\': 'core:undo'
+        """
+
+      it "escapes the single quotes before copying", ->
+        spyOn(atom.keymaps, 'getUserKeymapPath').andReturn 'keymap.cson'
+        panel.element.querySelectorAll('.copy-icon')[1].click()
+        expect(atom.clipboard.read()).toBe """
+          'atom-text-editor[data-grammar~=\\'css\\']':
+            'ctrl-z\\'': 'core:toggle'
         """
 
   describe "when the key bindings change", ->

--- a/spec/keybindings-panel-spec.coffee
+++ b/spec/keybindings-panel-spec.coffee
@@ -95,7 +95,7 @@ describe "KeybindingsPanel", ->
       atom.keymaps.emitter.emit 'did-reload-keymap'
 
       waitsFor "the new keybinding to show up in the keybinding panel", ->
-        panel.refs.keybindingRows.children.length is 3
+        panel.refs.keybindingRows.children.length is 4
 
       runs ->
         row = panel.refs.keybindingRows.children[1]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Escapes quotes and backslashes better in the keybinding-to-string function.

In addition to linked issue, this is a keybinding I found on my own Atom that needs quote escaping
```cson
'atom-text-editor[data-grammar~=\'css\']':
  'ctrl-alt-c': 'css-declaration-sorter:sort'
```
Without this PR, it wouldn't escape the value quotes.

Also tidied up the composition part, which was really hard to read IMO. Now it's a clean single line with well defined newlines and spacing.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Considered `CSON.stringify(...)`, but 
(1) it does a lot of extra work for little benefit, 
(2) it returns with double quotes, and 
(3) ~~[it's wrong](https://github.com/groupon/cson-parser/blob/15bfd9695c79b627bd4dd7aabe1a4cc925a42494/lib/stringify.js#L80); trying that with the raw text `\\"` (escaped backslash + `"`) ironically gives `\"`, which is an escaped `"`.~~ (Actually might not be wrong, as `\\"` would already be escaped by `JSON.stringify` to `\\\"`. But I don't want to add a new dependency just for one thing) 

Could also run `JSON.stringify` and then swap quote escapes + replace single with double quotes, but I don't think it's necessary.

### Benefits

Correctly escape `'`, `"`, and `\` in strings

### Possible Drawbacks

none

### Applicable Issues

closes https://github.com/atom/settings-view/issues/1110