### PR TITLE
Fix sticky header gap

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -234,7 +234,7 @@
 
     .sub-section-heading {
       position: sticky;
-      top: 0px;
+      top: -1px; // -1px fixes a rounding issue on retina screens
       z-index: 1;
       margin: 0;
       padding: @component-padding 0;


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This fixes the 1px gap above sticky headers. Note: It's only reproducible on retina screens. Maybe a rounding error?

Before | After
--- | ---
![sticky-before](https://user-images.githubusercontent.com/378023/52925527-2830fc80-3375-11e9-9b40-58c185384b84.gif) | ![sticky-after](https://user-images.githubusercontent.com/378023/52925529-2830fc80-3375-11e9-85c2-87e987b8cabd.gif)

### Alternate Designs

N/A

### Benefits

Less distracting.

### Possible Drawbacks

If themes want to add a border or so, it might get cut off.

### Applicable Issues

Fixes #1111
