### PR TITLE
fix: Don't error if the readme doesn't exist

### DIFF
--- a/lib/package-detail-view.js
+++ b/lib/package-detail-view.js
@@ -375,7 +375,7 @@ export default class PackageDetailView {
       readme = null
     }
 
-    if (this.readmePath && fs.statSync(this.readmePath).isFile() && !readme) {
+    if (this.readmePath && fs.existsSync(this.readmePath) && fs.statSync(this.readmePath).isFile() && !readme) {
       readme = fs.readFileSync(this.readmePath, {encoding: 'utf8'})
     }
 


### PR DESCRIPTION

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Maybe atom should warn instead of ignoring this

Also I'm not sure what happens if the readme (or even the whole folder) is manually deleted
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

No errors
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Silently ignored
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

https://github.com/atom/atom/issues?q=is%3Aissue+is%3Aopen+PackageDetailView.renderReadme

Resolves atom/atom#23475
Resolves atom/atom#22699
Resolves atom/atom#22499
Resolves atom/atom#22435
<!-- Enter any applicable Issues here -->
