### PR TITLE
Attempt to fix unreliable tests

### DIFF
--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -45,15 +45,15 @@ describe "InstalledPackageView", ->
     shouldRunScopeTest = parseFloat(atom.getVersion()) >= 1.33
 
     waitsForPromise ->
+      atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+    waitsForPromise ->
       atom.packages.activatePackage('snippets').then (p) ->
         snippetsModule = p.mainModule
         return unless snippetsModule.provideSnippets().getUnparsedSnippets?
 
         SnippetsProvider =
           getSnippets: -> snippetsModule.provideSnippets().getUnparsedSnippets()
-
-    waitsForPromise ->
-      atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
     waitsFor 'snippets to load', -> snippetsModule.provideSnippets().bundledSnippetsLoaded()
 
@@ -82,15 +82,15 @@ describe "InstalledPackageView", ->
       snippetsModule = null
 
       waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+      waitsForPromise ->
         atom.packages.activatePackage('snippets').then (p) ->
           snippetsModule = p.mainModule
           return unless snippetsModule.provideSnippets().getUnparsedSnippets?
 
           SnippetsProvider =
             getSnippets: -> snippetsModule.provideSnippets().getUnparsedSnippets()
-
-      waitsForPromise ->
-        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
       waitsFor 'snippets to load', -> snippetsModule.provideSnippets().bundledSnippetsLoaded()
 
@@ -119,6 +119,9 @@ describe "InstalledPackageView", ->
 
       beforeEach ->
         waitsForPromise ->
+          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+        waitsForPromise ->
           atom.packages.activatePackage('snippets').then (p) ->
             snippetsModule = p.mainModule
             return unless snippetsModule.provideSnippets().getUnparsedSnippets?
@@ -126,9 +129,6 @@ describe "InstalledPackageView", ->
             SnippetsProvider =
               getSnippets: -> snippetsModule.provideSnippets().getUnparsedSnippets()
               getUserSnippetsPath: snippetsModule.getUserSnippetsPath()
-
-        waitsForPromise ->
-          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
         waitsFor 'snippets to load', -> snippetsModule.provideSnippets().bundledSnippetsLoaded()
 
@@ -168,6 +168,10 @@ describe "InstalledPackageView", ->
     it "sets the packagesWithSnippetsDisabled config to include the package name", ->
       [pack, card] = []
       snippetsModule = []
+
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
       waitsForPromise ->
         atom.packages.activatePackage('snippets').then (p) ->
           snippetsModule = p.mainModule
@@ -175,9 +179,6 @@ describe "InstalledPackageView", ->
 
           SnippetsProvider =
             getSnippets: -> snippetsModule.provideSnippets().getUnparsedSnippets()
-
-      waitsForPromise ->
-        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
 
       waitsFor 'snippets to load', -> snippetsModule.provideSnippets().bundledSnippetsLoaded()
 


### PR DESCRIPTION
This PR attempts intermittent failures of tests that interact with snippets. I think these failures are caused by the following race condition:

* The tests activate the `snippets` package first.
* The snippets package loads bundled snippets, then reads all loaded packages in an async function.
* The tests then activate the `language-test` package asynchronously in a `waitsFor` block.
* Most of the time, the `waitsFor` block runs before the async function that reads loaded packages in the `snippets` package, but this isn't guaranteed.
* If the `waitsFor` block runs *after* the async code in the snippets package, snippets from the `language-test` package are never loaded and the tests fail.

I think this what is happening. Hopefully I am right and CI will pass now. 🤞 