### PR TITLE
Use a less timing-sensitive condition to hopefully fix flaky test

### DIFF
--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -95,8 +95,8 @@ describe 'UpdatesPanel', ->
 
         resolveC()
 
-      waitsFor (done) ->
-        atom.notifications.onDidAddNotification(done)
+      waitsFor ->
+        atom.notifications.getNotifications().length == 1
 
       runs ->
         notifications = atom.notifications.getNotifications()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -96,7 +96,7 @@ describe 'UpdatesPanel', ->
         resolveC()
 
       waitsFor ->
-        atom.notifications.getNotifications().length == 1
+        atom.notifications.getNotifications().length is 1
 
       runs ->
         notifications = atom.notifications.getNotifications()


### PR DESCRIPTION
Jasmine 1.3 queueing makes async testing weird. In this case, we resolve a promise with the expectation that it asynchronously displays a notification. Then, in a `waitsFor` block on the next line, we subscribe to `onDidAddNotification`. The problem is that this `waitsFor` block might not even be *run* before the notification gets displayed. So the notification is displayed before we even subscribe to `onDidAddNotification` and the `waitsForBlock` gets stuck. This kind of thing seems especially frequent on Windows/AppVeyor.

The ideal fix would be to convert all these tests to JS and use `async`/`await`. Then we could *synchronously* subscribe to `onDidAddNotification` after resolving the promise and avoid this race. But in this case, I think using a looser condition should work as well.