### PR TITLE
add hidden property

### DIFF
--- a/lib/settings-panel.js
+++ b/lib/settings-panel.js
@@ -392,6 +392,10 @@ function elementForSetting (namespace, name, value) {
       return document.createDocumentFragment()
     }
   }
+  let schema = atom.config.getSchema(`${namespace}.${name}`)
+  if (schema && schema.hidden) {
+    return document.createDocumentFragment()
+  }
 
   const controlGroup = document.createElement('div')
   controlGroup.classList.add('control-group')
@@ -400,7 +404,6 @@ function elementForSetting (namespace, name, value) {
   controls.classList.add('controls')
   controlGroup.appendChild(controls)
 
-  let schema = atom.config.getSchema(`${namespace}.${name}`)
   if (schema && schema.enum) {
     controls.appendChild(elementForOptions(namespace, name, value, {radio: schema.radio}))
   } else if (schema && schema.type === 'color') {

--- a/spec/settings-panel-spec.coffee
+++ b/spec/settings-panel-spec.coffee
@@ -379,3 +379,89 @@ describe "SettingsPanel", ->
         atom.config.set('foo.commaValueArray', [', 4'])
         advanceClock(1000)
         expect(commaValueArrayEditor.getModel().getText()).toBe '\\, 4'
+
+  describe 'hidden settings', ->
+    beforeEach ->
+      config =
+        type: 'object'
+        properties:
+          hiddenString:
+            name: 'hiddenString'
+            title: 'Hidden String'
+            description: 'The hiddenString setting'
+            type: 'string'
+            hidden: true
+            default: 'hiddenString'
+          hiddenEnum:
+            name: 'hiddenEnum'
+            title: 'Hidden Enum'
+            description: 'The hiddenEnum setting'
+            type: 'string'
+            hidden: true
+            default: 'a'
+            enum: [
+              {value: 'a', description: 'Alice'},
+              {value: 'b', description: 'Bob'}
+            ]
+          hiddenInteger:
+            name: 'hiddenInteger'
+            title: 'Hidden Integer'
+            description: 'The hiddenInteger setting'
+            type: 'integer'
+            hidden: true
+            default: 1
+          hiddenBoolean:
+            name: 'hiddenBoolean'
+            title: 'Hidden Boolean'
+            description: 'The hiddenBoolean setting'
+            type: 'boolean'
+            hidden: true
+            default: true
+          visibleString:
+            name: 'visibleString'
+            title: 'Visible String'
+            description: 'The visibleString setting'
+            type: 'string'
+            default: 'visibleString'
+          visibleObject:
+            title: 'A visible object'
+            type: 'object'
+            properties:
+              hiddenProp:
+                title: 'Visible in visible object'
+                type: 'boolean'
+                hidden: true
+                default: true
+              visibleProp:
+                title: 'Hidden in visible object'
+                type: 'boolean'
+                default: true
+          hiddenObject:
+            title: 'A hidden object'
+            type: 'object'
+            hidden: true
+            properties:
+              hiddenProp1:
+                title: 'Hidden in hidden object'
+                type: 'boolean'
+                hidden: true
+                default: true
+              hiddenProp2:
+                title: 'Hidden by hidden object'
+                type: 'boolean'
+                default: true
+
+      atom.config.setSchema("foo", config)
+      expect(_.size(atom.config.get('foo'))).toBe 7
+      settingsPanel = new SettingsPanel({namespace: "foo", includeTitle: false})
+
+    it "only shows visible settings", ->
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenString').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenEnum').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenInteger').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenBoolean').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.visibleString').not.toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.visibleObject\\.visibleProp').not.toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.visibleObject\\.hiddenProp').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenObject\\.hiddenProp1').toBe(null)
+      expect(settingsPanel.element.querySelector '#foo\\.hiddenObject\\.hiddenProp2').toBe(null)


### PR DESCRIPTION
### Description of the Change

Allow certain config settings to be hidden from the settings panel.

```cson
{
	"config": {
		"someSetting": {
			"type": "boolean",
			"default": false,
			"hidden": true
		}
	}
}
```

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Use an automatically collapsed object to hide the settings, but they can still be shown.

![image](https://user-images.githubusercontent.com/97994/74965142-4a22ec00-53da-11ea-8d18-8c9d2649f54a.png)

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

packages can hide configuration settings that users shouldn't change manually.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#1143

<!-- Enter any applicable Issues here -->
