### PR TITLE
Fix space between version and deprecated label

### DIFF
--- a/styles/package-card.less
+++ b/styles/package-card.less
@@ -83,7 +83,8 @@
     }
 
     .package-version {
-      font-size: .8em
+      font-size: .8em;
+      margin-right: @component-padding;
     }
 
     .description {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This adds some space between version and deprecated label.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/378023/53135463-a0d6c980-35be-11e9-830a-1da2c1388346.png) | ![after](https://user-images.githubusercontent.com/378023/53135464-a16f6000-35be-11e9-87c9-6f83b686c9a6.png)


### Benefits

Easier to read

### Possible Drawbacks

None

### Applicable Issues

Fixes #1113
