### PR TITLE
Pass `this` into the promise function

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -195,7 +195,7 @@ class AtomIoClient
       gzip: true
     }
 
-    new Promise (resolve, reject) ->
+    new Promise (resolve, reject) =>
       request options, (err, res, body) =>
         if err
           error = new Error("Searching for \u201C#{query}\u201D failed.")


### PR DESCRIPTION
Two levels of callbacks = two fat arrows needed. I'll try to add a spec or two for this.

Fixes atom/atom#19293