### PR TITLE
Don't mock JSON.parse globally in test

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -78,7 +78,7 @@ class AtomIoClient
       try
         # NOTE: request's json option does not populate err if parsing fails,
         # so we do it manually
-        body = JSON.parse(body)
+        body = @parseJSON(body)
         delete body.versions
 
         cached =
@@ -99,7 +99,7 @@ class AtomIoClient
   # the cached data and pretends it's null if it's stale and we're online
   fetchFromCache: (packagePath) ->
     cached = localStorage.getItem(@cacheKeyForPath(packagePath))
-    cached = if cached then JSON.parse(cached)
+    cached = if cached then @parseJSON(cached)
     if cached? and (not @online() or Date.now() - cached.createdOn < @expiry)
       return cached.data
     else
@@ -196,7 +196,7 @@ class AtomIoClient
     }
 
     new Promise (resolve, reject) ->
-      request options, (err, res, body) ->
+      request options, (err, res, body) =>
         if err
           error = new Error("Searching for \u201C#{query}\u201D failed.")
           error.stderr = err.message
@@ -205,7 +205,7 @@ class AtomIoClient
           try
             # NOTE: request's json option does not populate err if parsing fails,
             # so we do it manually
-            body = JSON.parse(body)
+            body = @parseJSON(body)
             resolve(
               body.filter (pkg) -> pkg.releases?.latest?
                   .map ({readme, metadata, downloads, stargazers_count, repository}) ->
@@ -215,3 +215,6 @@ class AtomIoClient
             error = new Error("Searching for \u201C#{query}\u201D failed.")
             error.stderr = e.message + '\n' + body
             reject error
+
+  parseJSON: (s) ->
+    JSON.parse(s)

--- a/spec/atom-io-client-spec.coffee
+++ b/spec/atom-io-client-spec.coffee
@@ -25,7 +25,7 @@ describe "AtomIoClient", ->
       jsonParse = JSON.parse
 
       waitsFor (done) ->
-        spyOn(JSON, 'parse').andThrow()
+        spyOn(@client, 'parseJSON').andThrow()
         @client.request 'path', (error, data) ->
           expect(error).not.toBeNull()
           done()


### PR DESCRIPTION
We might end up calling it in unrelated code paths, such as `@atom/notify`, which is why I'm making this change.