### PR TITLE
Restore package search ordering by popularity

### DIFF
--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -208,7 +208,7 @@ class AtomIoClient
             body = @parseJSON(body)
             resolve(
               body.filter (pkg) -> pkg.releases?.latest?
-                  .filter (pkg) -> !atom.packages.isDeprecatedPackage(pkg.name, pkg.version)
+                  .filter (pkg) -> not atom.packages.isDeprecatedPackage(pkg.name, pkg.version)
                   .map ({readme, metadata, downloads, stargazers_count, repository}) ->
                     Object.assign metadata, {readme, downloads, stargazers_count, repository: repository.url}
                   .sort (a, b) -> b.downloads - a.downloads

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -208,6 +208,7 @@ class AtomIoClient
             body = @parseJSON(body)
             resolve(
               body.filter (pkg) -> pkg.releases?.latest?
+                  .filter (pkg) -> !atom.packages.isDeprecatedPackage(pkg.name, pkg.version)
                   .map ({readme, metadata, downloads, stargazers_count, repository}) ->
                     Object.assign metadata, {readme, downloads, stargazers_count, repository: repository.url}
                   .sort (a, b) -> b.downloads - a.downloads

--- a/lib/atom-io-client.coffee
+++ b/lib/atom-io-client.coffee
@@ -210,6 +210,7 @@ class AtomIoClient
               body.filter (pkg) -> pkg.releases?.latest?
                   .map ({readme, metadata, downloads, stargazers_count, repository}) ->
                     Object.assign metadata, {readme, downloads, stargazers_count, repository: repository.url}
+                  .sort (a, b) -> b.downloads - a.downloads
             )
           catch e
             error = new Error("Searching for \u201C#{query}\u201D failed.")

--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -220,10 +220,30 @@ export default class InstallPanel {
         this.refs.searchMessage.style.display = ''
       }
 
+      this.highlightExactMatch(this.refs.resultsContainer, query, packages)
+      this.addCloseMatches(this.refs.resultsContainer, query, packages)
       this.addPackageViews(this.refs.resultsContainer, packages)
     } catch (error) {
       this.refs.searchMessage.style.display = 'none'
       this.refs.searchErrors.appendChild(new ErrorView(this.packageManager, error).element)
+    }
+  }
+
+  highlightExactMatch (container, query, packages) {
+    const exactMatch = packages.filter(pkg => pkg.name.toLowerCase() === query)[0]
+
+    if (exactMatch) {
+      this.addPackageCardView(container, this.getPackageCardView(exactMatch))
+      packages.splice(packages.indexOf(exactMatch), 1)
+    }
+  }
+
+  addCloseMatches (container, query, packages) {
+    const matches = packages.filter(pkg => pkg.name.toLowerCase().indexOf(query) >= 0)
+
+    for (let pack of matches) {
+      this.addPackageCardView(container, this.getPackageCardView(pack))
+      packages.splice(packages.indexOf(pack), 1)
     }
   }
 

--- a/spec/install-panel-spec.coffee
+++ b/spec/install-panel-spec.coffee
@@ -59,16 +59,29 @@ describe 'InstallPanel', ->
       expect(@panel.search.callCount).toBe 3
 
   describe "searching packages", ->
-    it "displays the packages in the order returned", ->
-      spyOn(@panel.client, 'search').andCallFake -> Promise.resolve([{name: 'not-first'}, {name: 'first'}])
+    it "highlights exact name matches", ->
+      spyOn(@panel.client, 'search').andCallFake ->
+        new Promise (resolve, reject) -> resolve([ {name: 'not-first'}, {name: 'first'} ])
       spyOn(@panel, 'getPackageCardView').andCallThrough()
 
       waitsForPromise =>
         @panel.search('first')
 
       runs ->
-        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'not-first'
-        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'first'
+        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'first'
+        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'not-first'
+
+    it "prioritizes partial name matches", ->
+      spyOn(@panel.client, 'search').andCallFake ->
+        new Promise (resolve, reject) -> resolve([ {name: 'something else'}, {name: 'partial name match'} ])
+      spyOn(@panel, 'getPackageCardView').andCallThrough()
+
+      waitsForPromise =>
+        @panel.search('match')
+
+      runs ->
+        expect(@panel.getPackageCardView.argsForCall[0][0].name).toEqual 'partial name match'
+        expect(@panel.getPackageCardView.argsForCall[1][0].name).toEqual 'something else'
 
   describe "searching git packages", ->
     beforeEach ->


### PR DESCRIPTION
### Description of the Change

This PR reverts https://github.com/atom/settings-view/pull/1042/commits/38b9408d6d569a40879d8c60c426dcea398ad979. It adds reasonable sorting of package search results, instead of relying on the sort order from the cloud search API.

A couple of other items to note:

* The original PR (linked above) referred to making the search results consistent with `apm search`. If this PR is accepted, I would be happy to submit the short PR to add these same sorts to `apm`.
* I also added a filter for deprecated packages, which `apm` had but `settings-view` did not.

After this PR, the search ordering on [atom.io's package search](https://atom.io/packages/search) will differ that of `settings-view` (and then, `apm`). Ideally we would make this change on atom.io, but that backend isn't open source, so we're stuck with this.

Given this is a reversion of a previous PR, I feel I should motivate the need. It can be seen in many comments since the original sorting was removed:

> Please consider adding this feature. When I try to search for a package to add sometimes the top three results will each have only 2-4 stars and somewhere far down the page a much more developed and stable package with 200,000 stars will almost be overlooked.
> 
> It leads people to install packages that might not be production ready when much better options are out there.
— @charrismatic [link](https://github.com/atom/atom.io/issues/9#issuecomment-487716728)

> I think to have the option to sort the packages by stars or downloads is a good idea
— @MarcusE1W [link](https://discuss.atom.io/t/need-extensions-packages-plugins-ranked-by-highest-rated-to-lowest-so-we-all-can-see-what-atom-can-do/53920/2)

> It would be very helpful to be able to sort by downloads.
> 
> On the SublimeText packagecontrol.io, I find that the most used extensions are often ones that have been tested and are more complete. Today I searched for react native and there are over a dozen pages to dig through.
— @pale2hall [link](https://discuss.atom.io/t/no-way-to-sort-package-searche-results/52167/8)

One important difference between atom.io and `settings-view` is that the latter doesn't have pagination, so the sort ordering is especially important in `settings-view`.

### Alternate Designs

* Making this change on atom.io, but as mentioned above this isn't possible.
* Use a more sophisticated sort -- there are lots of options for this but I think this sort gives an 80/20, and is an improvement over the status quo.

### Benefits

Atom users are more likely to find plugins which have downloads, indicating that they solve a need, are well described, and that previous searchers found them promising.

### Possible Drawbacks

Any plugins that don't have downloads will be disfavored.

### Applicable Issues

None.

/cc @50Wliu 
