### PR TITLE
Use server repository instead of package defined

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -208,8 +208,8 @@ class AtomIoClient
             body = JSON.parse(body)
             resolve(
               body.filter (pkg) -> pkg.releases?.latest?
-                  .map ({readme, metadata, downloads, stargazers_count}) ->
-                    Object.assign metadata, {readme, downloads, stargazers_count}
+                  .map ({readme, metadata, downloads, stargazers_count, repository}) ->
+                    Object.assign metadata, {readme, downloads, stargazers_count, repository: repository.url}
             )
           catch e
             error = new Error("Searching for \u201C#{query}\u201D failed.")


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Use the repository URL returned from the atom.io server query as the URL of the repository, instead of the one defined by the package itself in its own metadata to prevent potential for impersonation of other authors.

Before:
![image](https://user-images.githubusercontent.com/427137/53474189-48ba2000-3a21-11e9-9d52-5296d9f63bfc.png)

After:
![image](https://user-images.githubusercontent.com/427137/53474154-39d36d80-3a21-11e9-8a4e-8c9db43a98da.png)

### Alternate Designs

Potential enhancements to this include making the atom.io server reject package versions where the metadata in the package doesn't agree with the repository the version is coming from. Since this hasn't been in place from the start though we need to either purge all packages from atom.io that don't match or implement something within Atom to hide this.

### Benefits

It should now be impossible to impersonate other authors within Atom's search results when submitting a package.

### Possible Drawbacks

The repository defined in the package's metadata from `package.json` is now entirely ignored in query results. I'm not sure what potential downsides there are to this. It may pose an additional barrier to migrating a package to an another user.

The entire `search` method is currently untested, so this change may have side-effects that are unaccounted for.

### Applicable Issues

Fixes #1118.
