### PR TITLE
Added result sorting by downloads and/or stars

### DIFF
--- a/lib/install-panel.js
+++ b/lib/install-panel.js
@@ -98,6 +98,14 @@ export default class InstallPanel {
                 <button ref='searchPackagesButton' className='btn btn-default selected' onclick={this.didClickSearchPackagesButton.bind(this)}>Packages</button>
                 <button ref='searchThemesButton' className='btn btn-default' onclick={this.didClickSearchThemesButton.bind(this)}>Themes</button>
               </div>
+              <div className='sort-group'>
+                <div className='checkbox'>
+                  <input ref='searchSortDownloads' className='input-checkbox selected' type='checkbox' id='searchSortDownloadsID' checked  onclick={this.didClickSearchPackagesButton.bind(this)} />Downloads
+                </div>
+                <div className='checkbox'>
+                  <input ref='searchSortStars' className='input-checkbox selected' type='checkbox' id='searchSortStarsID' onclick={this.didClickSearchPackagesButton.bind(this)} />Stars
+                </div>
+              </div>
             </div>
 
             <div ref='searchErrors' />
@@ -220,6 +228,9 @@ export default class InstallPanel {
         this.refs.searchMessage.style.display = ''
       }
 
+      if (searchSortDownloadsID.checked && searchSortStarsID.checked) { packages.sort(function(a, b) {return b.downloads - a.downloads || b.stargazers_count - a.stargazers_count;}); }
+      else if (searchSortDownloadsID.checked) { packages.sort(function(a, b) {return b.downloads - a.downloads;}); }
+      else if (searchSortStarsID.checked) { packages.sort(function(a, b) {return b.stargazers_count - a.stargazers_count;}); }
       this.addPackageViews(this.refs.resultsContainer, packages)
     } catch (error) {
       this.refs.searchMessage.style.display = 'none'


### PR DESCRIPTION
* Was unable to add the checkboxes side-by-side, due to overlapping, thus I stacked them.
* Set most downloads as the prefered order.
* Selection change invokes search.
* Did not add a method for default selection as I do not know how to.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In response to https://github.com/atom/atom.io/issues/9, this will allow the user to sort searched package/template results by downloads and/or stars value greatest to least.

### Alternate Designs

Dropdown for more order combinations.
Time was the primary factor in only providing checkboxes and greatest to least.

### Benefits

New users will be able to determine what others are using, most popular tend to be the best maintained.

### Possible Drawbacks

Newer better packages may get overlooked

### Applicable Issues

Config for default sorting method wasn't implemented as I wasn't sure how to.
