### PR TITLE
Support settings-view in docks

### DIFF
--- a/styles/docks.less
+++ b/styles/docks.less
@@ -1,0 +1,147 @@
+@import "ui-variables";
+
+// Dock overrides
+// Allows settings to be used in left/right dock
+
+atom-dock.left .settings-view,
+atom-dock.right .settings-view {
+  // display: block;
+  flex-direction: column;
+
+  &.pane-item {
+    background-color: @tool-panel-background-color;
+  }
+
+  .config-menu {
+    flex: none;
+    padding-top: 0;
+    min-width: 0;
+    max-width: none;
+    border: none;
+    border-bottom: 1px solid @base-border-color;
+    background-color: inherit;
+    overflow-x: initial;
+
+    .nav {
+      display: contents;
+
+      & > li {
+        & > a {
+         padding: @component-padding/1.5 @component-padding*1.5;
+        }
+      }
+    }
+
+    &:not(:hover) {
+      .nav > li {
+        display: none;
+        &.active {
+          display: block;
+          & > a {
+            background-color: transparent;
+          }
+        }
+      }
+      .button-area {
+        display: none;
+      }
+    }
+  }
+
+  .panels .panels-item {
+    min-width: 100px;
+  }
+
+  .section,
+  .section:first-child, .settings-view .section:last-child {
+    padding: @component-padding*1.5;
+  }
+
+  .sub-section:not(.collapsed) .package-container {
+    padding-bottom: 0;
+  }
+
+  section .section-heading,
+  .section .section-heading {
+    font-size: 1.25em;
+  }
+
+  .sub-section .sub-section-heading {
+    font-size: 1.15em;
+
+    &.has-items::before {
+      margin-right: 0;
+      font-size: 1.15em;
+    }
+  }
+
+  .setting-title {
+    font-size: 1.1em;
+    font-weight: 500;
+    color: @text-color-highlight;
+  }
+
+  .form-control {
+    font-size: 1.1em;
+  }
+
+  .package-card {
+    padding: @component-padding;
+    font-size: inherit;
+    background-color: mix(@tool-panel-background-color, @base-background-color, 25%);
+
+    &:hover {
+      background-color: mix(@tool-panel-background-color, @base-background-color, 75%);
+    }
+
+    .package-name {
+      font-size: inherit;
+      font-weight: 600;
+    }
+
+    .package-version {
+      font-size: .9em;
+      color: @text-color-subtle;
+      font-weight: 400;
+    }
+
+    .meta {
+      display: block;
+    }
+
+    .meta-user .avatar {
+      width: 20px;
+      height: 20px;
+    }
+    .meta-user .author {
+      margin-left: .5em;
+    }
+
+    .btn-toolbar {
+      .btn-group {
+        display: flex;
+        float: none;
+        .btn {
+          flex: 1 1 auto;
+          overflow: hidden;
+          &.status-indicator {
+            flex: none;
+            border: none;
+          }
+        }
+      }
+    }
+
+  }
+
+  .themes-panel {
+    .themes-picker-item {
+      margin-top: @component-padding*1.5;
+    }
+    .theme-description {
+      margin: @component-padding/2 0;
+    }
+  }
+
+
+}

--- a/styles/docks.less
+++ b/styles/docks.less
@@ -5,7 +5,6 @@
 
 atom-dock.left .settings-view,
 atom-dock.right .settings-view {
-  // display: block;
   flex-direction: column;
 
   &.pane-item {
@@ -14,7 +13,11 @@ atom-dock.right .settings-view {
 
   .config-menu {
     flex: none;
-    padding-top: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    padding: @component-padding/2;
     min-width: 0;
     max-width: none;
     border: none;
@@ -23,27 +26,31 @@ atom-dock.right .settings-view {
     overflow-x: initial;
 
     .nav {
-      display: contents;
+      display: contents; // hide from DOM
 
-      & > li {
-        & > a {
-         padding: @component-padding/1.5 @component-padding*1.5;
-        }
+      & > li > a {
+        padding: 0 .5em;
+        border-radius: @component-border-radius;
+      }
+
+      .icon:before {
+        display: none;
       }
     }
 
-    &:not(:hover) {
-      .nav > li {
-        display: none;
-        &.active {
-          display: block;
-          & > a {
-            background-color: transparent;
-          }
+    .button-area {
+      display: contents; // hide from DOM
+
+      .icon-link-external {
+        font-size: 0;
+        width: auto;
+        margin: 0 @component-padding/2;
+        padding: @component-padding/4 @component-padding/2;
+        overflow: hidden;
+        &:before {
+          font-size: 16px;
+          margin: 0;
         }
-      }
-      .button-area {
-        display: none;
       }
     }
   }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This improves the layout of the settings-view when moved to the left/right dock.

![settings](https://user-images.githubusercontent.com/378023/53223134-afeb7380-36b3-11e9-9be7-caf0d7d9e06c.gif)


### Alternate Designs

There are a [few options](https://github.com/atom/settings-view/pull/1115#issuecomment-466282855) for the navigation.

### Benefits

When moving the settings-view to a dock, it allows you to keep the editor in sight. Great when making changes to the settings and then see the result in the editor.

![settings](https://user-images.githubusercontent.com/378023/53154688-aeac3f00-35fe-11e9-8f15-48472e8f157e.gif)


### Possible Drawbacks

- It is a bit experimental with just some CSS overrides.
- The Keybindings need to be scrolled horizontally and fit better in the center.
- Adds extra maintenance cost.

### Applicable Issues

N/A
