### PR TITLE
Fix scroll in package settings pane

### DIFF
--- a/styles/settings-view.less
+++ b/styles/settings-view.less
@@ -442,6 +442,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    height: 100%;
 
     .package-keymap-table,
     .package-grammars-table,


### PR DESCRIPTION
An upgrade to [electron 6](https://github.com/atom/atom/pull/21079) broke the scrolling in the package settings pane.

Fixes: https://github.com/atom/settings-view/issues/1155