### PR TITLE
Feature decorate disabled pkg keymap

### DIFF
--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -132,7 +132,6 @@ export default class PackageKeymapView {
         continue
       }
 
-
       const keyBindingRow = document.createElement('tr')
       keyBindingRow.dataset.selector = selector
       keyBindingRow.dataset.keystrokes = keystrokes
@@ -168,8 +167,7 @@ export default class PackageKeymapView {
           let matched =  kb.selector == selector
                   && sourceRegex.test(kb.source)
                   && kb.command == command
-                  && (kb.keystrokes.length < 1 || kb.keystrokes[0] == keystrokes[0])
-                  && (kb.keystrokes.length < 2 || kb.keystrokes[1] == keystrokes[1]);
+                  && kb.keystrokes == keystrokes;
            return matched;
        });
 

--- a/lib/package-keymap-view.js
+++ b/lib/package-keymap-view.js
@@ -132,6 +132,7 @@ export default class PackageKeymapView {
         continue
       }
 
+
       const keyBindingRow = document.createElement('tr')
       keyBindingRow.dataset.selector = selector
       keyBindingRow.dataset.keystrokes = keystrokes
@@ -160,6 +161,26 @@ export default class PackageKeymapView {
       const sourceTd = document.createElement('td')
       sourceTd.textContent = KeybindingsPanel.determineSource(source)
       keyBindingRow.appendChild(sourceTd)
+
+      // if the keybinding from the source file is not installed, mark it as inactive
+      var sourceRegex = new RegExp(source);
+      var isBindingInstalled = atom.keymaps.keyBindings.find((kb)=>{
+          let matched =  kb.selector == selector
+                  && sourceRegex.test(kb.source)
+                  && kb.command == command
+                  && (kb.keystrokes.length < 1 || kb.keystrokes[0] == keystrokes[0])
+                  && (kb.keystrokes.length < 2 || kb.keystrokes[1] == keystrokes[1]);
+           return matched;
+       });
+
+      if (!isBindingInstalled) {
+          keyBindingRow.classList.add('text-subtle');
+          keystrokesTd.classList.add('icon', 'icon-circle-slash');
+          this.disposables.add(atom.tooltips.add(keystrokesTd, {
+              title: "Disabled. This binding it not in the list of active bindings"
+          }));
+      }
+
 
       this.refs.keybindingItems.appendChild(keyBindingRow)
     }

--- a/spec/installed-package-view-spec.coffee
+++ b/spec/installed-package-view-spec.coffee
@@ -270,6 +270,44 @@ describe "InstalledPackageView", ->
           }
         """
 
+  describe "when a package keybinding is installed", ->
+    it "does not decorate its row with and first column with text-subtle and icon.inoc-circle-slash classes", ->
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+      runs ->
+        pack = atom.packages.getActivePackage('language-test')
+        card = new PackageKeymapView(pack)
+        jasmine.attachToDOM(card.element)
+
+        normalKeyRows = card.element.querySelectorAll('.package-keymap-table tr.text-subtle')
+        expect(normalKeyRows.length).toBe 0
+
+        disabledKeysByIcon = card.element.querySelectorAll('.package-keymap-table td.icon.icon-circle-slash')
+        expect(disabledKeysByIcon.length).toBe 0
+
+  describe "when a package keybinding is not installed", ->
+    it "decorates its row with and first column with text-subtle and icon.inoc-circle-slash classes", ->
+    it "decorates rows with a disabled keybinding", ->
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'language-test'))
+
+      runs ->
+        atom.keymaps.keyBindings = atom.keymaps.keyBindings.filter (keyBinding) ->
+            return !(/language-test/.test(keyBinding.source) || keyBinding.selector == 'test')
+
+        pack = atom.packages.getActivePackage('language-test')
+        card = new PackageKeymapView(pack)
+        jasmine.attachToDOM(card.element)
+
+        disabledKeyRows = card.element.querySelectorAll('.package-keymap-table tr.text-subtle')
+        expect(disabledKeyRows.length).toBe 1
+
+        disabledKeysByIcon = card.element.querySelectorAll('.package-keymap-table td.icon.icon-circle-slash')
+        expect(disabledKeysByIcon.length).toBe 1
+
+
+
   describe "when the package is active", ->
     it "displays the correct enablement state", ->
       packageCard = null


### PR DESCRIPTION
### Description of the Change
In PackageKeymapView::updateKeyBindingView in the loop that creates the table element with rows for each of the packages keybings, I added a block that checks to see if the keybinding is currently in atom.keymaps.keyBindings[] and adds decorators to the row elements if it is not.

Decorators on Disabled Keybinding rows:
*  text-sublte class to the keybinding row
* 'icon icon-circle-slash' classes to the first column
* tooltip on the first column that reads "Disabled. This binding it not in the list of active bindings".

The result is ...
![DisabledKeybindingRow](https://user-images.githubusercontent.com/36312888/76705343-bc26e200-66b5-11ea-9191-6e91faa41133.png)

I added two specs -- one to test that enabled keybindings do not have the class decorators and another to test that a disabled keybinding does. I did two specs so that I could reuse an existing fixture which seemed less intrusive.

### Alternate Designs
This just makes the package keymap section of settings view tell the current truth about the state of the package's keybindings.  I can not think of any alternatives. 

### Benefits
There are already packages like 'disable-keybindings' (8k downloads) that allow the user selectively disable just some of the keybindings that a package provides but the settings view does not reflect the correct state when this happens.  It decreases confusion when the user has a more accurate picture of the system state.  
    
### Possible Drawbacks
I think that this change is safe because it does not introduce any new behavior itself (you may support or be against the idea of disabling keybindings selectively at runtime) but if for any reason a keybinding is not active, this allows the user to see that its not active. 

The user may be left wondering why the keybinding is disabled but addressing that would be a step further. Compared to the settings view making it look like all the package's keybindings are enabled when they are not, the user is better off. 

We could go further and add a KeymapManager::remove(reason, filterCallback) API. Then the PackageKeymapView::updateKeyBindingView code could display the reason a keybinding is disabled. That would provide a path to good citizenship for the disable-keybindings and similar packages that modify atom.keymap.keyBindings directly when really they should not be doing that.

LMK if you would like me to add that to this PR.

### Applicable Issues

None known. (BTW, I was not sure if I should go straight to a PR or if I should have created a feature request issue first. LMK)
