### PR TITLE
fix: update async dependency

### DIFF
--- a/lib/updates-panel.js
+++ b/lib/updates-panel.js
@@ -2,7 +2,7 @@
 /** @jsx etch.dom */
 
 import {CompositeDisposable} from 'atom'
-import async from 'async'
+import asyncQueue from 'async/queue'
 import etch from 'etch'
 
 import ErrorView from './error-view'
@@ -169,7 +169,7 @@ export default class UpdatesPanel {
       ? atom.config.get('settings-view.packageUpdateConcurrency')
       : Number.POSITIVE_INFINITY
 
-    const queue = async.queue(function (packageCard, callback) {
+    const queue = asyncQueue(function (packageCard, callback) {
       const onUpdateCompleted = function (err) {
         err == null ? successfulUpdatesCount++ : failedUpdatesCount++
       }
@@ -181,15 +181,9 @@ export default class UpdatesPanel {
       }
     }, concurrency)
 
-    const queueDrainedPromise = new Promise((resolve) => {
-      queue.drain = resolve
-    })
+    queue.push(this.packageCards)
 
-    for (let packageCard of this.packageCards) {
-      queue.push(packageCard)
-    }
-
-    await queueDrainedPromise
+    await queue.drain()
 
     if (successfulUpdatesCount > 0) {
       const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,9 +115,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "async": "~0.2.9",
+    "async": "^3.2.0",
     "dompurify": "^1.0.2",
     "etch": "0.9.0",
     "fs-plus": "^3.0.0",


### PR DESCRIPTION
### Description of the Change

This PR updates async dependency:
- queue.drain is async now, no need to manually make it async
- queue.push accepts an array

The docs for asyncQueue
https://caolan.github.io/async/v3/docs.html#queue

### Benefits

This speeds up updating the packages.


### Possible Drawbacks
N/A

### Applicable Issues

<!-- Enter any applicable Issues here -->
