### PR TITLE
Catch README file not found error

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -375,7 +375,7 @@ export default class PackageDetailView {
       readme = null
     }
 
-    if (this.readmePath && !readme) {
+    if (this.readmePath && fs.statSync(this.readmePath).isFile() && !readme) {
       readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
     }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

- Use a `fs.statSync` to check if the file is available before calling `fs.readFileSync`

See https://github.com/atom/atom/issues/22109 

### Alternate Designs

- Add a `try catch` block around `fs.readFileSync` because the call to `fs.readFileSync` could throw an error in the event a file is not available.

```js
try {
  readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
} catch(err) {
  readme = null
}
```

### Benefits

Improved user experience. We should not be throwing an error if the README file is not available, we should fail safely. 

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/atom/atom/issues/22109 
