### PR TITLE
Update spec to not use proxy settings when calling apm

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -7,6 +7,7 @@ describe "PackageManager", ->
 
   beforeEach ->
     spyOn(atom.packages, 'getApmPath').andReturn('/an/invalid/apm/command/to/run')
+    atom.config.set('core.useProxySettingsWhenCallingApm', false)
     packageManager = new PackageManager()
 
   it "handle errors spawning apm", ->


### PR DESCRIPTION
The command is meant to fail therefore there is no need to use proxy. Using proxy in this case causes the test to timeout.