### PR TITLE
feat: add explicit button to skip restarting after package updating

### DIFF
--- a/lib/package-card.js
+++ b/lib/package-card.js
@@ -208,11 +208,6 @@ export default class PackageCard {
     const updateButtonClickHandler = (event) => {
       event.stopPropagation()
       this.update().then(() => {
-        const buttons = [{
-          text: 'Restart',
-          onDidClick () { return atom.restartApplication() }
-        }]
-
         let oldVersion = ''
         let newVersion = ''
 
@@ -229,8 +224,17 @@ export default class PackageCard {
           detail = `${oldVersion} -> ${newVersion}`
         }
 
-        atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
-          dismissable: true, buttons, detail
+        const notification = atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
+          dismissable: true,
+          buttons: [{
+            text: 'Restart now',
+            onDidClick () { return atom.restartApplication() }
+          },
+          {
+            text: 'I\'ll do it later',
+            onDidClick () { notification.dismiss() }
+          }],
+          detail
         })
       })
     }

--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -212,11 +212,18 @@ export default class UpdatesPanel {
       })
       detail = detail.trim()
 
-      const buttons = [{
-        text: 'Restart',
-        onDidClick () { return atom.restartApplication() }
-      }]
-      atom.notifications.addSuccess(message, {dismissable: true, buttons, detail})
+      const notification = atom.notifications.addSuccess(message, {
+        dismissable: true,
+        buttons: [{
+          text: 'Restart now',
+          onDidClick () { return atom.restartApplication() }
+        },
+        {
+          text: 'I\'ll do it later',
+          onDidClick () { notification.dismiss() }
+        }],
+        detail
+      })
     }
 
     if (failedUpdatesCount === 0) {

--- a/spec/package-card-spec.coffee
+++ b/spec/package-card-spec.coffee
@@ -535,11 +535,18 @@ describe "PackageCard", ->
 
             notifications = atom.notifications.getNotifications()
             expect(notifications.length).toBe 1
-            expect(notifications[0].options.detail).toBe "1.0.0 -> 1.1.0"
+            notif = notifications[0]
+            
+            expect(notif.options.detail).toBe "1.0.0 -> 1.1.0"
+            expect(notif.options.buttons.length).toBe(2)
 
             spyOn(atom, 'restartApplication')
-            notifications[0].options.buttons[0].onDidClick()
+            notif.options.buttons[0].onDidClick()
             expect(atom.restartApplication).toHaveBeenCalled()
+
+            spyOn(notif, 'dismiss')
+            notif.options.buttons[1].onDidClick()
+            expect(notif.dismiss).toHaveBeenCalled()
 
         it "shows the sha in the notification when a git url package is updated", ->
           expect(atom.packages.getLoadedPackage('package-with-config')).toBeTruthy()

--- a/spec/updates-panel-spec.coffee
+++ b/spec/updates-panel-spec.coffee
@@ -101,11 +101,19 @@ describe 'UpdatesPanel', ->
       runs ->
         notifications = atom.notifications.getNotifications()
         expect(notifications.length).toBe 1
-        expect(notifications[0].options.detail).toBe 'test-package-a@1.0.0 -> 99.0.0\ntest-package-b@1.0.0 -> 99.0.0\ntest-package-c@cf23df22 -> a296114f'
+        notif = notifications[0]
+
+        expect(notif.options.detail).toBe 'test-package-a@1.0.0 -> 99.0.0\ntest-package-b@1.0.0 -> 99.0.0\ntest-package-c@cf23df22 -> a296114f'
+
+        expect(notif.options.buttons.length).toBe(2)
 
         spyOn(atom, 'restartApplication')
-        notifications[0].options.buttons[0].onDidClick()
+        notif.options.buttons[0].onDidClick()
         expect(atom.restartApplication).toHaveBeenCalled()
+
+        spyOn(notif, 'dismiss')
+        notif.options.buttons[1].onDidClick()
+        expect(notif.dismiss).toHaveBeenCalled()
 
     it 'works with queue enabled', ->
       expect(panel.refs.updateAllButton).not.toBeDisabled()


### PR DESCRIPTION
### Description of the Change

This pull request adds a button to skip restarting after package updating. 

### Benefits

The cross button in the top right corner does the same thing but based on my statistics, the users don't use it often, and they think restarting in the middle of their work session is forced by Atom. This button explicitly gives them the option to skip restarting after updates. This is useful if they are in the middle of a work session and restarting Atom is considered a disturbance.


### Verification
The tests are added for the "I'll do it later" button.
The rest of the tests should pass.